### PR TITLE
feat: add MCP server for OpenBin

### DIFF
--- a/server/mcp/package-lock.json
+++ b/server/mcp/package-lock.json
@@ -1,0 +1,1717 @@
+{
+  "name": "@openbin/mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openbin/mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.3",
+        "tsx": "^4.19.4",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openbin/mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server for OpenBin inventory management",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "tsx": "^4.19.4",
+    "typescript": "^5.7.3"
+  }
+}

--- a/server/mcp/src/api-client.ts
+++ b/server/mcp/src/api-client.ts
@@ -70,6 +70,28 @@ export class ApiClient {
   del<T>(path: string): Promise<T> {
     return this.request<T>("DELETE", path);
   }
+
+  async getText(path: string): Promise<string> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+    });
+
+    if (!res.ok) {
+      let code = "UNKNOWN";
+      let message = `HTTP ${res.status}`;
+      try {
+        const err = (await res.json()) as ErrorBody;
+        code = err.error;
+        message = err.message;
+      } catch {
+        // use defaults
+      }
+      throw new OpenBinApiError(res.status, code, message);
+    }
+
+    return res.text();
+  }
 }
 
 type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean };

--- a/server/mcp/src/api-client.ts
+++ b/server/mcp/src/api-client.ts
@@ -1,0 +1,97 @@
+export class OpenBinApiError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "OpenBinApiError";
+  }
+}
+
+interface ErrorBody {
+  error: string;
+  message: string;
+}
+
+export class ApiClient {
+  constructor(
+    private baseUrl: string,
+    private apiKey: string,
+  ) {}
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!res.ok) {
+      let code = "UNKNOWN";
+      let message = `HTTP ${res.status}`;
+      try {
+        const err = (await res.json()) as ErrorBody;
+        code = err.error;
+        message = err.message;
+      } catch {
+        // use defaults
+      }
+      throw new OpenBinApiError(res.status, code, message);
+    }
+
+    if (res.status === 204) {
+      return undefined as T;
+    }
+
+    return (await res.json()) as T;
+  }
+
+  get<T>(path: string): Promise<T> {
+    return this.request<T>("GET", path);
+  }
+
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+
+  put<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PUT", path, body);
+  }
+
+  del<T>(path: string): Promise<T> {
+    return this.request<T>("DELETE", path);
+  }
+}
+
+type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+export function withErrorHandling<T extends Record<string, unknown>>(
+  fn: (args: T) => Promise<ToolResult>,
+): (args: T) => Promise<ToolResult> {
+  return async (args: T) => {
+    try {
+      return await fn(args);
+    } catch (err) {
+      if (err instanceof OpenBinApiError) {
+        return {
+          content: [{ type: "text" as const, text: `Error (${err.code}): ${err.message}` }],
+          isError: true,
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text" as const, text: `Unexpected error: ${message}` }],
+        isError: true,
+      };
+    }
+  };
+}

--- a/server/mcp/src/index.ts
+++ b/server/mcp/src/index.ts
@@ -1,0 +1,41 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ApiClient, OpenBinApiError } from "./api-client.js";
+import { registerLocationTools } from "./tools/locations.js";
+import { registerAreaTools } from "./tools/areas.js";
+import { registerBinTools } from "./tools/bins.js";
+import { registerItemTools } from "./tools/items.js";
+import { registerTagTools } from "./tools/tags.js";
+import { registerScanHistoryTools } from "./tools/scan-history.js";
+
+const apiKey = process.env.OPENBIN_API_KEY;
+if (!apiKey) {
+  console.error("OPENBIN_API_KEY environment variable is required");
+  process.exit(1);
+}
+
+const apiUrl = process.env.OPENBIN_API_URL || "http://localhost:3000";
+const api = new ApiClient(apiUrl, apiKey);
+
+const server = new McpServer({
+  name: "openbin",
+  version: "1.0.0",
+});
+
+registerLocationTools(server, api);
+registerAreaTools(server, api);
+registerBinTools(server, api);
+registerItemTools(server, api);
+registerTagTools(server, api);
+registerScanHistoryTools(server, api);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`OpenBin MCP server running (API: ${apiUrl})`);
+}
+
+main().catch((err) => {
+  console.error("Failed to start MCP server:", err);
+  process.exit(1);
+});

--- a/server/mcp/src/index.ts
+++ b/server/mcp/src/index.ts
@@ -7,6 +7,8 @@ import { registerBinTools } from "./tools/bins.js";
 import { registerItemTools } from "./tools/items.js";
 import { registerTagTools } from "./tools/tags.js";
 import { registerScanHistoryTools } from "./tools/scan-history.js";
