### PR TITLE
feat: sidebar location switcher and UI polish

### DIFF
--- a/server/src/routes/locations.ts
+++ b/server/src/routes/locations.ts
@@ -25,7 +25,7 @@ router.get('/', asyncHandler(async (req, res) => {
             (SELECT COUNT(*) FROM areas WHERE location_id = l.id) AS area_count
      FROM locations l
      JOIN location_members lm ON lm.location_id = l.id AND lm.user_id = $1
-     ORDER BY l.updated_at DESC`,
+     ORDER BY l.name COLLATE NOCASE ASC`,
     [req.user!.id]
   );
 

--- a/src/features/activity/ActivityPage.tsx
+++ b/src/features/activity/ActivityPage.tsx
@@ -110,13 +110,15 @@ export function ActivityPage() {
       </h1>
 
       {isLoading && entries.length === 0 ? (
-        <div className="space-y-4">
+        <div className="space-y-3">
           {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="flex items-start gap-3">
-              <Skeleton className="h-8 w-8 rounded-full shrink-0" />
-              <div className="flex-1 space-y-1.5">
-                <Skeleton className="h-4 w-3/4" />
-                <Skeleton className="h-3 w-1/4" />
+            <div key={i} className="glass-card rounded-[var(--radius-lg)] px-4 py-3.5">
+              <div className="flex items-start gap-3">
+                <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-1/4" />
+                </div>
               </div>
             </div>
           ))}
@@ -138,11 +140,11 @@ export function ActivityPage() {
               <h2 className="text-[13px] font-semibold text-[var(--text-tertiary)] uppercase tracking-wide">
                 {dateLabel}
               </h2>
-              <div className="space-y-0">
+              <div className="space-y-3">
                 {items.map((entry) => (
                   <button
                     key={entry.id}
-                    className="w-full flex items-start gap-3 py-2.5 px-1 text-left hover:bg-[var(--bg-hover)] rounded-[var(--radius-md)] transition-colors"
+                    className="glass-card w-full flex items-start gap-3 px-4 py-3.5 text-left rounded-[var(--radius-lg)] hover:bg-[var(--bg-hover)] active:scale-[0.98] transition-all duration-200"
                     onClick={() => {
                       if (entry.entity_type === 'bin' && entry.entity_id && entry.action !== 'permanent_delete') {
                         navigate(`/bin/${entry.entity_id}`);

--- a/src/features/activity/ActivityPage.tsx
+++ b/src/features/activity/ActivityPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { usePermissions } from '@/lib/usePermissions';
 import { Clock, Package, MapPin, Users, Image, RotateCcw, Trash2, Plus, Pencil, LogIn, LogOut, UserMinus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -99,9 +100,15 @@ function groupByDate(entries: ActivityLogEntry[]): Map<string, ActivityLogEntry[
 
 export function ActivityPage() {
   const navigate = useNavigate();
+  const { isAdmin } = usePermissions();
   const t = useTerminology();
   const { entries, isLoading, hasMore, loadMore } = useActivityLog({ limit: 50 });
   const grouped = groupByDate(entries);
+
+  if (!isAdmin) {
+    navigate('/', { replace: true });
+    return null;
+  }
 
   return (
     <div className="flex flex-col gap-4 px-5 pt-2 lg:pt-6 pb-2 max-w-2xl mx-auto">

--- a/src/features/areas/AreaCard.tsx
+++ b/src/features/areas/AreaCard.tsx
@@ -129,13 +129,13 @@ export function AreaCard({ id, name, binCount, isAdmin, onNavigate, onRename, on
             variant="ghost"
             size="icon"
             onClick={(e) => { e.stopPropagation(); setActionsOpen(!actionsOpen); }}
-            className="h-7 w-7 rounded-full opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus:opacity-100 transition-opacity"
+            className="h-9 w-9 rounded-full [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 focus:opacity-100 transition-opacity"
             aria-label="More actions"
           >
             <MoreHorizontal className="h-3.5 w-3.5" />
           </Button>
           {actionsOpen && (
-            <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[140px] glass-heavy rounded-[var(--radius-lg)] py-1 shadow-lg border border-[var(--border-glass)] overflow-hidden">
+            <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[140px] glass-heavy rounded-[var(--radius-lg)] shadow-lg border border-[var(--border-glass)] overflow-hidden">
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); startEdit(); }}

--- a/src/features/areas/AreaCard.tsx
+++ b/src/features/areas/AreaCard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useTerminology } from '@/lib/terminology';
+import { cn } from '@/lib/utils';
 
 interface AreaCardProps {
   id: string;
@@ -102,10 +103,15 @@ export function AreaCard({ id, name, binCount, isAdmin, onNavigate, onRename, on
   }
 
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => onNavigate(id)}
-      className="glass-card rounded-[var(--radius-lg)] p-4 cursor-pointer hover:bg-[var(--bg-hover)] transition-all duration-200 active:scale-[0.98] text-left relative group"
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onNavigate(id); } }}
+      className={cn(
+        "glass-card rounded-[var(--radius-lg)] p-4 cursor-pointer hover:bg-[var(--bg-hover)] transition-all duration-200 active:scale-[0.98] text-left relative group",
+        actionsOpen && "z-10"
+      )}
     >
       <span className="text-[15px] font-semibold text-[var(--text-primary)] truncate block pr-7">
         {name}
@@ -123,13 +129,13 @@ export function AreaCard({ id, name, binCount, isAdmin, onNavigate, onRename, on
             variant="ghost"
             size="icon"
             onClick={(e) => { e.stopPropagation(); setActionsOpen(!actionsOpen); }}
-            className="h-7 w-7 rounded-full opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+            className="h-7 w-7 rounded-full opacity-100 lg:opacity-0 lg:group-hover:opacity-100 focus:opacity-100 transition-opacity"
             aria-label="More actions"
           >
             <MoreHorizontal className="h-3.5 w-3.5" />
           </Button>
           {actionsOpen && (
-            <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[140px] glass-heavy rounded-[var(--radius-lg)] py-1 shadow-lg border border-[var(--border-glass)]">
+            <div className="absolute right-0 top-full mt-1.5 z-50 min-w-[140px] glass-heavy rounded-[var(--radius-lg)] py-1 shadow-lg border border-[var(--border-glass)] overflow-hidden">
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); startEdit(); }}
@@ -151,7 +157,7 @@ export function AreaCard({ id, name, binCount, isAdmin, onNavigate, onRename, on
           )}
         </div>
       )}
-    </button>
+    </div>
   );
 }
 

--- a/src/features/areas/AreasPage.tsx
+++ b/src/features/areas/AreasPage.tsx
@@ -252,7 +252,7 @@ export function AreasPage() {
               )}
             </div>
           ) : (
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {areaInfos.map((area) => (
                 <AreaCard
                   key={area.id}

--- a/src/features/bins/BinDetailPage.tsx
+++ b/src/features/bins/BinDetailPage.tsx
@@ -548,7 +548,7 @@ export function BinDetailPage() {
                       onPaste={quickAdd.handlePaste}
                       placeholder="Add item..."
                       disabled={quickAdd.saving}
-                      className="h-7 bg-transparent p-0 text-base focus-visible:ring-0"
+                      className="h-7 bg-transparent px-0.5 py-0 text-base focus-visible:ring-0"
                     />
                     {quickAdd.value.trim() && (
                       <button

--- a/src/features/bins/BinDetailPage.tsx
+++ b/src/features/bins/BinDetailPage.tsx
@@ -256,7 +256,7 @@ export function BinDetailPage() {
         ) : (
           <div className="flex gap-1.5">
             {showAiButton && (
-              <Tooltip content="Analyze with AI">
+              <Tooltip content="Analyze with AI" side="bottom">
                 <Button
                   size="icon"
                   onClick={handleAnalyzeClick}
@@ -272,7 +272,7 @@ export function BinDetailPage() {
                 </Button>
               </Tooltip>
             )}
-            <Tooltip content={bin.is_pinned ? 'Unpin' : 'Pin'}>
+            <Tooltip content={bin.is_pinned ? 'Unpin' : 'Pin'} side="bottom">
               <Button
                 variant="ghost"
                 size="icon"
@@ -292,7 +292,7 @@ export function BinDetailPage() {
               </Button>
             </Tooltip>
             {canEdit && (
-              <Tooltip content="Edit">
+              <Tooltip content="Edit" side="bottom">
                 <Button
                   variant="ghost"
                   size="icon"
@@ -304,7 +304,7 @@ export function BinDetailPage() {
                 </Button>
               </Tooltip>
             )}
-            <Tooltip content="Print label">
+            <Tooltip content="Print label" side="bottom">
               <Button
                 variant="ghost"
                 size="icon"
@@ -316,7 +316,7 @@ export function BinDetailPage() {
               </Button>
             </Tooltip>
             {isAdmin && otherLocations.length > 0 && (
-              <Tooltip content="Move">
+              <Tooltip content="Move" side="bottom">
                 <Button
                   variant="ghost"
                   size="icon"
@@ -336,7 +336,7 @@ export function BinDetailPage() {
               </Tooltip>
             )}
             {canDelete && (
-              <Tooltip content="Delete">
+              <Tooltip content="Delete" side="bottom">
                 <Button
                   variant="ghost"
                   size="icon"

--- a/src/features/bins/ItemsInput.tsx
+++ b/src/features/bins/ItemsInput.tsx
@@ -203,7 +203,7 @@ export function ItemsInput({ items, onChange, showAi, aiConfigured, onAiSetupNee
             onKeyDown={handleInputKeyDown}
             onPaste={handlePaste}
             placeholder={items.length === 0 ? 'Add items...' : 'Add another item...'}
-            className="h-7 bg-transparent p-0 text-base focus-visible:ring-0"
+            className="h-7 bg-transparent px-0.5 py-0 text-base focus-visible:ring-0"
           />
           {input.trim() && (
             <button

--- a/src/features/bins/TagInput.tsx
+++ b/src/features/bins/TagInput.tsx
@@ -113,7 +113,7 @@ export function TagInput({ tags, onChange, suggestions = [] }: TagInputProps) {
           onKeyDown={handleKeyDown}
           onFocus={() => setShowSuggestions(true)}
           placeholder={tags.length === 0 ? 'Add tags...' : ''}
-          className="h-6 min-w-[80px] flex-1 bg-transparent p-0 text-base focus-visible:ring-0"
+          className="h-6 min-w-[80px] flex-1 bg-transparent px-0.5 py-0 text-base focus-visible:ring-0"
         />
       </div>
       {visible && (

--- a/src/features/bins/TrashPage.tsx
+++ b/src/features/bins/TrashPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Trash2, RotateCcw, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -27,6 +28,7 @@ function formatTimeAgo(dateStr: string): string {
 }
 
 export function TrashPage() {
+  const navigate = useNavigate();
   const { bins, isLoading } = useTrashBins();
   const { showToast } = useToast();
   const { activeLocationId } = useAuth();
@@ -36,6 +38,11 @@ export function TrashPage() {
   const [confirmDelete, setConfirmDelete] = useState<Bin | null>(null);
   const activeLoc = locations.find((l) => l.id === activeLocationId);
   const retentionDays = (activeLoc as { trash_retention_days?: number } | undefined)?.trash_retention_days ?? 30;
+
+  if (!isAdmin) {
+    navigate('/', { replace: true });
+    return null;
+  }
 
   async function handleRestore(bin: Bin) {
     try {

--- a/src/features/layout/AppLayout.tsx
+++ b/src/features/layout/AppLayout.tsx
@@ -76,7 +76,7 @@ export function AppLayout() {
       >
         Skip to main content
       </a>
-      <Sidebar />
+      <Sidebar locations={locations} activeLocationId={activeLocationId} onLocationChange={setActiveLocationId} />
       {/* pb: nav-height(52) + bottom-offset(20) + safe-area + breathing(16) ≈ 88+safe */}
       <main id="main-content" className="lg:ml-[260px] pt-[var(--safe-top)] pb-[calc(88px+var(--safe-bottom))] lg:pb-8">
         <div className="mx-auto w-full max-w-7xl">

--- a/src/features/layout/LocationSwitcher.tsx
+++ b/src/features/layout/LocationSwitcher.tsx
@@ -1,0 +1,98 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { MapPin, ChevronsUpDown, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useClickOutside } from '@/lib/useClickOutside';
+import { Badge } from '@/components/ui/badge';
+import type { Location } from '@/types';
+
+interface LocationSwitcherProps {
+  locations: Location[];
+  activeLocationId: string | null;
+  onLocationChange: (id: string) => void;
+}
+
+export function LocationSwitcher({ locations, activeLocationId, onLocationChange }: LocationSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+  useClickOutside(ref, close);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  if (locations.length === 0) return null;
+
+  const active = locations.find((l) => l.id === activeLocationId);
+
+  if (locations.length === 1) {
+    return (
+      <div className="flex items-center gap-2.5 px-3 py-2.5 text-[14px] font-medium text-[var(--text-secondary)]">
+        <MapPin className="h-4 w-4 text-[var(--text-tertiary)] shrink-0" />
+        <span className="truncate">{active?.name ?? locations[0].name}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className={cn(
+          'flex items-center gap-2.5 w-full px-3 py-2.5 rounded-[var(--radius-sm)] text-[14px] font-medium transition-colors text-left',
+          open
+            ? 'glass-card text-[var(--text-primary)]'
+            : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+        )}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <MapPin className="h-4 w-4 text-[var(--text-tertiary)] shrink-0" />
+        <span className="flex-1 truncate">{active?.name ?? 'Select location'}</span>
+        <ChevronsUpDown className="h-3.5 w-3.5 text-[var(--text-tertiary)] shrink-0" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 right-0 top-full mt-1.5 z-50 glass-heavy rounded-[var(--radius-lg)] py-1 shadow-lg border border-[var(--border-glass)] max-h-64 overflow-y-auto"
+        >
+          {locations.map((loc) => {
+            const isActive = loc.id === activeLocationId;
+            return (
+              <button
+                key={loc.id}
+                role="option"
+                aria-selected={isActive}
+                onClick={() => {
+                  onLocationChange(loc.id);
+                  setOpen(false);
+                }}
+                className={cn(
+                  'w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] transition-colors',
+                  isActive
+                    ? 'text-[var(--text-primary)] bg-[var(--bg-hover)]'
+                    : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+                )}
+              >
+                <Check className={cn('h-4 w-4 shrink-0', isActive ? 'text-[var(--accent)]' : 'invisible')} />
+                <span className="flex-1 truncate">{loc.name}</span>
+                {loc.role && (
+                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                    {loc.role}
+                  </Badge>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/layout/LocationSwitcher.tsx
+++ b/src/features/layout/LocationSwitcher.tsx
@@ -31,14 +31,7 @@ export function LocationSwitcher({ locations, activeLocationId, onLocationChange
 
   const active = locations.find((l) => l.id === activeLocationId);
 
-  if (locations.length === 1) {
-    return (
-      <div className="flex items-center gap-2.5 px-3 py-2.5 text-[14px] font-medium text-[var(--text-secondary)]">
-        <MapPin className="h-4 w-4 text-[var(--text-tertiary)] shrink-0" />
-        <span className="truncate">{active?.name ?? locations[0].name}</span>
-      </div>
-    );
-  }
+  if (locations.length <= 1) return null;
 
   return (
     <div className="relative" ref={ref}>

--- a/src/features/layout/Sidebar.tsx
+++ b/src/features/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useAppSettings } from '@/lib/appSettings';
 import { useTerminology } from '@/lib/terminology';
 import type { TermKey } from '@/lib/navItems';
 import { useAuth } from '@/lib/auth';
+import { usePermissions } from '@/lib/usePermissions';
 import { getAvatarUrl } from '@/lib/api';
 import { LocationSwitcher } from './LocationSwitcher';
 import type { Location as LocationType } from '@/types';
@@ -63,6 +64,7 @@ export function Sidebar({ locations, activeLocationId, onLocationChange }: Sideb
   const { settings } = useAppSettings();
   const t = useTerminology();
   const { user, logout } = useAuth();
+  const { isAdmin } = usePermissions();
 
   return (
     <aside aria-label="Main navigation" className="hidden lg:flex flex-col w-[260px] h-dvh fixed left-0 top-0 bg-[var(--bg-sidebar)] border-r border-[var(--border-subtle)] print-hide">
@@ -132,7 +134,7 @@ export function Sidebar({ locations, activeLocationId, onLocationChange }: Sideb
               <span className="flex-1 truncate">{user.displayName || user.username}</span>
             </button>
           )}
-          <NavButton path="/activity" label="Activity" icon={Clock} currentPath={location.pathname} navigate={navigate} />
+          {isAdmin && <NavButton path="/activity" label="Activity" icon={Clock} currentPath={location.pathname} navigate={navigate} />}
           <NavButton path="/settings" label="Settings" icon={Settings} currentPath={location.pathname} navigate={navigate} />
           <button
             onClick={logout}

--- a/src/features/layout/Sidebar.tsx
+++ b/src/features/layout/Sidebar.tsx
@@ -6,6 +6,8 @@ import { useTerminology } from '@/lib/terminology';
 import type { TermKey } from '@/lib/navItems';
 import { useAuth } from '@/lib/auth';
 import { getAvatarUrl } from '@/lib/api';
+import { LocationSwitcher } from './LocationSwitcher';
+import type { Location as LocationType } from '@/types';
 
 const topItems: { path: string; label: string; icon: React.ComponentType<{ className?: string }>; termKey?: TermKey }[] = [
   { path: '/', label: 'Home', icon: LayoutDashboard },
@@ -49,7 +51,13 @@ function NavButton({ path, label, icon: Icon, currentPath, navigate }: {
   );
 }
 
-export function Sidebar() {
+interface SidebarProps {
+  locations: LocationType[];
+  activeLocationId: string | null;
+  onLocationChange: (id: string) => void;
+}
+
+export function Sidebar({ locations, activeLocationId, onLocationChange }: SidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { settings } = useAppSettings();
@@ -65,6 +73,13 @@ export function Sidebar() {
             {settings.appName}
           </h1>
         </div>
+
+        {/* Location switcher */}
+        <LocationSwitcher
+          locations={locations}
+          activeLocationId={activeLocationId}
+          onLocationChange={onLocationChange}
+        />
 
         {/* Top: Home, Bins */}
         <div className="space-y-1">

--- a/src/features/layout/Sidebar.tsx
+++ b/src/features/layout/Sidebar.tsx
@@ -76,15 +76,14 @@ export function Sidebar({ locations, activeLocationId, onLocationChange }: Sideb
           </h1>
         </div>
 
-        {/* Location switcher */}
-        <LocationSwitcher
-          locations={locations}
-          activeLocationId={activeLocationId}
-          onLocationChange={onLocationChange}
-        />
-
         {/* Top: Home, Bins */}
         <div className="space-y-1">
+          {/* Location switcher */}
+          <LocationSwitcher
+            locations={locations}
+            activeLocationId={activeLocationId}
+            onLocationChange={onLocationChange}
+          />
           {topItems.map((item) => (
             <NavButton key={item.path} {...item} label={item.termKey ? t[item.termKey] : item.label} currentPath={location.pathname} navigate={navigate} />
           ))}

--- a/src/lib/__tests__/appSettings.test.ts
+++ b/src/lib/__tests__/appSettings.test.ts
@@ -72,13 +72,19 @@ describe('useAppSettings', () => {
   });
 
   it('updateSettings calls updateLocation', () => {
+    vi.useFakeTimers();
     const { result } = renderHook(() => useAppSettings());
 
     act(() => {
       result.current.updateSettings({ appName: 'NewName' });
     });
 
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
     expect(mockUpdateLocation).toHaveBeenCalledWith('loc-1', { app_name: 'NewName' });
+    vi.useRealTimers();
   });
 
   it('resetSettings calls updateLocation with OpenBin', () => {

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
 import { useAuth } from '@/lib/auth';
 import { useLocationList, updateLocation } from '@/features/locations/useLocations';
 
@@ -12,40 +12,73 @@ export interface AppSettings {
 export function useAppSettings() {
   const { activeLocationId } = useAuth();
   const { locations, isLoading } = useLocationList();
+  const [pendingPatch, setPendingPatch] = useState<Partial<AppSettings> | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const pendingPayloadRef = useRef<Record<string, string | number>>({});
 
   const activeLocation = locations.find((l) => l.id === activeLocationId);
-  const settings: AppSettings = {
+  const serverSettings: AppSettings = {
     appName: activeLocation?.app_name ?? 'OpenBin',
     termBin: activeLocation?.term_bin ?? '',
     termLocation: activeLocation?.term_location ?? '',
     termArea: activeLocation?.term_area ?? '',
   };
 
+  // Merge server state with any pending optimistic patch
+  const settings: AppSettings = pendingPatch
+    ? { ...serverSettings, ...pendingPatch }
+    : serverSettings;
+
   useEffect(() => {
     document.title = settings.appName;
   }, [settings.appName]);
 
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
   const updateSettings = useCallback((patch: Partial<AppSettings>) => {
     if (!activeLocationId) return;
-    const payload: Record<string, string | number> = {};
-    if (patch.appName !== undefined) payload.app_name = patch.appName || 'OpenBin';
-    if (patch.termBin !== undefined) payload.term_bin = patch.termBin;
-    if (patch.termLocation !== undefined) payload.term_location = patch.termLocation;
-    if (patch.termArea !== undefined) payload.term_area = patch.termArea;
-    if (Object.keys(payload).length > 0) {
+
+    // Build API payload from this patch
+    const newFields: Record<string, string | number> = {};
+    if (patch.appName !== undefined) newFields.app_name = patch.appName || 'OpenBin';
+    if (patch.termBin !== undefined) newFields.term_bin = patch.termBin;
+    if (patch.termLocation !== undefined) newFields.term_location = patch.termLocation;
+    if (patch.termArea !== undefined) newFields.term_area = patch.termArea;
+    if (Object.keys(newFields).length === 0) return;
+
+    // Accumulate fields across rapid calls so nothing is lost
+    pendingPayloadRef.current = { ...pendingPayloadRef.current, ...newFields };
+
+    // Update optimistic local state immediately
+    setPendingPatch((prev) => ({ ...prev, ...patch }));
+
+    // Debounce the actual API call
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const payload = pendingPayloadRef.current;
+      pendingPayloadRef.current = {};
+      setPendingPatch(null);
       updateLocation(activeLocationId, payload);
-    }
+    }, 500);
   }, [activeLocationId]);
 
   const resetSettings = useCallback(() => {
-    if (activeLocationId) {
-      updateLocation(activeLocationId, {
-        app_name: 'OpenBin',
-        term_bin: '',
-        term_location: '',
-        term_area: '',
-      });
-    }
+    if (!activeLocationId) return;
+    // Cancel any pending debounced save
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    pendingPayloadRef.current = {};
+    setPendingPatch(null);
+    updateLocation(activeLocationId, {
+      app_name: 'OpenBin',
+      term_bin: '',
+      term_location: '',
+      term_area: '',
+    });
   }, [activeLocationId]);
 
   return { settings, updateSettings, resetSettings, isLoading };


### PR DESCRIPTION
## Summary
- Add a location switcher dropdown to the sidebar for quick location switching without navigating away
- Restrict admin-only pages (Activity, Trash) and settings sections to admin users
- Debounce app settings saves with optimistic updates to prevent rapid API calls
- Improve area grid responsiveness, touch targets, AreaCard accessibility, and activity page styling
- Sort locations alphabetically and hide switcher for single-location users

## Test plan
- [ ] Verify sidebar location switcher appears for multi-location users and hides for single-location users
- [ ] Switch locations via the sidebar dropdown and confirm bins/areas update
- [ ] Log in as a non-admin and verify Activity/Trash pages redirect and admin settings sections are hidden
- [ ] Change settings rapidly and verify debounced saves (no flicker, no rapid API calls)
- [ ] Check area cards on mobile for visible action buttons and proper touch targets
- [ ] Run `npx vitest run` to confirm tests pass