### PR TITLE
Fix PWA dark mode color desync and refine UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: http://localhost:4000; media-src 'self' blob:; connect-src 'self' http://localhost:4000 http://localhost:3000 ws://localhost:4000;">
     <link rel="apple-touch-icon" sizes="180x180" href="/pwa-192x192.png" />
     <title>OpenBin</title>
     <script>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,9 +34,10 @@ export function createApp(): express.Express {
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
     res.setHeader('Permissions-Policy', 'camera=(self), microphone=(), geolocation=()');
+    // CSP hash must match the inline theme script in index.html — update if that script changes
     res.setHeader(
       'Content-Security-Policy',
-      "default-src 'self'; img-src 'self' data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self' blob:;",
+      "default-src 'self'; img-src 'self' data: blob:; script-src 'self' 'sha256-7KadoKzu1sd1+0LivMFrmxISBXbhj6nm/vOZqEaVC5I='; style-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self' blob:;",
     );
     next();
   });

--- a/src/features/areas/AreaRow.tsx
+++ b/src/features/areas/AreaRow.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
 import { useTerminology } from '@/lib/terminology';
 
 interface AreaRowProps {
@@ -20,12 +19,24 @@ export function AreaRow({ id, name, binCount, isOwner, onNavigate, onRename, onD
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [saving, setSaving] = useState(false);
-  const [mobileActionsOpen, setMobileActionsOpen] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!actionsOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setActionsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [actionsOpen]);
 
   function startEdit() {
     setEditValue(name);
     setEditing(true);
-    setMobileActionsOpen(false);
+    setActionsOpen(false);
   }
 
   async function handleSave() {
@@ -93,66 +104,36 @@ export function AreaRow({ id, name, binCount, isOwner, onNavigate, onRename, onD
         {binCount} {binCount !== 1 ? t.bins : t.bin}
       </span>
       {isOwner && (
-        <>
-          {/* Desktop: hover-to-reveal */}
-          <div className={cn(
-            'hidden lg:flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity',
-          )}>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(e) => { e.stopPropagation(); startEdit(); }}
-              className="h-7 w-7 rounded-full"
-              aria-label={`Rename ${name}`}
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(e) => { e.stopPropagation(); onDelete(id, name, binCount); }}
-              className="h-7 w-7 rounded-full text-[var(--destructive)]"
-              aria-label={`Delete ${name}`}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-          {/* Mobile: tap "..." to toggle */}
-          <div className="lg:hidden">
-            {mobileActionsOpen ? (
-              <div className="flex gap-0.5">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={(e) => { e.stopPropagation(); startEdit(); }}
-                  className="h-7 w-7 rounded-full"
-                  aria-label={`Rename ${name}`}
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={(e) => { e.stopPropagation(); onDelete(id, name, binCount); }}
-                  className="h-7 w-7 rounded-full text-[var(--destructive)]"
-                  aria-label={`Delete ${name}`}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={(e) => { e.stopPropagation(); setMobileActionsOpen(true); }}
-                className="h-7 w-7 rounded-full"
-                aria-label="More actions"
+        <div className="relative" ref={menuRef}>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={(e) => { e.stopPropagation(); setActionsOpen(!actionsOpen); }}
+            className="h-7 w-7 rounded-full"
+            aria-label="More actions"
+          >
+            <MoreHorizontal className="h-3.5 w-3.5" />
+          </Button>
+          {actionsOpen && (
+            <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[140px] glass-heavy rounded-[var(--radius-lg)] py-1 shadow-lg border border-[var(--border-glass)]">
+              <button
+                onClick={(e) => { e.stopPropagation(); startEdit(); }}
+                className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
               >
-                <MoreHorizontal className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          </div>
-        </>
+                <Pencil className="h-4 w-4" />
+                Rename
+              </button>
+              <div className="my-1 border-t border-[var(--border-glass)]" />
+              <button
+                onClick={(e) => { e.stopPropagation(); setActionsOpen(false); onDelete(id, name, binCount); }}
+                className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] text-[var(--destructive)] hover:bg-[var(--bg-hover)] transition-colors"
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/features/areas/LocationCard.tsx
+++ b/src/features/areas/LocationCard.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Check, Crown, Users, Plus, MapPinned } from 'lucide-react';
+import { Crown, Users, Plus, MapPinned } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
@@ -104,11 +104,11 @@ export function LocationCard({
               </span>
             ) : 'Member'}
           </span>
-          <span className="text-[13px] text-[var(--text-quaternary)]">&middot;</span>
+          <span className="text-[13px] text-[var(--text-tertiary)] opacity-50">&middot;</span>
           <span className="text-[13px] text-[var(--text-tertiary)]">
             {location.member_count ?? 0} {(location.member_count ?? 0) !== 1 ? 'members' : 'member'}
           </span>
-          <span className="text-[13px] text-[var(--text-quaternary)]">&middot;</span>
+          <span className="text-[13px] text-[var(--text-tertiary)] opacity-50">&middot;</span>
           <span className="text-[13px] text-[var(--text-tertiary)]">
             {location.area_count ?? 0} {(location.area_count ?? 0) !== 1 ? t.areas : t.area}
           </span>
@@ -142,120 +142,112 @@ export function LocationCard({
   }
 
   // --- Active card (expanded) ---
+  const memberCount = location.member_count ?? 0;
+
   return (
-    <div className={cn(
-      'glass-card rounded-[var(--radius-lg)] border-l-3 border-[var(--accent)]',
-      'p-4 flex flex-col gap-3',
-    )}>
-      {/* Header */}
-      <div className="flex items-center gap-2">
-        <span className="text-[17px] font-semibold text-[var(--text-primary)] truncate min-w-0 flex-1">
-          {location.name}
-        </span>
-        <Badge variant="default" className="text-[11px] gap-1 py-0 shrink-0">
-          <Check className="h-3 w-3" />
-          Active
-        </Badge>
-      </div>
-
-      {/* Meta row */}
-      <div className="flex items-center gap-2 text-[13px] text-[var(--text-tertiary)]">
-        {isOwner ? (
-          <span className="inline-flex items-center gap-1">
-            <Crown className="h-3 w-3" />
-            Owner
+    <div
+      className={cn(
+        'glass-card rounded-[var(--radius-lg)]',
+        'outline outline-[1.5px] -outline-offset-[1.5px] outline-[var(--accent)]',
+        'flex flex-col relative z-10',
+      )}
+      style={{ boxShadow: 'var(--shadow-glass), 0 0 12px color-mix(in srgb, var(--accent) 30%, transparent)' }}
+    >
+      {/* Header band */}
+      <div className="px-4 pt-4 pb-3 flex flex-col gap-1.5">
+        {/* Name row */}
+        <div className="flex items-center gap-2">
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent)] shrink-0" />
+          <span className="text-[17px] font-semibold text-[var(--text-primary)] truncate min-w-0 flex-1">
+            {location.name}
           </span>
-        ) : (
-          <span>Member</span>
-        )}
-        <span className="text-[var(--text-quaternary)]">&middot;</span>
-        <span>{location.member_count ?? 0} {(location.member_count ?? 0) !== 1 ? 'members' : 'member'}</span>
-      </div>
-
-      {/* Areas section */}
-      <div className="flex flex-col gap-2 mt-1">
-        <div className="flex items-center justify-between">
-          <span className="text-[13px] uppercase tracking-wider text-[var(--text-tertiary)] font-medium">
-            {t.Areas}
-          </span>
-          <div className="flex items-center gap-1.5">
-            {isOwner && (
-              <Button
-                onClick={onCreateArea}
-                size="icon"
-                className="h-7 w-7 rounded-full"
-                aria-label={`Create ${t.area}`}
-              >
-                <Plus className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          </div>
+          <LocationSettingsMenu
+            compact
+            isOwner={isOwner}
+            onRename={() => onRename(location.id)}
+            onRetention={() => onRetention(location.id)}
+            onDelete={() => onDelete(location.id)}
+            onLeave={() => onLeave(location.id)}
+          />
         </div>
 
-        {areaInfos.length === 0 && unassignedCount === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-3 py-8 text-[var(--text-tertiary)]">
-            <MapPinned className="h-10 w-10 opacity-40" />
-            <p className="text-[13px]">
-              {`No ${t.areas} yet`}
-            </p>
-            {isOwner && (
-              <Button onClick={onCreateArea} variant="outline" size="sm" className="rounded-[var(--radius-full)]">
-                <Plus className="h-3.5 w-3.5 mr-1.5" />
-                {`Create ${t.Area}`}
-              </Button>
-            )}
-          </div>
-        ) : (
-          <div className="flex flex-col -mx-4">
-            {areaInfos.map((area) => (
-              <AreaRow
-                key={area.id}
-                id={area.id}
-                name={area.name}
-                binCount={area.binCount}
-                isOwner={isOwner}
-                onNavigate={handleAreaClick}
-                onRename={onRenameArea}
-                onDelete={onDeleteArea}
-              />
-            ))}
-            {unassignedCount > 0 && (
-              <button
-                onClick={handleUnassignedClick}
-                className="flex items-center gap-3 px-4 py-2.5 hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
-              >
-                <span className="flex-1 text-[15px] text-[var(--text-primary)] font-medium">
-                  Unassigned
-                </span>
-                <span className="text-[13px] text-[var(--text-tertiary)] tabular-nums">
-                  {unassignedCount} {unassignedCount !== 1 ? t.bins : t.bin}
-                </span>
-              </button>
-            )}
-          </div>
-        )}
+        {/* Meta row */}
+        <div className="flex items-center gap-2 text-[13px] text-[var(--text-tertiary)]">
+          {isOwner ? (
+            <span className="inline-flex items-center gap-1">
+              <Crown className="h-3 w-3" />
+              Owner
+            </span>
+          ) : (
+            <span>Member</span>
+          )}
+          <span className="text-[var(--text-tertiary)] opacity-50">&middot;</span>
+          <button
+            className="inline-flex items-center gap-1 hover:text-[var(--text-primary)] transition-colors cursor-pointer"
+            onClick={() => onMembers(location.id)}
+          >
+            <Users className="h-3 w-3" />
+            {memberCount} {memberCount !== 1 ? 'members' : 'member'}
+          </button>
+          <div className="flex-1" />
+          {isOwner && (
+            <Button
+              onClick={onCreateArea}
+              size="icon"
+              className="h-7 w-7 rounded-full"
+              aria-label={`Create ${t.area}`}
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-2 pt-1 border-t border-[var(--border-glass)]">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="rounded-[var(--radius-full)] h-8 px-3"
-          onClick={() => onMembers(location.id)}
-        >
-          <Users className="h-3.5 w-3.5 mr-1.5" />
-          Members
-        </Button>
-        <div className="flex-1" />
-        <LocationSettingsMenu
-          isOwner={isOwner}
-          onRename={() => onRename(location.id)}
-          onRetention={() => onRetention(location.id)}
-          onDelete={() => onDelete(location.id)}
-          onLeave={() => onLeave(location.id)}
-        />
-      </div>
+      {/* Area list */}
+      {areaInfos.length === 0 && unassignedCount === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-8 text-[var(--text-tertiary)]">
+          <MapPinned className="h-10 w-10 opacity-40" />
+          <p className="text-[13px]">
+            {`No ${t.areas} yet`}
+          </p>
+          {isOwner && (
+            <Button onClick={onCreateArea} variant="outline" size="sm" className="rounded-[var(--radius-full)]">
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              {`Create ${t.Area}`}
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col border-t border-[var(--border-glass)]">
+          {areaInfos.map((area) => (
+            <AreaRow
+              key={area.id}
+              id={area.id}
+              name={area.name}
+              binCount={area.binCount}
+              isOwner={isOwner}
+              onNavigate={handleAreaClick}
+              onRename={onRenameArea}
+              onDelete={onDeleteArea}
+            />
+          ))}
+          {unassignedCount > 0 && (
+            <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-[var(--bg-hover)] transition-colors">
+              <button
+                className="flex-1 min-w-0 text-left cursor-pointer"
+                onClick={handleUnassignedClick}
+              >
+                <span className="text-[15px] font-medium text-[var(--text-primary)] truncate block">
+                  Unassigned
+                </span>
+              </button>
+              <span className="text-[13px] text-[var(--text-tertiary)] shrink-0 tabular-nums">
+                {unassignedCount} {unassignedCount !== 1 ? t.bins : t.bin}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/areas/LocationSettingsMenu.tsx
+++ b/src/features/areas/LocationSettingsMenu.tsx
@@ -8,9 +8,10 @@ interface LocationSettingsMenuProps {
   onRetention: () => void;
   onDelete: () => void;
   onLeave: () => void;
+  compact?: boolean;
 }
 
-export function LocationSettingsMenu({ isOwner, onRename, onRetention, onDelete, onLeave }: LocationSettingsMenuProps) {
+export function LocationSettingsMenu({ isOwner, onRename, onRetention, onDelete, onLeave, compact }: LocationSettingsMenuProps) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -34,12 +35,15 @@ export function LocationSettingsMenu({ isOwner, onRename, onRetention, onDelete,
     return (
       <Button
         variant="ghost"
-        size="sm"
+        size={compact ? 'icon' : 'sm'}
         onClick={onLeave}
-        className="rounded-[var(--radius-full)] h-8 px-3 text-[var(--destructive)]"
+        className={compact
+          ? 'h-7 w-7 rounded-full text-[var(--destructive)]'
+          : 'rounded-[var(--radius-full)] h-8 px-3 text-[var(--destructive)]'
+        }
       >
-        <LogOut className="h-3.5 w-3.5 mr-1.5" />
-        Leave
+        <LogOut className="h-3.5 w-3.5" />
+        {!compact && <span className="ml-1.5">Leave</span>}
       </Button>
     );
   }
@@ -48,13 +52,21 @@ export function LocationSettingsMenu({ isOwner, onRename, onRetention, onDelete,
     <div className="relative" ref={menuRef}>
       <Button
         variant="ghost"
-        size="sm"
+        size={compact ? 'icon' : 'sm'}
         onClick={() => setOpen(!open)}
-        className="rounded-[var(--radius-full)] h-8 px-3"
+        className={compact
+          ? 'h-7 w-7 rounded-full'
+          : 'rounded-[var(--radius-full)] h-8 px-3'
+        }
+        aria-label="Settings"
       >
-        <Settings className="h-3.5 w-3.5 mr-1.5" />
-        Settings
-        <ChevronRight className={`h-3.5 w-3.5 ml-1 transition-transform ${open ? 'rotate-90' : ''}`} />
+        <Settings className="h-3.5 w-3.5" />
+        {!compact && (
+          <>
+            <span className="ml-1.5">Settings</span>
+            <ChevronRight className={`h-3.5 w-3.5 ml-1 transition-transform ${open ? 'rotate-90' : ''}`} />
+          </>
+        )}
       </Button>
       {open && (
         <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[180px] glass-heavy rounded-[var(--radius-lg)] py-1 shadow-lg border border-[var(--border-glass)]">

--- a/src/features/locations/LocationMembersDialog.tsx
+++ b/src/features/locations/LocationMembersDialog.tsx
@@ -91,7 +91,7 @@ export function LocationMembersDialog({ locationId, open, onOpenChange }: Locati
         {/* Invite Code */}
         {location?.invite_code && (
           <div className="flex items-center gap-2 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-input)]">
-            <span className="flex-1 text-[14px] font-mono text-[var(--text-primary)] tracking-wider">
+            <span className="flex-1 min-w-0 text-[14px] font-mono text-[var(--text-primary)] tracking-wider truncate">
               {location.invite_code}
             </span>
             <Button

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* ─── iOS 26 Liquid Glass Design Tokens ─── */
 :root {
   --bg-base: #f2f2f7;
@@ -22,6 +24,7 @@
   --destructive-hover: #d63028;
   --shadow-glass: 0 2px 16px rgba(0, 0, 0, 0.08), 0 0 1px rgba(0, 0, 0, 0.1);
   --shadow-elevated: 0 8px 32px rgba(0, 0, 0, 0.12), 0 0 1px rgba(0, 0, 0, 0.08);
+  --radius-xs: 8px;
   --radius-sm: 10px;
   --radius-md: 14px;
   --radius-lg: 20px;

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -28,7 +28,7 @@ function applyToDOM(resolved: ResolvedTheme) {
 }
 
 let currentPreference: ThemePreference = getStoredPreference();
-let currentTheme: ResolvedTheme = resolve(currentPreference);
+let currentTheme: ResolvedTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
 const listeners = new Set<() => void>();
 
 function notify() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
         name: 'OpenBin',
         short_name: 'OpenBin',
         description: 'Label storage bins with QR codes and maintain a searchable digital inventory',
-        theme_color: '#1e293b',
-        background_color: '#0f172a',
+        theme_color: '#000000',
+        background_color: '#000000',
         display: 'standalone',
         orientation: 'portrait',
         icons: [


### PR DESCRIPTION
## Summary
- Fix PWA dark mode color desync on iOS initial load by trusting the DOM class set by the inline theme script instead of re-evaluating the media query
- Move CSP from client-side meta tag to server-side header with SHA-256 hash for the inline theme script
- Add Tailwind CSS 4 `@custom-variant dark` so `dark:` utilities respond to the `.dark` class instead of the OS media query
- Unify area row actions into a single dropdown menu (replaces separate desktop hover / mobile tap patterns)
- Redesign active location card with outline glow, compact header settings gear, and clickable member count
- Fix invite code overflow in members dialog

## Test plan
- [ ] Open PWA on iOS in dark mode — theme should match on first paint without flash
- [ ] Verify CSP allows the inline theme script (no console errors)
- [ ] Test area row rename/delete via the new dropdown menu on both mobile and desktop
- [ ] Confirm active location card renders correctly with glow outline and settings gear
- [ ] Check invite code truncates gracefully in members dialog on narrow screens