+import { registerExportTools } from "./tools/export.js";
+import { registerActivityTools } from "./tools/activity.js";
 
 const apiKey = process.env.OPENBIN_API_KEY;
 if (!apiKey) {
@@ -28,6 +30,8 @@ registerBinTools(server, api);
 registerItemTools(server, api);
 registerTagTools(server, api);
 registerScanHistoryTools(server, api);
+registerExportTools(server, api);
+registerActivityTools(server, api);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/server/mcp/src/tools/activity.ts
+++ b/server/mcp/src/tools/activity.ts
@@ -1,0 +1,87 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface ActivityEntry {
+  id: string;
+  location_id: string;
+  user_id: string;
+  user_name: string;
+  display_name: string;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  entity_name: string;
+  changes: Record<string, unknown>;
+  created_at: string;
+}
+
+interface ListResponse {
+  results: ActivityEntry[];
+  count: number;
+}
+
+function formatEntry(entry: ActivityEntry): string {
+  const who = entry.display_name || entry.user_name;
+  const parts = [`- **${who}** ${entry.action} ${entry.entity_type} "${entry.entity_name}"`];
+  parts.push(`  ${entry.created_at}`);
+
+  if (entry.changes && Object.keys(entry.changes).length > 0) {
+    const changes = Object.entries(entry.changes)
+      .map(([key, val]) => {
+        if (typeof val === "object" && val !== null && "old" in val && "new" in val) {
+          const v = val as { old: unknown; new: unknown };
+          return `${key}: ${v.old} → ${v.new}`;
+        }
+        return `${key}: ${JSON.stringify(val)}`;
+      })
+      .join(", ");
+    parts.push(`  Changes: ${changes}`);
+  }
+
+  return parts.join("\n");
+}
+
+export function registerActivityTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "get_activity_log",
+    "Get the activity log for a location",
+    {
+      location_id: z.string().describe("Location UUID"),
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 50)"),
+      offset: z.number().min(0).optional().describe("Offset for pagination"),
+      entity_type: z
+        .string()
+        .optional()
+        .describe("Filter by entity type (e.g. 'bin', 'area', 'photo')"),
+      entity_id: z.string().optional().describe("Filter by specific entity UUID"),
+    },
+    withErrorHandling(async ({ location_id, limit, offset, entity_type, entity_id }) => {
+      const params = new URLSearchParams();
+      if (limit) params.set("limit", String(limit));
+      if (offset) params.set("offset", String(offset));
+      if (entity_type) params.set("entity_type", entity_type);
+      if (entity_id) params.set("entity_id", entity_id);
+
+      const query = params.toString();
+      const data = await api.get<ListResponse>(
+        `/api/locations/${encodeURIComponent(location_id)}/activity${query ? `?${query}` : ""}`,
+      );
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No activity found." }] };
+      }
+
+      const lines = data.results.map(formatEntry);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `${data.count} activity entries${data.results.length < data.count ? ` (showing ${data.results.length})` : ""}:\n\n${lines.join("\n\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/activity.ts
+++ b/server/mcp/src/tools/activity.ts
@@ -13,6 +13,7 @@ interface ActivityEntry {
   entity_id: string;
   entity_name: string;
   changes: Record<string, unknown>;
+  auth_method: 'jwt' | 'api_key' | null;
   created_at: string;
 }
 
@@ -24,7 +25,9 @@ interface ListResponse {
 function formatEntry(entry: ActivityEntry): string {
   const who = entry.display_name || entry.user_name;
   const parts = [`- **${who}** ${entry.action} ${entry.entity_type} "${entry.entity_name}"`];
-  parts.push(`  ${entry.created_at}`);
+  const meta = [entry.created_at];
+  if (entry.auth_method) meta.push(`via ${entry.auth_method}`);
+  parts.push(`  ${meta.join(' | ')}`);
 
   if (entry.changes && Object.keys(entry.changes).length > 0) {
     const changes = Object.entries(entry.changes)
@@ -58,8 +61,8 @@ export function registerActivityTools(server: McpServer, api: ApiClient) {
     },
     withErrorHandling(async ({ location_id, limit, offset, entity_type, entity_id }) => {
       const params = new URLSearchParams();
-      if (limit) params.set("limit", String(limit));
-      if (offset) params.set("offset", String(offset));
+      if (limit !== undefined) params.set("limit", String(limit));
+      if (offset !== undefined) params.set("offset", String(offset));
       if (entity_type) params.set("entity_type", entity_type);
       if (entity_id) params.set("entity_id", entity_id);
 

--- a/server/mcp/src/tools/areas.ts
+++ b/server/mcp/src/tools/areas.ts
@@ -1,0 +1,43 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface Area {
+  id: string;
+  name: string;
+  location_id: string;
+  created_at: string;
+}
+
+interface ListResponse {
+  results: Area[];
+  count: number;
+}
+
+export function registerAreaTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "list_areas",
+    "List all areas within a location",
+    { location_id: z.string().describe("Location UUID") },
+    withErrorHandling(async ({ location_id }) => {
+      const data = await api.get<ListResponse>(
+        `/api/locations/${encodeURIComponent(location_id)}/areas`,
+      );
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No areas found in this location." }] };
+      }
+
+      const lines = data.results.map((area) => `- **${area.name}** (id: ${area.id})`);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${data.count} area(s):\n\n${lines.join("\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/areas.ts
+++ b/server/mcp/src/tools/areas.ts
@@ -40,4 +40,71 @@ export function registerAreaTools(server: McpServer, api: ApiClient) {
       };
     }),
   );
+
+  server.tool(
+    "create_area",
+    "Create a new area within a location (admin only)",
+    {
+      location_id: z.string().describe("Location UUID"),
+      name: z.string().describe("Area name"),
+    },
+    withErrorHandling(async ({ location_id, name }) => {
+      const area = await api.post<Area>(
+        `/api/locations/${encodeURIComponent(location_id)}/areas`,
+        { name },
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Area created successfully!\n\n- **${area.name}** (id: ${area.id})`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "rename_area",
+    "Rename an existing area (admin only)",
+    {
+      location_id: z.string().describe("Location UUID"),
+      area_id: z.string().describe("Area UUID"),
+      name: z.string().describe("New area name"),
+    },
+    withErrorHandling(async ({ location_id, area_id, name }) => {
+      const area = await api.put<Area>(
+        `/api/locations/${encodeURIComponent(location_id)}/areas/${encodeURIComponent(area_id)}`,
+        { name },
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Area renamed successfully!\n\n- **${area.name}** (id: ${area.id})`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "delete_area",
+    "Delete an area (admin only). Bins in the area become unassigned.",
+    {
+      location_id: z.string().describe("Location UUID"),
+      area_id: z.string().describe("Area UUID"),
+    },
+    withErrorHandling(async ({ location_id, area_id }) => {
+      await api.del(
+        `/api/locations/${encodeURIComponent(location_id)}/areas/${encodeURIComponent(area_id)}`,
+      );
+
+      return {
+        content: [{ type: "text" as const, text: "Area deleted. Any bins in it are now unassigned." }],
+      };
+    }),
+  );
 }

--- a/server/mcp/src/tools/bins.ts
+++ b/server/mcp/src/tools/bins.ts
@@ -1,0 +1,218 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface BinItem {
+  id: string;
+  name: string;
+}
+
+interface Bin {
+  id: string;
+  location_id: string;
+  name: string;
+  area_id: string | null;
+  area_name: string;
+  items: BinItem[];
+  notes: string;
+  tags: string[];
+  icon: string;
+  color: string;
+  short_code: string;
+  created_by_name: string;
+  visibility: string;
+  created_at: string;
+  updated_at: string;
+  is_pinned?: boolean;
+}
+
+interface ListResponse {
+  results: Bin[];
+  count: number;
+}
+
+function formatBin(bin: Bin): string {
+  const parts = [`**${bin.name}** (${bin.short_code})`, `ID: ${bin.id}`];
+
+  if (bin.area_name) parts.push(`Area: ${bin.area_name}`);
+  if (bin.items.length > 0)
+    parts.push(`Items (${bin.items.length}): ${bin.items.map((i) => i.name).join(", ")}`);
+  if (bin.tags.length > 0) parts.push(`Tags: ${bin.tags.join(", ")}`);
+  if (bin.notes) parts.push(`Notes: ${bin.notes}`);
+  if (bin.icon) parts.push(`Icon: ${bin.icon}`);
+  if (bin.color) parts.push(`Color: ${bin.color}`);
+  parts.push(`Created by: ${bin.created_by_name} | Updated: ${bin.updated_at}`);
+
+  return parts.join("\n");
+}
+
+export function registerBinTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "search_bins",
+    "Search bins in a location with optional filters",
+    {
+      location_id: z.string().describe("Location UUID (required)"),
+      q: z.string().optional().describe("Search text (searches name, notes, items, tags)"),
+      tag: z.string().optional().describe("Filter by a single tag"),
+      tags: z.string().optional().describe("Filter by multiple tags (comma-separated)"),
+      area_id: z
+        .string()
+        .optional()
+        .describe("Filter by area UUID (use '__unassigned__' for bins with no area)"),
+      sort: z
+        .enum(["name", "created_at", "updated_at", "area"])
+        .optional()
+        .describe("Sort field"),
+      sort_dir: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100)"),
+    },
+    withErrorHandling(async ({ location_id, q, tag, tags, area_id, sort, sort_dir, limit }) => {
+      const params = new URLSearchParams({ location_id });
+      if (q) params.set("q", q);
+      if (tags) params.set("tags", tags);
+      else if (tag) params.set("tag", tag);
+      if (area_id) params.set("area_id", area_id);
+      if (sort) params.set("sort", sort);
+      if (sort_dir) params.set("sort_dir", sort_dir);
+      if (limit) params.set("limit", String(limit));
+
+      const data = await api.get<ListResponse>(`/api/bins?${params}`);
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No bins found matching your search." }] };
+      }
+
+      const lines = data.results.map((bin) => formatBin(bin));
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${data.count} bin(s)${data.results.length < data.count ? ` (showing ${data.results.length})` : ""}:\n\n${lines.join("\n\n---\n\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "get_bin",
+    "Get a single bin by ID or short code",
+    {
+      id: z.string().optional().describe("Bin UUID"),
+      short_code: z.string().optional().describe("6-character short code (e.g. 'A1B2C3')"),
+    },
+    withErrorHandling(async ({ id, short_code }) => {
+      if (!id && !short_code) {
+        return {
+          content: [{ type: "text" as const, text: "Provide either 'id' or 'short_code'." }],
+          isError: true,
+        };
+      }
+
+      const path = id
+        ? `/api/bins/${encodeURIComponent(id)}`
+        : `/api/bins/lookup/${encodeURIComponent(short_code!)}`;
+
+      const bin = await api.get<Bin>(path);
+
+      return { content: [{ type: "text" as const, text: formatBin(bin) }] };
+    }),
+  );
+
+  server.tool(
+    "create_bin",
+    "Create a new bin in a location",
+    {
+      location_id: z.string().describe("Location UUID"),
+      name: z.string().describe("Bin name"),
+      items: z.array(z.string()).optional().describe("List of item names"),
+      tags: z.array(z.string()).optional().describe("List of tags"),
+      notes: z.string().optional().describe("Notes"),
+      area_id: z.string().optional().describe("Area UUID to assign the bin to"),
+      icon: z.string().optional().describe("Icon identifier"),
+      color: z.string().optional().describe("Color value"),
+    },
+    withErrorHandling(async ({ location_id, name, items, tags, notes, area_id, icon, color }) => {
+      const body: Record<string, unknown> = { locationId: location_id, name };
+      if (items) body.items = items;
+      if (tags) body.tags = tags;
+      if (notes) body.notes = notes;
+      if (area_id) body.areaId = area_id;
+      if (icon) body.icon = icon;
+      if (color) body.color = color;
+
+      const bin = await api.post<Bin>("/api/bins", body);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Bin created successfully!\n\n${formatBin(bin)}`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "update_bin",
+    "Update an existing bin",
+    {
+      id: z.string().describe("Bin UUID"),
+      name: z.string().optional().describe("New bin name"),
+      items: z
+        .array(z.string())
+        .optional()
+        .describe("Replace all items with this list"),
+      tags: z.array(z.string()).optional().describe("Replace all tags with this list"),
+      notes: z.string().optional().describe("New notes"),
+      area_id: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Area UUID (null to unassign)"),
+      icon: z.string().optional().describe("Icon identifier"),
+      color: z.string().optional().describe("Color value"),
+    },
+    withErrorHandling(async ({ id, name, items, tags, notes, area_id, icon, color }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (items !== undefined) body.items = items;
+      if (tags !== undefined) body.tags = tags;
+      if (notes !== undefined) body.notes = notes;
+      if (area_id !== undefined) body.areaId = area_id;
+      if (icon !== undefined) body.icon = icon;
+      if (color !== undefined) body.color = color;
+
+      const bin = await api.put<Bin>(`/api/bins/${encodeURIComponent(id)}`, body);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Bin updated successfully!\n\n${formatBin(bin)}`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "delete_bin",
+    "Soft-delete a bin (moves to trash, can be restored)",
+    { id: z.string().describe("Bin UUID") },
+    withErrorHandling(async ({ id }) => {
+      const bin = await api.del<Bin>(`/api/bins/${encodeURIComponent(id)}`);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Bin "${bin.name}" (${bin.short_code}) has been moved to trash.`,
+          },
+        ],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/export.ts
+++ b/server/mcp/src/tools/export.ts
@@ -49,7 +49,7 @@ export function registerExportTools(server: McpServer, api: ApiClient) {
 
       for (const bin of data.bins) {
         const parts = [`- **${bin.name}** (${bin.shortCode})`];
-        if (bin.location) parts[0] += ` — ${bin.location}`;
+        if (bin.location) parts.push(`  Area: ${bin.location}`);
         if (bin.items.length > 0) parts.push(`  Items: ${bin.items.join(", ")}`);
         if (bin.tags.length > 0) parts.push(`  Tags: ${bin.tags.join(", ")}`);
         if (bin.notes) parts.push(`  Notes: ${bin.notes}`);

--- a/server/mcp/src/tools/export.ts
+++ b/server/mcp/src/tools/export.ts
@@ -1,0 +1,82 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface ExportPhoto {
+  id: string;
+  filename: string;
+  mimeType: string;
+}
+
+interface ExportBin {
+  id: string;
+  name: string;
+  location: string;
+  items: string[];
+  notes: string;
+  tags: string[];
+  icon: string;
+  color: string;
+  shortCode: string;
+  createdAt: string;
+  updatedAt: string;
+  photos: ExportPhoto[];
+}
+
+interface ExportData {
+  version: number;
+  exportedAt: string;
+  locationName: string;
+  bins: ExportBin[];
+}
+
+export function registerExportTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "export_location_json",
+    "Export all bins in a location as JSON",
+    {
+      location_id: z.string().describe("Location UUID"),
+    },
+    withErrorHandling(async ({ location_id }) => {
+      const data = await api.get<ExportData>(
+        `/api/locations/${encodeURIComponent(location_id)}/export`,
+      );
+
+      const summary = [
+        `**${data.locationName}** — exported ${data.bins.length} bin(s)`,
+        `Exported at: ${data.exportedAt}`,
+      ];
+
+      for (const bin of data.bins) {
+        const parts = [`- **${bin.name}** (${bin.shortCode})`];
+        if (bin.location) parts[0] += ` — ${bin.location}`;
+        if (bin.items.length > 0) parts.push(`  Items: ${bin.items.join(", ")}`);
+        if (bin.tags.length > 0) parts.push(`  Tags: ${bin.tags.join(", ")}`);
+        if (bin.notes) parts.push(`  Notes: ${bin.notes}`);
+        if (bin.photos.length > 0) parts.push(`  Photos: ${bin.photos.length}`);
+        summary.push(parts.join("\n"));
+      }
+
+      return {
+        content: [{ type: "text" as const, text: summary.join("\n\n") }],
+      };
+    }),
+  );
+
+  server.tool(
+    "export_location_csv",
+    "Export all bins in a location as CSV text",
+    {
+      location_id: z.string().describe("Location UUID"),
+    },
+    withErrorHandling(async ({ location_id }) => {
+      const csv = await api.getText(
+        `/api/locations/${encodeURIComponent(location_id)}/export/csv`,
+      );
+
+      return {
+        content: [{ type: "text" as const, text: csv }],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/items.ts
+++ b/server/mcp/src/tools/items.ts
@@ -98,4 +98,48 @@ export function registerItemTools(server: McpServer, api: ApiClient) {
       };
     }),
   );
+
+  server.tool(
+    "rename_item",
+    "Rename an item within a bin",
+    {
+      bin_id: z.string().describe("Bin UUID"),
+      item_id: z.string().describe("Item UUID"),
+      name: z.string().describe("New item name"),
+    },
+    withErrorHandling(async ({ bin_id, item_id, name }) => {
+      const item = await api.put<{ id: string; name: string }>(
+        `/api/bins/${encodeURIComponent(bin_id)}/items/${encodeURIComponent(item_id)}`,
+        { name },
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Item renamed to "${item.name}".`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "reorder_items",
+    "Reorder items within a bin",
+    {
+      bin_id: z.string().describe("Bin UUID"),
+      item_ids: z.array(z.string()).min(1).describe("Item UUIDs in the desired order"),
+    },
+    withErrorHandling(async ({ bin_id, item_ids }) => {
+      await api.put(
+        `/api/bins/${encodeURIComponent(bin_id)}/items/reorder`,
+        { item_ids },
+      );
+
+      return {
+        content: [{ type: "text" as const, text: `Items reordered (${item_ids.length} items).` }],
+      };
+    }),
+  );
 }

--- a/server/mcp/src/tools/items.ts
+++ b/server/mcp/src/tools/items.ts
@@ -16,8 +16,43 @@ interface ItemListResponse {
   count: number;
 }
 
+interface BinItem {
+  id: string;
+  name: string;
+}
+
+interface BinDetail {
+  id: string;
+  items: BinItem[];
+}
+
 interface AddItemsResponse {
   items: Array<{ id: string; name: string }>;
+}
+
+async function resolveItemId(
+  api: ApiClient,
+  bin_id: string,
+  item_id: string | undefined,
+  item_name: string | undefined,
+): Promise<{ id: string } | { error: string }> {
+  if (item_id) return { id: item_id };
+
+  const bin = await api.get<BinDetail>(`/api/bins/${encodeURIComponent(bin_id)}`);
+  const matches = bin.items.filter(
+    (i) => i.name.toLowerCase() === item_name!.toLowerCase(),
+  );
+
+  if (matches.length === 0) {
+    return { error: `No item named "${item_name}" found in this bin.` };
+  }
+  if (matches.length > 1) {
+    const list = matches.map((m) => `- ${m.name} [${m.id}]`).join("\n");
+    return {
+      error: `Multiple items named "${item_name}" found. Specify item_id to disambiguate:\n${list}`,
+    };
+  }
+  return { id: matches[0].id };
 }
 
 export function registerItemTools(server: McpServer, api: ApiClient) {
@@ -29,12 +64,14 @@ export function registerItemTools(server: McpServer, api: ApiClient) {
       q: z.string().optional().describe("Search text"),
       sort: z.enum(["alpha", "bin"]).optional().describe("Sort by item name or bin name"),
       limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 40)"),
+      offset: z.number().min(0).optional().describe("Offset for pagination"),
     },
-    withErrorHandling(async ({ location_id, q, sort, limit }) => {
+    withErrorHandling(async ({ location_id, q, sort, limit, offset }) => {
       const params = new URLSearchParams({ location_id });
       if (q) params.set("q", q);
       if (sort) params.set("sort", sort);
-      if (limit) params.set("limit", String(limit));
+      if (limit !== undefined) params.set("limit", String(limit));
+      if (offset !== undefined) params.set("offset", String(offset));
 
       const data = await api.get<ItemListResponse>(`/api/items?${params}`);
 
@@ -43,7 +80,7 @@ export function registerItemTools(server: McpServer, api: ApiClient) {
       }
 
       const lines = data.results.map(
-        (item) => `- **${item.name}** in bin "${item.bin_name}" (bin_id: ${item.bin_id})`,
+        (item) => `- **${item.name}** [${item.id}] in bin "${item.bin_name}" (bin_id: ${item.bin_id})`,
       );
 
       return {
@@ -83,14 +120,27 @@ export function registerItemTools(server: McpServer, api: ApiClient) {
 
   server.tool(
     "remove_item",
-    "Remove a single item from a bin",
+    "Remove a single item from a bin. Provide item_id or item_name (not both).",
     {
       bin_id: z.string().describe("Bin UUID"),
-      item_id: z.string().describe("Item UUID"),
+      item_id: z.string().optional().describe("Item UUID"),
+      item_name: z.string().optional().describe("Item name (case-insensitive match)"),
     },
-    withErrorHandling(async ({ bin_id, item_id }) => {
+    withErrorHandling(async ({ bin_id, item_id, item_name }) => {
+      if (!item_id && !item_name) {
+        return {
+          content: [{ type: "text" as const, text: "Provide either 'item_id' or 'item_name'." }],
+          isError: true,
+        };
+      }
+
+      const resolved = await resolveItemId(api, bin_id, item_id, item_name);
+      if ("error" in resolved) {
+        return { content: [{ type: "text" as const, text: resolved.error }], isError: true };
+      }
+
       await api.del(
-        `/api/bins/${encodeURIComponent(bin_id)}/items/${encodeURIComponent(item_id)}`,
+        `/api/bins/${encodeURIComponent(bin_id)}/items/${encodeURIComponent(resolved.id)}`,
       );
 
       return {
@@ -101,15 +151,28 @@ export function registerItemTools(server: McpServer, api: ApiClient) {
 
   server.tool(
     "rename_item",
-    "Rename an item within a bin",
+    "Rename an item within a bin. Provide item_id or item_name (not both).",
     {
       bin_id: z.string().describe("Bin UUID"),
-      item_id: z.string().describe("Item UUID"),
+      item_id: z.string().optional().describe("Item UUID"),
+      item_name: z.string().optional().describe("Current item name (case-insensitive match)"),
       name: z.string().describe("New item name"),
     },
-    withErrorHandling(async ({ bin_id, item_id, name }) => {
+    withErrorHandling(async ({ bin_id, item_id, item_name, name }) => {
+      if (!item_id && !item_name) {
+        return {
+          content: [{ type: "text" as const, text: "Provide either 'item_id' or 'item_name'." }],
+          isError: true,
+        };
+      }
+
+      const resolved = await resolveItemId(api, bin_id, item_id, item_name);
+      if ("error" in resolved) {
+        return { content: [{ type: "text" as const, text: resolved.error }], isError: true };
+      }
+
       const item = await api.put<{ id: string; name: string }>(
-        `/api/bins/${encodeURIComponent(bin_id)}/items/${encodeURIComponent(item_id)}`,
+        `/api/bins/${encodeURIComponent(bin_id)}/items/${encodeURIComponent(resolved.id)}`,
         { name },
       );
 
@@ -126,19 +189,53 @@ export function registerItemTools(server: McpServer, api: ApiClient) {
 
   server.tool(
     "reorder_items",
-    "Reorder items within a bin",
+    "Reorder items within a bin. Provide item_ids or item_names (not both).",
     {
       bin_id: z.string().describe("Bin UUID"),
-      item_ids: z.array(z.string()).min(1).describe("Item UUIDs in the desired order"),
+      item_ids: z.array(z.string()).optional().describe("Item UUIDs in the desired order"),
+      item_names: z.array(z.string()).optional().describe("Item names in the desired order (resolved to IDs via bin lookup)"),
     },
-    withErrorHandling(async ({ bin_id, item_ids }) => {
+    withErrorHandling(async ({ bin_id, item_ids, item_names }) => {
+      if (!item_ids && !item_names) {
+        return {
+          content: [{ type: "text" as const, text: "Provide either 'item_ids' or 'item_names'." }],
+          isError: true,
+        };
+      }
+
+      let resolvedIds = item_ids;
+      if (!resolvedIds && item_names) {
+        const bin = await api.get<BinDetail>(`/api/bins/${encodeURIComponent(bin_id)}`);
+        const ids: string[] = [];
+        for (const name of item_names) {
+          const matches = bin.items.filter(
+            (i) => i.name.toLowerCase() === name.toLowerCase(),
+          );
+          if (matches.length === 0) {
+            return {
+              content: [{ type: "text" as const, text: `No item named "${name}" found in this bin.` }],
+              isError: true,
+            };
+          }
+          if (matches.length > 1) {
+            const list = matches.map((m) => `- ${m.name} [${m.id}]`).join("\n");
+            return {
+              content: [{ type: "text" as const, text: `Multiple items named "${name}" found. Use item_ids instead:\n${list}` }],
+              isError: true,
+            };
+          }
+          ids.push(matches[0].id);
+        }
+        resolvedIds = ids;
+      }
+
       await api.put(
         `/api/bins/${encodeURIComponent(bin_id)}/items/reorder`,
-        { item_ids },
+        { item_ids: resolvedIds },
       );
 
       return {
-        content: [{ type: "text" as const, text: `Items reordered (${item_ids.length} items).` }],
+        content: [{ type: "text" as const, text: `Items reordered (${resolvedIds!.length} items).` }],
       };
     }),
   );

--- a/server/mcp/src/tools/items.ts
+++ b/server/mcp/src/tools/items.ts
@@ -1,0 +1,101 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface Item {
+  id: string;
+  name: string;
+  bin_id: string;
+  bin_name: string;
+  bin_icon: string;
+  bin_color: string;
+}
+
+interface ItemListResponse {
+  results: Item[];
+  count: number;
+}
+
+interface AddItemsResponse {
+  items: Array<{ id: string; name: string }>;
+}
+
+export function registerItemTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "search_items",
+    "Search items across all bins in a location",
+    {
+      location_id: z.string().describe("Location UUID (required)"),
+      q: z.string().optional().describe("Search text"),
+      sort: z.enum(["alpha", "bin"]).optional().describe("Sort by item name or bin name"),
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 40)"),
+    },
+    withErrorHandling(async ({ location_id, q, sort, limit }) => {
+      const params = new URLSearchParams({ location_id });
+      if (q) params.set("q", q);
+      if (sort) params.set("sort", sort);
+      if (limit) params.set("limit", String(limit));
+
+      const data = await api.get<ItemListResponse>(`/api/items?${params}`);
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No items found." }] };
+      }
+
+      const lines = data.results.map(
+        (item) => `- **${item.name}** in bin "${item.bin_name}" (bin_id: ${item.bin_id})`,
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${data.count} item(s)${data.results.length < data.count ? ` (showing ${data.results.length})` : ""}:\n\n${lines.join("\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "add_items",
+    "Add items to a bin",
+    {
+      bin_id: z.string().describe("Bin UUID"),
+      items: z.array(z.string()).min(1).describe("Item names to add"),
+    },
+    withErrorHandling(async ({ bin_id, items }) => {
+      const data = await api.post<AddItemsResponse>(
+        `/api/bins/${encodeURIComponent(bin_id)}/items`,
+        { items },
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Added ${data.items.length} item(s): ${data.items.map((i) => i.name).join(", ")}`,
+          },
+        ],
+      };
+    }),
+  );
+
+  server.tool(
+    "remove_item",
+    "Remove a single item from a bin",
+    {
+      bin_id: z.string().describe("Bin UUID"),
+      item_id: z.string().describe("Item UUID"),
+    },
+    withErrorHandling(async ({ bin_id, item_id }) => {
+      await api.del(
+        `/api/bins/${encodeURIComponent(bin_id)}/items/${encodeURIComponent(item_id)}`,
+      );
+
+      return {
+        content: [{ type: "text" as const, text: "Item removed successfully." }],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/locations.ts
+++ b/server/mcp/src/tools/locations.ts
@@ -1,0 +1,49 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface Location {
+  id: string;
+  name: string;
+  role: string;
+  member_count: number;
+  area_count: number;
+  invite_code: string;
+  term_bin: string;
+  term_location: string;
+  term_area: string;
+  created_at: string;
+}
+
+interface ListResponse {
+  results: Location[];
+  count: number;
+}
+
+export function registerLocationTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "list_locations",
+    "List all locations the authenticated user belongs to",
+    {},
+    withErrorHandling(async () => {
+      const data = await api.get<ListResponse>("/api/locations");
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No locations found." }] };
+      }
+
+      const lines = data.results.map(
+        (loc) =>
+          `- **${loc.name}** (id: ${loc.id})\n  Role: ${loc.role} | Members: ${loc.member_count} | Areas: ${loc.area_count}\n  Invite code: ${loc.invite_code}`,
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${data.count} location(s):\n\n${lines.join("\n\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/scan-history.ts
+++ b/server/mcp/src/tools/scan-history.ts
@@ -1,0 +1,50 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface ScanEntry {
+  id: string;
+  bin_id: string;
+  scanned_at: string;
+}
+
+interface ListResponse {
+  results: ScanEntry[];
+  count: number;
+}
+
+export function registerScanHistoryTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "get_scan_history",
+    "Get the user's recent QR scan history",
+    {
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 20)"),
+    },
+    withErrorHandling(async ({ limit }) => {
+      const params = new URLSearchParams();
+      if (limit) params.set("limit", String(limit));
+
+      const query = params.toString();
+      const data = await api.get<ListResponse>(
+        `/api/scan-history${query ? `?${query}` : ""}`,
+      );
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No scan history found." }] };
+      }
+
+      const lines = data.results.map(
+        (entry) => `- Bin ${entry.bin_id} scanned at ${entry.scanned_at}`,
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `${data.count} recent scan(s):\n\n${lines.join("\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+}

--- a/server/mcp/src/tools/tags.ts
+++ b/server/mcp/src/tools/tags.ts
@@ -1,0 +1,47 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type ApiClient, withErrorHandling } from "../api-client.js";
+
+interface Tag {
+  tag: string;
+  count: number;
+}
+
+interface ListResponse {
+  results: Tag[];
+  count: number;
+}
+
+export function registerTagTools(server: McpServer, api: ApiClient) {
+  server.tool(
+    "list_tags",
+    "List all tags used in a location with usage counts",
+    {
+      location_id: z.string().describe("Location UUID (required)"),
+      q: z.string().optional().describe("Search text to filter tags"),
+      limit: z.number().min(1).max(100).optional().describe("Max results (1-100, default 40)"),
+    },
+    withErrorHandling(async ({ location_id, q, limit }) => {
+      const params = new URLSearchParams({ location_id });
+      if (q) params.set("q", q);
+      if (limit) params.set("limit", String(limit));
+
+      const data = await api.get<ListResponse>(`/api/tags?${params}`);
+
+      if (data.results.length === 0) {
+        return { content: [{ type: "text" as const, text: "No tags found." }] };
+      }
+
+      const lines = data.results.map((t) => `- **${t.tag}** (${t.count} bin${t.count !== 1 ? "s" : ""})`);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Found ${data.count} tag(s):\n\n${lines.join("\n")}`,
+          },
+        ],
+      };
+    }),
+  );
+}

--- a/server/mcp/tsconfig.json
+++ b/server/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/server/migrations/008_activity_auth_method.sql
+++ b/server/migrations/008_activity_auth_method.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity_log ADD COLUMN auth_method TEXT;

--- a/server/src/lib/activityLog.ts
+++ b/server/src/lib/activityLog.ts
@@ -9,6 +9,7 @@ export interface LogActivityOptions {
   entityId?: string;
   entityName?: string;
   changes?: Record<string, { old: unknown; new: unknown }>;
+  authMethod?: 'jwt' | 'api_key';
 }
 
 /**
@@ -18,8 +19,8 @@ export interface LogActivityOptions {
 export async function logActivity(opts: LogActivityOptions): Promise<void> {
   try {
     await query(
-      `INSERT INTO activity_log (id, location_id, user_id, user_name, action, entity_type, entity_id, entity_name, changes)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      `INSERT INTO activity_log (id, location_id, user_id, user_name, action, entity_type, entity_id, entity_name, changes, auth_method)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
       [
         generateUuid(),
         opts.locationId,
@@ -30,6 +31,7 @@ export async function logActivity(opts: LogActivityOptions): Promise<void> {
         opts.entityId ?? null,
         opts.entityName ?? null,
         opts.changes ? JSON.stringify(opts.changes) : null,
+        opts.authMethod ?? null,
       ]
     );
 

--- a/server/src/lib/commandExecutor.ts
+++ b/server/src/lib/commandExecutor.ts
@@ -27,6 +27,7 @@ interface PendingActivity {
   entityId?: string;
   entityName?: string;
   changes?: Record<string, { old: unknown; new: unknown }>;
+  authMethod?: 'jwt' | 'api_key';
 }
 
 const MAX_ACTIONS = 50;
@@ -36,7 +37,8 @@ export async function executeActions(
   actions: CommandAction[],
   locationId: string,
   userId: string,
-  userName: string
+  userName: string,
+  authMethod?: 'jwt' | 'api_key'
 ): Promise<ExecuteResult> {
   if (actions.length > MAX_ACTIONS) {
     throw new Error(`Too many actions (${actions.length}). Maximum is ${MAX_ACTIONS}.`);
@@ -50,7 +52,7 @@ export async function executeActions(
   const transaction = db.transaction(() => {
     for (const action of actions) {
       try {
-        const result = executeSingleAction(action, locationId, userId, userName, pendingActivities);
+        const result = executeSingleAction(action, locationId, userId, userName, pendingActivities, authMethod);
         executed.push(result);
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error';
@@ -80,7 +82,8 @@ function executeSingleAction(
   locationId: string,
   userId: string,
   userName: string,
-  pendingActivities: PendingActivity[]
+  pendingActivities: PendingActivity[],
+  authMethod?: 'jwt' | 'api_key'
 ): ActionResult {
   switch (action.type) {
     case 'add_items': {
@@ -94,7 +97,7 @@ function executeSingleAction(
       }
       querySync("UPDATE bins SET updated_at = datetime('now') WHERE id = $1", [action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { items_added: { old: null, new: action.items } },
       });
@@ -109,7 +112,7 @@ function executeSingleAction(
       }
       querySync("UPDATE bins SET updated_at = datetime('now') WHERE id = $1", [action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { items_removed: { old: action.items, new: null } },
       });
@@ -122,7 +125,7 @@ function executeSingleAction(
       querySync("UPDATE bin_items SET name = $1, updated_at = datetime('now') WHERE bin_id = $2 AND LOWER(name) = LOWER($3)", [action.new_item, action.bin_id, action.old_item]);
       querySync("UPDATE bins SET updated_at = datetime('now') WHERE id = $1", [action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { items_renamed: { old: action.old_item, new: action.new_item } },
       });
@@ -150,7 +153,7 @@ function executeSingleAction(
           );
           areaId = newAreaId;
           pendingActivities.push({
-            locationId, userId, userName,
+            locationId, userId, userName, authMethod,
             action: 'create', entityType: 'area', entityId: newAreaId, entityName: action.area_name,
           });
         }
@@ -184,7 +187,7 @@ function executeSingleAction(
       }
 
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'create', entityType: 'bin', entityId: binId, entityName: action.name,
       });
       return { type: 'create_bin', success: true, details: `Created bin "${action.name}"`, bin_id: binId, bin_name: action.name };
@@ -195,7 +198,7 @@ function executeSingleAction(
       if (bin.rows.length === 0) throw new Error(`Bin not found: ${action.bin_name}`);
       querySync("UPDATE bins SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = $1", [action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'delete', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
       });
       return { type: 'delete_bin', success: true, details: `Deleted bin "${action.bin_name}"`, bin_id: action.bin_id, bin_name: action.bin_name };
@@ -208,7 +211,7 @@ function executeSingleAction(
       const merged = [...new Set([...current, ...action.tags])];
       querySync("UPDATE bins SET tags = $1, updated_at = datetime('now') WHERE id = $2", [merged, action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { tags: { old: current, new: merged } },
       });
@@ -223,7 +226,7 @@ function executeSingleAction(
       const filtered = current.filter((t) => !removeSet.has(t.toLowerCase()));
       querySync("UPDATE bins SET tags = $1, updated_at = datetime('now') WHERE id = $2", [filtered, action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { tags: { old: current, new: filtered } },
       });
@@ -237,7 +240,7 @@ function executeSingleAction(
       const modified = current.map((t) => t.toLowerCase() === action.old_tag.toLowerCase() ? action.new_tag : t);
       querySync("UPDATE bins SET tags = $1, updated_at = datetime('now') WHERE id = $2", [modified, action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { tags: { old: current, new: modified } },
       });
@@ -265,7 +268,7 @@ function executeSingleAction(
           );
           areaId = newAreaId;
           pendingActivities.push({
-            locationId, userId, userName,
+            locationId, userId, userName, authMethod,
             action: 'create', entityType: 'area', entityId: newAreaId, entityName: action.area_name,
           });
         }
@@ -280,7 +283,7 @@ function executeSingleAction(
         oldAreaName = oldArea.rows[0]?.name ?? '';
       }
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { area: { old: oldAreaName || null, new: action.area_name || null } },
       });
@@ -304,7 +307,7 @@ function executeSingleAction(
       }
       querySync("UPDATE bins SET notes = $1, updated_at = datetime('now') WHERE id = $2", [newNotes, action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { notes: { old: oldNotes, new: newNotes } },
       });
@@ -316,7 +319,7 @@ function executeSingleAction(
       if (bin.rows.length === 0) throw new Error(`Bin not found: ${action.bin_name}`);
       querySync("UPDATE bins SET icon = $1, updated_at = datetime('now') WHERE id = $2", [action.icon, action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { icon: { old: bin.rows[0].icon, new: action.icon } },
       });
@@ -328,7 +331,7 @@ function executeSingleAction(
       if (bin.rows.length === 0) throw new Error(`Bin not found: ${action.bin_name}`);
       querySync("UPDATE bins SET color = $1, updated_at = datetime('now') WHERE id = $2", [action.color, action.bin_id]);
       pendingActivities.push({
-        locationId, userId, userName,
+        locationId, userId, userName, authMethod,
         action: 'update', entityType: 'bin', entityId: action.bin_id, entityName: action.bin_name,
         changes: { color: { old: bin.rows[0].color, new: action.color } },
       });

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -41,7 +41,7 @@ router.get('/:locationId/activity', requireLocationMember('locationId'), asyncHa
     `SELECT al.id, al.location_id, al.user_id, al.user_name,
             COALESCE(u.display_name, al.user_name) AS display_name,
             al.action, al.entity_type, al.entity_id, al.entity_name,
-            al.changes, al.created_at
+            al.changes, al.auth_method, al.created_at
      FROM activity_log al
      LEFT JOIN users u ON u.id = al.user_id
      ${whereClause}

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -345,7 +345,7 @@ router.post('/execute', aiLimiter, requireLocationMember(), aiRouteHandler('exec
     return;
   }
 
-  const result = await executeActions(parsed.actions, locationId, req.user!.id, req.user!.username);
+  const result = await executeActions(parsed.actions, locationId, req.user!.id, req.user!.username, req.authMethod);
   res.json({
     executed: result.executed,
     interpretation: parsed.interpretation,

--- a/server/src/routes/areas.ts
+++ b/server/src/routes/areas.ts
@@ -47,6 +47,7 @@ router.post('/:locationId/areas', requireLocationAdmin('locationId'), asyncHandl
       entityType: 'area',
       entityId: area.id,
       entityName: area.name,
+      authMethod: req.authMethod,
     });
 
     res.status(201).json(area);
@@ -96,6 +97,7 @@ router.put('/:locationId/areas/:areaId', requireLocationAdmin('locationId'), asy
         entityId: areaId,
         entityName: area.name,
         changes: { name: { old: oldName, new: name.trim() } },
+        authMethod: req.authMethod,
       });
     }
 
@@ -134,6 +136,7 @@ router.delete('/:locationId/areas/:areaId', requireLocationAdmin('locationId'), 
     entityType: 'area',
     entityId: areaId,
     entityName: areaName,
+    authMethod: req.authMethod,
   });
 
   res.json({ message: 'Area deleted' });

--- a/server/src/routes/binItems.ts
+++ b/server/src/routes/binItems.ts
@@ -56,6 +56,7 @@ router.post('/:id/items', asyncHandler(async (req, res) => {
     entityId: id,
     entityName: binResult.rows[0]?.name,
     changes: { items_added: { old: null, new: newItems.map((i) => i.name) } },
+    authMethod: req.authMethod,
   });
 
   res.status(201).json({ items: newItems });
@@ -93,6 +94,7 @@ router.delete('/:id/items/:itemId', asyncHandler(async (req, res) => {
     entityId: id,
     entityName: binResult.rows[0]?.name,
     changes: { items_removed: { old: [itemName], new: null } },
+    authMethod: req.authMethod,
   });
 
   res.json({ success: true });
@@ -161,6 +163,7 @@ router.put('/:id/items/:itemId', asyncHandler(async (req, res) => {
     entityId: id,
     entityName: binResult.rows[0]?.name,
     changes: { items_renamed: { old: oldName, new: name.trim() } },
+    authMethod: req.authMethod,
   });
 
   res.json({ id: itemId, name: name.trim() });

--- a/server/src/routes/bins.ts
+++ b/server/src/routes/bins.ts
@@ -104,6 +104,7 @@ router.post('/', asyncHandler(async (req, res) => {
         entityType: 'bin',
         entityId: bin.id,
         entityName: bin.name,
+        authMethod: req.authMethod,
       });
 
       res.status(201).json(bin);
@@ -567,6 +568,7 @@ router.put('/:id', asyncHandler(async (req, res) => {
         entityId: id,
         entityName: bin.name,
         changes: allChanges,
+        authMethod: req.authMethod,
       });
     }
   }
@@ -613,6 +615,7 @@ router.delete('/:id', asyncHandler(async (req, res) => {
     entityType: 'bin',
     entityId: id,
     entityName: bin.name,
+    authMethod: req.authMethod,
   });
 
   res.json(bin);
@@ -660,6 +663,7 @@ router.post('/:id/restore', asyncHandler(async (req, res) => {
     entityType: 'bin',
     entityId: id,
     entityName: bin.name,
+    authMethod: req.authMethod,
   });
 
   res.json(bin);
@@ -727,6 +731,7 @@ router.delete('/:id/permanent', asyncHandler(async (req, res) => {
     entityType: 'bin',
     entityId: id,
     entityName: binName,
+    authMethod: req.authMethod,
   });
 
   res.json({ message: 'Bin permanently deleted' });
@@ -771,6 +776,7 @@ router.post('/:id/photos', binPhotoUpload.single('photo'), asyncHandler(async (r
     entityType: 'bin',
     entityId: binId,
     entityName: binResult.rows[0]?.name,
+    authMethod: req.authMethod,
   });
 
   res.status(201).json({ id: photo.id });
@@ -878,6 +884,7 @@ router.post('/:id/move', asyncHandler(async (req, res) => {
     entityId: id,
     entityName: bin.name,
     changes,
+    authMethod: req.authMethod,
   });
 
   // Log in target location
@@ -890,6 +897,7 @@ router.post('/:id/move', asyncHandler(async (req, res) => {
     entityId: id,
     entityName: bin.name,
     changes,
+    authMethod: req.authMethod,
   });
 
   res.json(bin);

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -213,8 +213,8 @@ router.get('/locations/:id/export/csv', requireLocationMember(), asyncHandler(as
       csvEscape(bin.icon || ''),
       csvEscape(bin.color || ''),
       csvEscape(bin.short_code || ''),
-      bin.created_at,
-      bin.updated_at,
+      bin.created_at?.includes('T') ? bin.created_at : `${bin.created_at.replace(' ', 'T')}Z`,
+      bin.updated_at?.includes('T') ? bin.updated_at : `${bin.updated_at.replace(' ', 'T')}Z`,
     ].join(',');
   });
 

--- a/server/src/routes/locations.ts
+++ b/server/src/routes/locations.ts
@@ -197,6 +197,7 @@ router.put('/:id', asyncHandler(async (req, res) => {
       entityId: id,
       entityName: location.name,
       changes,
+      authMethod: req.authMethod,
     });
   }
 
@@ -269,6 +270,7 @@ router.post('/join', asyncHandler(async (req, res) => {
     action: 'join',
     entityType: 'member',
     entityName: req.user!.username,
+    authMethod: req.authMethod,
   });
 
   // Get area count for the joined location
@@ -372,6 +374,7 @@ router.delete('/:id/members/:userId', asyncHandler(async (req, res) => {
     action,
     entityType: 'member',
     entityName: removedUsername,
+    authMethod: req.authMethod,
   });
 
   res.json({ message: 'Member removed' });
@@ -430,6 +433,7 @@ router.put('/:id/members/:userId/role', asyncHandler(async (req, res) => {
     entityType: 'member',
     entityName: targetUsername,
     changes: { role: { old: targetRole, new: role } },
+    authMethod: req.authMethod,
   });
 
   res.json({ message: `Role updated to ${role}` });

--- a/server/src/routes/photos.ts
+++ b/server/src/routes/photos.ts
@@ -116,6 +116,7 @@ router.delete('/:id', asyncHandler(async (req, res) => {
     entityType: 'bin',
     entityId: access.binId,
     entityName: binResult.rows[0]?.name,
+    authMethod: req.authMethod,
   });
 
   res.json({ message: 'Photo deleted' });

--- a/src/features/activity/ActivityPage.tsx
+++ b/src/features/activity/ActivityPage.tsx
@@ -212,6 +212,11 @@ export function ActivityPage() {
                       )}
                       <p className="text-[12px] text-[var(--text-tertiary)] mt-0.5">
                         {formatTime(entry.created_at)}
+                        {entry.auth_method === 'api_key' && (
+                          <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-[var(--bg-elevated)] text-[var(--text-tertiary)]">
+                            API
+                          </span>
+                        )}
                       </p>
                     </div>
                   </button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export interface ActivityLogEntry {
   entity_id: string | null;
   entity_name: string | null;
   changes: Record<string, { old: unknown; new: unknown }> | null;
+  auth_method: 'jwt' | 'api_key' | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- Add stdio-based MCP server (`server/mcp/`) exposing OpenBin inventory via API key auth
- 30+ tools: bins CRUD, search, items management, areas, trash/restore, pins, export (JSON/CSV), activity log, tags, scan history, locations
- Track `auth_method` (jwt/api_key) in activity log for audit trail
- Fix offset pagination, JSON/CSV export formatting, and tag filtering (`tag_mode` any/all)

## Test plan
- [ ] Build MCP server: `cd server/mcp && npm install && npm run build`
- [ ] Configure `.mcp.json` with API key and base URL, verify tools appear in Claude Code
- [ ] Test core flows: list locations, search bins, create/update/delete bins, manage items
- [ ] Test area, pin, trash, and export tools
- [ ] Verify activity log entries include `auth_method` field