### PR TITLE
feat: add bin shortcode change/reassign for admins

### DIFF
--- a/docs/api/bins.md
+++ b/docs/api/bins.md
@@ -220,6 +220,24 @@ Moves a bin to a different location. The user must be a member of both locations
 
 ---
 
+### POST /api/bins/`{id}`/change-code
+
+Changes a bin's shortcode (primary key). If the new code belongs to another bin, that bin is permanently deleted. Requires admin role in the bin's location (and the target bin's location, if cross-location).
+
+**Path parameters**: `id` (bin ID of the survivor)
+
+**Request body**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `code` | string | Yes | New code to adopt. Must be 4-8 uppercase alphanumeric characters (`^[A-Z0-9]{4,8}$`). |
+
+**Response (200)**: Updated `Bin` object with the new code as its `id`.
+
+**Errors**: `403` if not admin, `404` if bin not found, `409` if concurrent modification, `422` if invalid code format or same as current code.
+
+---
+
 ### DELETE /api/bins/`{id}`/permanent
 
 Permanently deletes a bin and removes its photos from storage. Only works on bins that are already soft-deleted (in trash).

--- a/docs/guide/bins.md
+++ b/docs/guide/bins.md
@@ -104,6 +104,7 @@ Every bin has a 6-character alphanumeric short code auto-generated from its name
 - Appears printed on QR labels alongside the QR code itself.
 - Can be typed manually into the scanner or search bar to look up a bin without a camera.
 - Is stable — it does not change if you rename the bin.
+- Can be changed by admins via the overflow menu on the bin detail page (Change Code). If the target code belongs to another bin, that bin is permanently deleted.
 
 ## Soft Delete and Trash
 

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -2897,6 +2897,48 @@ paths:
         '422':
           $ref: '#/components/responses/ValidationError'
 
+  /bins/{id}/change-code:
+    post:
+      summary: Change bin shortcode
+      description: |
+        Change a bin's shortcode (primary key). If the new code belongs to another bin,
+        that bin is permanently deleted. Requires admin role.
+      tags: [Bins]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: ID of the bin whose code will change (the survivor)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [code]
+              properties:
+                code:
+                  type: string
+                  pattern: '^[A-Z0-9]{4,8}$'
+                  description: New code to adopt
+      responses:
+        '200':
+          description: Bin with updated code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bin'
+        '403':
+          description: Not admin in one or both locations
+        '404':
+          description: Target bin not found
+        '409':
+          description: Conflict (concurrent modification)
+        '422':
+          description: Invalid code format or same as current code
+
   /bins/{id}/permanent:
     delete:
       tags: [Bins]

--- a/server/src/__tests__/changeCode.test.ts
+++ b/server/src/__tests__/changeCode.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import type { Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import './setup.js';
 import { validateCodeFormat } from '../lib/binValidation.js';
+import { createApp } from '../index.js';
+import { createTestBin, createTestLocation, createTestUser } from './helpers.js';
 
 describe('validateCodeFormat', () => {
   it('accepts valid 6-char uppercase codes', () => {
@@ -33,5 +37,147 @@ describe('validateCodeFormat', () => {
 
   it('rejects empty string', () => {
     expect(() => validateCodeFormat('')).toThrow('Code must be 4-8 alphanumeric characters');
+  });
+});
+
+describe('POST /api/bins/:id/change-code', () => {
+  let app: Express;
+  beforeEach(() => { app = createApp(); });
+
+  it('changes bin code to an unclaimed code', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, loc.id, { name: 'My Bin' });
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/change-code`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ code: 'ZZZZZZ' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('ZZZZZZ');
+    expect(res.body.name).toBe('My Bin');
+
+    // Old code should be gone
+    const old = await request(app)
+      .get(`/api/bins/${bin.id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(old.status).toBe(404);
+  });
+
+  it('changes bin code to a claimed code and deletes the old bin', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+    const binA = await createTestBin(app, token, loc.id, { name: 'Bin A', items: ['item1'] });
+    const binB = await createTestBin(app, token, loc.id, { name: 'Bin B', items: ['item2'] });
+
+    // Bin A adopts Bin B's code
+    const res = await request(app)
+      .post(`/api/bins/${binA.id}/change-code`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ code: binB.id });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(binB.id);
+    expect(res.body.name).toBe('Bin A');
+
+    // binB.id now points to Bin A's data
+    const lookup = await request(app)
+      .get(`/api/bins/${binB.id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(lookup.body.name).toBe('Bin A');
+  });
+
+  it('preserves items after code change', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, loc.id, { name: 'Items Bin', items: ['wrench', 'hammer'] });
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/change-code`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ code: 'TSTXYZ' });
+
+    expect(res.status).toBe(200);
+    const itemNames = res.body.items.map((i: { name: string }) => i.name);
+    expect(itemNames).toContain('wrench');
+    expect(itemNames).toContain('hammer');
+  });
+
+  it('rejects invalid code format', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, loc.id);
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/change-code`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ code: 'ab' });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects same code as current', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, loc.id);
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/change-code`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ code: bin.id });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects non-admin users', async () => {
+    const { token: adminToken } = await createTestUser(app);
+    const loc = await createTestLocation(app, adminToken);
+    const bin = await createTestBin(app, adminToken, loc.id);
+
+    // Create a member user
+    const { token: memberToken } = await createTestUser(app);
+    await request(app)
+      .post('/api/locations/join')
+      .set('Authorization', `Bearer ${memberToken}`)
+      .send({ inviteCode: loc.invite_code });
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/change-code`)
+      .set('Authorization', `Bearer ${memberToken}`)
+      .send({ code: 'ZZZZZZ' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects cross-location change when user is not admin in other location', async () => {
+    const { token: adminToken } = await createTestUser(app);
+    const loc1 = await createTestLocation(app, adminToken);
+    const bin1 = await createTestBin(app, adminToken, loc1.id, { name: 'Bin in Loc1' });
+
+    // Create a second user who is admin of a different location
+    const { token: otherToken } = await createTestUser(app);
+    const loc2 = await createTestLocation(app, otherToken);
+    const bin2 = await createTestBin(app, otherToken, loc2.id, { name: 'Bin in Loc2' });
+
+    // admin of loc1 tries to adopt a code from loc2 (where they are NOT a member)
+    const res = await request(app)
+      .post(`/api/bins/${bin1.id}/change-code`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ code: bin2.id });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for non-existent bin', async () => {
+    const { token } = await createTestUser(app);
+    await createTestLocation(app, token);
+
+    const res = await request(app)
+      .post('/api/bins/NOPE99/change-code')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ code: 'ZZZZZZ' });
+
+    expect(res.status).toBe(404);
   });
 });

--- a/server/src/__tests__/changeCode.test.ts
+++ b/server/src/__tests__/changeCode.test.ts
@@ -1,9 +1,9 @@
 import type { Express } from 'express';
 import request from 'supertest';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import './setup.js';
-import { validateCodeFormat } from '../lib/binValidation.js';
 import { createApp } from '../index.js';
+import { validateCodeFormat } from '../lib/binValidation.js';
 import { createTestBin, createTestLocation, createTestUser } from './helpers.js';
 
 describe('validateCodeFormat', () => {

--- a/server/src/__tests__/changeCode.test.ts
+++ b/server/src/__tests__/changeCode.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import './setup.js';
+import { validateCodeFormat } from '../lib/binValidation.js';
+
+describe('validateCodeFormat', () => {
+  it('accepts valid 6-char uppercase codes', () => {
+    expect(() => validateCodeFormat('ABCDEF')).not.toThrow();
+  });
+
+  it('accepts 4-char codes', () => {
+    expect(() => validateCodeFormat('ABCD')).not.toThrow();
+  });
+
+  it('accepts 8-char codes', () => {
+    expect(() => validateCodeFormat('ABCD1234')).not.toThrow();
+  });
+
+  it('accepts codes with digits', () => {
+    expect(() => validateCodeFormat('ABC123')).not.toThrow();
+  });
+
+  it('rejects codes shorter than 4 chars', () => {
+    expect(() => validateCodeFormat('ABC')).toThrow('Code must be 4-8 alphanumeric characters');
+  });
+
+  it('rejects codes longer than 8 chars', () => {
+    expect(() => validateCodeFormat('ABCDEFGHI')).toThrow('Code must be 4-8 alphanumeric characters');
+  });
+
+  it('rejects codes with special characters', () => {
+    expect(() => validateCodeFormat('ABC-DE')).toThrow('Code must be 4-8 alphanumeric characters');
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validateCodeFormat('')).toThrow('Code must be 4-8 alphanumeric characters');
+  });
+});

--- a/server/src/lib/binValidation.ts
+++ b/server/src/lib/binValidation.ts
@@ -1,5 +1,13 @@
 import { ValidationError } from './httpErrors.js';
 
+const CODE_REGEX = /^[A-Z0-9]{4,8}$/;
+
+export function validateCodeFormat(code: string): void {
+  if (!CODE_REGEX.test(code)) {
+    throw new ValidationError('Code must be 4-8 alphanumeric characters');
+  }
+}
+
 export function validateBinFields(fields: {
   items?: unknown;
   tags?: unknown;

--- a/server/src/routes/bins.ts
+++ b/server/src/routes/bins.ts
@@ -7,7 +7,8 @@ import { asyncHandler } from '../lib/asyncHandler.js';
 import { getMemberRole, isBinCreator, requireAdmin, requireMemberOrAbove, verifyAreaInLocation, verifyBinAccess, verifyDeletedBinAccess, verifyLocationMembership } from '../lib/binAccess.js';
 import { BIN_SELECT_COLS, buildBinListQuery, fetchBinById } from '../lib/binQueries.js';
 import { buildBinSetClauses, buildBinUpdateDiff, insertBinWithItems, replaceBinItems } from '../lib/binUpdateHelpers.js';
-import { validateBinFields } from '../lib/binValidation.js';
+import { validateBinFields, validateCodeFormat } from '../lib/binValidation.js';
+import { sensitiveAuthLimiter } from '../lib/rateLimiters.js';
 import { config } from '../lib/config.js';
 import { remapCustomFieldsForMove, replaceCustomFieldValues } from '../lib/customFieldHelpers.js';
 import { ForbiddenError, GoneError, NotFoundError, QuotaExceededError, ValidationError } from '../lib/httpErrors.js';
@@ -171,6 +172,131 @@ router.get('/lookup/:shortCode', asyncHandler(async (req, res) => {
   }
 
   res.json(result.rows[0]);
+}));
+
+// POST /api/bins/:id/change-code — change a bin's shortcode (admin only)
+router.post('/:id/change-code', sensitiveAuthLimiter, asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { code } = req.body;
+
+  if (!code || typeof code !== 'string') {
+    throw new ValidationError('Code is required');
+  }
+
+  const newCode = code.toUpperCase();
+  validateCodeFormat(newCode);
+
+  if (newCode === id.toUpperCase()) {
+    throw new ValidationError('New code is the same as current code');
+  }
+
+  // Verify access to target bin
+  const access = await verifyBinAccess(id, req.user!.id);
+  if (!access) {
+    throw new NotFoundError('Bin not found');
+  }
+
+  await requireAdmin(access.locationId, req.user!.id, 'change bin code');
+
+  // Check if newCode belongs to an existing bin (including trashed)
+  const existingResult = await query<{ id: string; name: string; location_id: string }>(
+    'SELECT id, name, location_id FROM bins WHERE UPPER(id) = $1',
+    [newCode]
+  );
+  const existingBin = existingResult.rows[0] ?? null;
+
+  // Cross-location permission check
+  if (existingBin && existingBin.location_id !== access.locationId) {
+    await requireAdmin(existingBin.location_id, req.user!.id, 'change bin code');
+  }
+
+  // Fetch photo paths before transaction (CASCADE will delete these rows)
+  let existingPhotos: { storage_path: string; thumb_path: string | null }[] = [];
+  if (existingBin) {
+    const photosResult = await query<{ storage_path: string; thumb_path: string | null }>(
+      'SELECT storage_path, thumb_path FROM photos WHERE bin_id = $1',
+      [existingBin.id]
+    );
+    existingPhotos = photosResult.rows;
+  }
+
+  // Run the transaction (better-sqlite3 is synchronous)
+  const db = getDb();
+  db.transaction(() => {
+    // defer_foreign_keys is required because steps below update child rows
+    // to reference newCode before the parent row with that ID exists.
+    db.pragma('defer_foreign_keys = ON');
+
+    // 1. Hard-delete existing bin at newCode (CASCADE removes children)
+    db.prepare('DELETE FROM bins WHERE id = ?').run(newCode);
+
+    // 2. Update all FK references
+    db.prepare('UPDATE bin_items SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
+    db.prepare('UPDATE photos SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
+    db.prepare('UPDATE bin_custom_field_values SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
+    db.prepare('UPDATE pinned_bins SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
+    db.prepare('UPDATE scan_history SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
+
+    // 3. Update photo storage paths
+    db.prepare(`UPDATE photos SET
+      storage_path = replace(storage_path, ? || '/', ? || '/'),
+      thumb_path = CASE WHEN thumb_path IS NOT NULL
+        THEN replace(thumb_path, ? || '/', ? || '/')
+        ELSE NULL END
+      WHERE bin_id = ?`).run(id, newCode, id, newCode, newCode);
+
+    // 4. Update activity log references (not a FK)
+    db.prepare("UPDATE activity_log SET entity_id = ? WHERE entity_id = ? AND entity_type = 'bin'")
+      .run(newCode, id);
+
+    // 5. Change the bin's primary key
+    db.prepare("UPDATE bins SET id = ?, updated_at = datetime('now') WHERE id = ?")
+      .run(newCode, id);
+  })();
+
+  // Post-transaction: clean up deleted bin's photos from disk
+  if (existingPhotos.length > 0) {
+    cleanupBinPhotos(newCode, existingPhotos);
+  }
+
+  // Rename target bin's photo directory
+  const oldDir = path.join(config.photoStoragePath, id);
+  const newDir = path.join(config.photoStoragePath, newCode);
+  try {
+    if (fs.existsSync(oldDir)) {
+      fs.renameSync(oldDir, newDir);
+    }
+  } catch (err) {
+    console.error(`Failed to rename photo directory ${oldDir} → ${newDir}:`, err);
+  }
+
+  // Activity logging (fire-and-forget, post-transaction)
+  if (existingBin) {
+    logRouteActivity(req, {
+      entityType: 'bin',
+      locationId: existingBin.location_id,
+      action: 'permanent_delete',
+      entityId: newCode,
+      entityName: existingBin.name,
+    });
+  }
+
+  // Return updated bin
+  const updatedBin = await fetchBinById(newCode, { userId: req.user!.id });
+  if (!updatedBin) {
+    throw new NotFoundError('Bin not found after code change');
+  }
+
+  logRouteActivity(req, {
+    entityType: 'bin',
+    locationId: access.locationId,
+    action: 'code_changed',
+    entityId: newCode,
+    entityName: updatedBin.name,
+    changes: { code: { old: id, new: newCode } },
+  });
+
+  res.json(updatedBin);
 }));
 
 // GET /api/bins/:id — get single bin

--- a/server/src/routes/bins.ts
+++ b/server/src/routes/bins.ts
@@ -8,12 +8,12 @@ import { getMemberRole, isBinCreator, requireAdmin, requireMemberOrAbove, verify
 import { BIN_SELECT_COLS, buildBinListQuery, fetchBinById } from '../lib/binQueries.js';
 import { buildBinSetClauses, buildBinUpdateDiff, insertBinWithItems, replaceBinItems } from '../lib/binUpdateHelpers.js';
 import { validateBinFields, validateCodeFormat } from '../lib/binValidation.js';
-import { sensitiveAuthLimiter } from '../lib/rateLimiters.js';
 import { config } from '../lib/config.js';
 import { remapCustomFieldsForMove, replaceCustomFieldValues } from '../lib/customFieldHelpers.js';
 import { ForbiddenError, GoneError, NotFoundError, QuotaExceededError, ValidationError } from '../lib/httpErrors.js';
 import { cleanupBinPhotos } from '../lib/photoCleanup.js';
 import { generateThumbnail } from '../lib/photoHelpers.js';
+import { sensitiveAuthLimiter } from '../lib/rateLimiters.js';
 import { logRouteActivity } from '../lib/routeHelpers.js';
 import { purgeExpiredTrash } from '../lib/trashPurge.js';
 import { binPhotoUpload, validateFileType } from '../lib/uploadConfig.js';
@@ -222,36 +222,37 @@ router.post('/:id/change-code', sensitiveAuthLimiter, asyncHandler(async (req, r
 
   // Run the transaction (better-sqlite3 is synchronous)
   const db = getDb();
+  const stmts = {
+    deleteBin: db.prepare('DELETE FROM bins WHERE id = ?'),
+    updateItems: db.prepare('UPDATE bin_items SET bin_id = ? WHERE bin_id = ?'),
+    updatePhotos: db.prepare('UPDATE photos SET bin_id = ? WHERE bin_id = ?'),
+    updateCustomFields: db.prepare('UPDATE bin_custom_field_values SET bin_id = ? WHERE bin_id = ?'),
+    updatePins: db.prepare('UPDATE pinned_bins SET bin_id = ? WHERE bin_id = ?'),
+    updateScans: db.prepare('UPDATE scan_history SET bin_id = ? WHERE bin_id = ?'),
+    updatePhotoPaths: db.prepare(`UPDATE photos SET
+      storage_path = replace(storage_path, ? || '/', ? || '/'),
+      thumb_path = CASE WHEN thumb_path IS NOT NULL
+        THEN replace(thumb_path, ? || '/', ? || '/')
+        ELSE NULL END
+      WHERE bin_id = ?`),
+    updateActivityLog: db.prepare("UPDATE activity_log SET entity_id = ? WHERE entity_id = ? AND entity_type = 'bin'"),
+    renameBin: db.prepare("UPDATE bins SET id = ?, updated_at = datetime('now') WHERE id = ?"),
+  };
+
   db.transaction(() => {
     // defer_foreign_keys is required because steps below update child rows
     // to reference newCode before the parent row with that ID exists.
     db.pragma('defer_foreign_keys = ON');
 
-    // 1. Hard-delete existing bin at newCode (CASCADE removes children)
-    db.prepare('DELETE FROM bins WHERE id = ?').run(newCode);
-
-    // 2. Update all FK references
-    db.prepare('UPDATE bin_items SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
-    db.prepare('UPDATE photos SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
-    db.prepare('UPDATE bin_custom_field_values SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
-    db.prepare('UPDATE pinned_bins SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
-    db.prepare('UPDATE scan_history SET bin_id = ? WHERE bin_id = ?').run(newCode, id);
-
-    // 3. Update photo storage paths
-    db.prepare(`UPDATE photos SET
-      storage_path = replace(storage_path, ? || '/', ? || '/'),
-      thumb_path = CASE WHEN thumb_path IS NOT NULL
-        THEN replace(thumb_path, ? || '/', ? || '/')
-        ELSE NULL END
-      WHERE bin_id = ?`).run(id, newCode, id, newCode, newCode);
-
-    // 4. Update activity log references (not a FK)
-    db.prepare("UPDATE activity_log SET entity_id = ? WHERE entity_id = ? AND entity_type = 'bin'")
-      .run(newCode, id);
-
-    // 5. Change the bin's primary key
-    db.prepare("UPDATE bins SET id = ?, updated_at = datetime('now') WHERE id = ?")
-      .run(newCode, id);
+    stmts.deleteBin.run(newCode);
+    stmts.updateItems.run(newCode, id);
+    stmts.updatePhotos.run(newCode, id);
+    stmts.updateCustomFields.run(newCode, id);
+    stmts.updatePins.run(newCode, id);
+    stmts.updateScans.run(newCode, id);
+    stmts.updatePhotoPaths.run(id, newCode, id, newCode, newCode);
+    stmts.updateActivityLog.run(newCode, id);
+    stmts.renameBin.run(newCode, id);
   })();
 
   // Post-transaction: clean up deleted bin's photos from disk
@@ -263,11 +264,11 @@ router.post('/:id/change-code', sensitiveAuthLimiter, asyncHandler(async (req, r
   const oldDir = path.join(config.photoStoragePath, id);
   const newDir = path.join(config.photoStoragePath, newCode);
   try {
-    if (fs.existsSync(oldDir)) {
-      fs.renameSync(oldDir, newDir);
-    }
+    fs.renameSync(oldDir, newDir);
   } catch (err) {
-    console.error(`Failed to rename photo directory ${oldDir} → ${newDir}:`, err);
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error(`Failed to rename photo directory ${oldDir} → ${newDir}:`, err);
+    }
   }
 
   // Activity logging (fire-and-forget, post-transaction)

--- a/src/features/bins/BinDetailPage.tsx
+++ b/src/features/bins/BinDetailPage.tsx
@@ -14,6 +14,7 @@ import { BinDetailSkeleton } from './BinDetailSkeleton';
 import { BinDetailToolbar } from './BinDetailToolbar';
 import { BinEditContent } from './BinEditContent';
 import { BinViewContent } from './BinViewContent';
+import { ChangeCodeDialog } from './ChangeCodeDialog';
 import { DeleteBinDialog } from './DeleteBinDialog';
 import { MoveBinDialog } from './MoveBinDialog';
 import { UnsavedChangesDialog } from './UnsavedChangesDialog';
@@ -171,6 +172,9 @@ export function BinDetailPage() {
           }
         }}
         onDelete={() => actions.setDeleteOpen(true)}
+        isAdmin={actions.isAdmin}
+        onChangeCode={() => actions.setChangeCodeMode('adopt')}
+        onReassignCode={() => actions.setChangeCodeMode('reassign')}
       />
 
       {edit.editing ? (
@@ -220,6 +224,15 @@ export function BinDetailPage() {
       />
 
       <AiSetupDialog open={actions.aiSetupOpen} onOpenChange={actions.setAiSetupOpen} />
+
+      {actions.changeCodeMode && (
+        <ChangeCodeDialog
+          open={!!actions.changeCodeMode}
+          onOpenChange={(open) => { if (!open) actions.setChangeCodeMode(null); }}
+          mode={actions.changeCodeMode}
+          currentBin={{ id: bin.id, name: bin.name }}
+        />
+      )}
 
       <UnsavedChangesDialog
         open={unsavedOpen}

--- a/src/features/bins/BinDetailPage.tsx
+++ b/src/features/bins/BinDetailPage.tsx
@@ -173,8 +173,7 @@ export function BinDetailPage() {
         }}
         onDelete={() => actions.setDeleteOpen(true)}
         isAdmin={actions.isAdmin}
-        onChangeCode={() => actions.setChangeCodeMode('adopt')}
-        onReassignCode={() => actions.setChangeCodeMode('reassign')}
+        onChangeCode={() => actions.setChangeCodeOpen(true)}
       />
 
       {edit.editing ? (
@@ -225,14 +224,11 @@ export function BinDetailPage() {
 
       <AiSetupDialog open={actions.aiSetupOpen} onOpenChange={actions.setAiSetupOpen} />
 
-      {actions.changeCodeMode && (
-        <ChangeCodeDialog
-          open={!!actions.changeCodeMode}
-          onOpenChange={(open) => { if (!open) actions.setChangeCodeMode(null); }}
-          mode={actions.changeCodeMode}
-          currentBin={{ id: bin.id, name: bin.name }}
-        />
-      )}
+      <ChangeCodeDialog
+        open={actions.changeCodeOpen}
+        onOpenChange={actions.setChangeCodeOpen}
+        currentBin={{ id: bin.id, name: bin.name }}
+      />
 
       <UnsavedChangesDialog
         open={unsavedOpen}

--- a/src/features/bins/BinDetailToolbar.tsx
+++ b/src/features/bins/BinDetailToolbar.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import { ArrowRightLeft, Check, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHorizontal, Pencil, Pin, Printer, Save, Sparkles, Trash2, X } from 'lucide-react';
+import { ArrowRightLeft, Check, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHorizontal, Pencil, Pin, Printer, QrCode, Save, Sparkles, Trash2, X } from 'lucide-react';
 import { useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { MenuButton } from '@/components/ui/menu-button';
@@ -37,6 +37,9 @@ interface BinDetailToolbarProps {
   onDuplicate: () => void;
   onMove: () => void;
   onDelete: () => void;
+  isAdmin: boolean;
+  onChangeCode: () => void;
+  onReassignCode: () => void;
 }
 
 export function BinDetailToolbar({
@@ -66,6 +69,9 @@ export function BinDetailToolbar({
   onDuplicate,
   onMove,
   onDelete,
+  isAdmin,
+  onChangeCode,
+  onReassignCode,
 }: BinDetailToolbarProps) {
   const t = useTerminology();
   const { visible, animating, close, toggle } = usePopover();
@@ -275,6 +281,26 @@ export function BinDetailToolbar({
                   >
                     <ArrowRightLeft className="h-4 w-4 text-[var(--text-tertiary)]" />
                     Move
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    type="button"
+                    className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors duration-150"
+                    onClick={() => handleItem(onChangeCode)}
+                  >
+                    <QrCode className="h-4 w-4 text-[var(--text-tertiary)]" />
+                    Change Code
+                  </button>
+                )}
+                {isAdmin && (
+                  <button
+                    type="button"
+                    className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors duration-150"
+                    onClick={() => handleItem(onReassignCode)}
+                  >
+                    <ArrowRightLeft className="h-4 w-4 text-[var(--text-tertiary)]" />
+                    Reassign Code
                   </button>
                 )}
                 {canDelete && (

--- a/src/features/bins/BinDetailToolbar.tsx
+++ b/src/features/bins/BinDetailToolbar.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import { ArrowRightLeft, Check, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHorizontal, Pencil, Pin, Printer, QrCode, Replace, Save, Sparkles, Trash2, X } from 'lucide-react';
+import { ArrowRightLeft, Check, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHorizontal, Pencil, Pin, Printer, QrCode, Save, Sparkles, Trash2, X } from 'lucide-react';
 import { useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { MenuButton } from '@/components/ui/menu-button';
@@ -39,7 +39,6 @@ interface BinDetailToolbarProps {
   onDelete: () => void;
   isAdmin: boolean;
   onChangeCode: () => void;
-  onReassignCode: () => void;
 }
 
 export function BinDetailToolbar({
@@ -71,7 +70,6 @@ export function BinDetailToolbar({
   onDelete,
   isAdmin,
   onChangeCode,
-  onReassignCode,
 }: BinDetailToolbarProps) {
   const t = useTerminology();
   const { visible, animating, close, toggle } = usePopover();
@@ -291,16 +289,6 @@ export function BinDetailToolbar({
                   >
                     <QrCode className="h-4 w-4 text-[var(--text-tertiary)]" />
                     Change Code
-                  </button>
-                )}
-                {isAdmin && (
-                  <button
-                    type="button"
-                    className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors duration-150"
-                    onClick={() => handleItem(onReassignCode)}
-                  >
-                    <Replace className="h-4 w-4 text-[var(--text-tertiary)]" />
-                    Reassign Code
                   </button>
                 )}
                 {canDelete && (

--- a/src/features/bins/BinDetailToolbar.tsx
+++ b/src/features/bins/BinDetailToolbar.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import { ArrowRightLeft, Check, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHorizontal, Pencil, Pin, Printer, QrCode, Save, Sparkles, Trash2, X } from 'lucide-react';
+import { ArrowRightLeft, Check, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHorizontal, Pencil, Pin, Printer, QrCode, Replace, Save, Sparkles, Trash2, X } from 'lucide-react';
 import { useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { MenuButton } from '@/components/ui/menu-button';
@@ -299,7 +299,7 @@ export function BinDetailToolbar({
                     className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-left text-[14px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors duration-150"
                     onClick={() => handleItem(onReassignCode)}
                   >
-                    <ArrowRightLeft className="h-4 w-4 text-[var(--text-tertiary)]" />
+                    <Replace className="h-4 w-4 text-[var(--text-tertiary)]" />
                     Reassign Code
                   </button>
                 )}

--- a/src/features/bins/ChangeCodeDialog.tsx
+++ b/src/features/bins/ChangeCodeDialog.tsx
@@ -1,23 +1,23 @@
-import { Keyboard, Loader2, QrCode } from 'lucide-react';
+import { Loader2, Search } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { OptionGroup } from '@/components/ui/option-group';
 import { useToast } from '@/components/ui/toast';
 import { Html5QrcodePlugin } from '@/features/qrcode/Html5QrcodePlugin';
 import { BIN_CODE_REGEX, BIN_URL_REGEX } from '@/lib/qr';
-import { cn } from '@/lib/utils';
 import { changeCode, lookupBinByCodeSafe } from './useBins';
 
 interface ChangeCodeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mode: 'adopt' | 'reassign';
   currentBin: { id: string; name: string };
 }
 
+type Mode = 'adopt' | 'reassign';
 type Step = 'input' | 'confirm' | 'submitting';
-type InputMode = 'manual' | 'scan';
 
 interface LookupResult {
   code: string;
@@ -25,12 +25,17 @@ interface LookupResult {
   binName?: string;
 }
 
-export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: ChangeCodeDialogProps) {
+const MODE_OPTIONS = [
+  { key: 'adopt' as const, label: 'Use a new code' },
+  { key: 'reassign' as const, label: 'Give code away' },
+];
+
+export function ChangeCodeDialog({ open, onOpenChange, currentBin }: ChangeCodeDialogProps) {
   const navigate = useNavigate();
   const { showToast } = useToast();
 
+  const [mode, setMode] = useState<Mode>('adopt');
   const [step, setStep] = useState<Step>('input');
-  const [inputMode, setInputMode] = useState<InputMode>('manual');
   const [code, setCode] = useState('');
   const [lookupResult, setLookupResult] = useState<LookupResult | null>(null);
   const [lookingUp, setLookingUp] = useState(false);
@@ -39,14 +44,22 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
   // Reset state when dialog opens/closes
   useEffect(() => {
     if (open) {
+      setMode('adopt');
       setStep('input');
-      setInputMode('manual');
       setCode('');
       setLookupResult(null);
       setLookingUp(false);
       setError('');
     }
   }, [open]);
+
+  function handleModeChange(newMode: Mode) {
+    setMode(newMode);
+    setCode('');
+    setLookupResult(null);
+    setError('');
+    setStep('input');
+  }
 
   const isValidCode = BIN_CODE_REGEX.test(code) && code !== currentBin.id;
 
@@ -60,6 +73,12 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
 
       if (result.status === 'forbidden') {
         setError('You do not have admin access to the location that owns this code.');
+        setLookingUp(false);
+        return;
+      }
+
+      if (mode === 'reassign' && result.status !== 'found') {
+        setError('No bin found with that code.');
         setLookingUp(false);
         return;
       }
@@ -82,8 +101,6 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
     setStep('submitting');
 
     try {
-      // In adopt mode: current bin adopts the entered code
-      // In reassign mode: the entered code's bin adopts current bin's code
       const targetBinId = mode === 'adopt' ? currentBin.id : lookupResult.code;
       const newCode = mode === 'adopt' ? lookupResult.code : currentBin.id;
 
@@ -91,8 +108,6 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
 
       onOpenChange(false);
       showToast({ message: `Code changed to ${result.id}` });
-
-      // Navigate to the bin with its new code
       navigate(`/bin/${result.id}`, { replace: true });
     } catch {
       setError('Failed to change code. Please try again.');
@@ -100,17 +115,13 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
     }
   }
 
-  // Scanner callback
   const handleScan = useCallback((decodedText: string) => {
     const match = decodedText.match(BIN_URL_REGEX);
     if (match) {
-      const scannedCode = match[1].toUpperCase();
-      setCode(scannedCode);
-      setInputMode('manual');
+      setCode(match[1].toUpperCase());
     }
   }, []);
 
-  const title = mode === 'adopt' ? 'Change Code' : 'Reassign Code';
   const description = mode === 'adopt'
     ? 'Scan or enter the code from the label you want this bin to use.'
     : `Enter the code of the bin that should receive code ${currentBin.id}.`;
@@ -122,71 +133,59 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
+          <DialogTitle>Change Code</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         {step === 'input' && (
           <div className="space-y-4 py-2">
-            {/* Input mode toggle */}
-            <div className="flex gap-1 p-1 rounded-lg bg-[var(--bg-flat)]">
-              <button
-                type="button"
-                className={cn(
-                  'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[13px] font-medium transition-colors',
-                  inputMode === 'manual'
-                    ? 'bg-[var(--bg-card)] text-[var(--text-primary)]'
-                    : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-                )}
-                onClick={() => setInputMode('manual')}
-              >
-                <Keyboard className="h-3.5 w-3.5" />
-                Enter Code
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[13px] font-medium transition-colors',
-                  inputMode === 'scan'
-                    ? 'bg-[var(--bg-card)] text-[var(--text-primary)]'
-                    : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-                )}
-                onClick={() => setInputMode('scan')}
-              >
-                <QrCode className="h-3.5 w-3.5" />
-                Scan QR
-              </button>
-            </div>
+            <OptionGroup options={MODE_OPTIONS} value={mode} onChange={handleModeChange} size="sm" />
 
-            {inputMode === 'manual' ? (
-              <div className="space-y-3">
-                <input
-                  type="text"
+            {open && <Html5QrcodePlugin onScanSuccess={handleScan} />}
+
+            <div>
+              <div className="flex gap-2">
+                <Input
                   value={code}
                   onChange={(e) => {
                     setCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8));
                     setError('');
                   }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && isValidCode && !lookingUp) {
+                      e.preventDefault();
+                      handleLookup();
+                    }
+                  }}
                   placeholder="Enter code..."
                   maxLength={8}
-                  className="w-full rounded-[var(--radius-sm)] border border-[var(--border-flat)] bg-[var(--bg-input)] px-3.5 py-2.5 text-base font-mono tracking-wider text-center uppercase text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-                  autoComplete="off"
-                  autoFocus
-                  onKeyDown={(e) => { if (e.key === 'Enter' && isValidCode && !lookingUp) handleLookup(); }}
+                  disabled={lookingUp}
+                  className="flex-1 font-mono uppercase tracking-widest"
                 />
-                {code && code === currentBin.id && (
-                  <p className="text-[13px] text-[var(--destructive)]">This is already this bin&apos;s code.</p>
-                )}
+                <Button
+                  onClick={handleLookup}
+                  disabled={!isValidCode || lookingUp}
+                  className="rounded-[var(--radius-md)] shrink-0"
+                >
+                  {lookingUp ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <>
+                      <Search className="h-4 w-4 mr-1.5" />
+                      Look Up
+                    </>
+                  )}
+                </Button>
               </div>
-            ) : (
-              <Html5QrcodePlugin onScanSuccess={handleScan} />
-            )}
-
-            {error && (
-              <p className="text-[13px] text-[var(--destructive)]">{error}</p>
-            )}
+              {code && code === currentBin.id && (
+                <p className="mt-2 text-[13px] text-[var(--destructive)]">This is already this bin&apos;s code.</p>
+              )}
+              {error && (
+                <p className="mt-2 text-[13px] text-[var(--destructive)]">{error}</p>
+              )}
+            </div>
           </div>
         )}
 
@@ -218,16 +217,7 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
         {step !== 'submitting' && (
           <DialogFooter>
             {step === 'input' && (
-              <>
-                <Button variant="ghost" onClick={() => handleOpenChange(false)}>Cancel</Button>
-                <Button
-                  onClick={handleLookup}
-                  disabled={!isValidCode || lookingUp}
-                  aria-label="Look up"
-                >
-                  {lookingUp ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Look Up'}
-                </Button>
-              </>
+              <Button variant="ghost" onClick={() => handleOpenChange(false)}>Cancel</Button>
             )}
             {step === 'confirm' && (
               <>

--- a/src/features/bins/ChangeCodeDialog.tsx
+++ b/src/features/bins/ChangeCodeDialog.tsx
@@ -1,0 +1,295 @@
+import { Keyboard, Loader2, QrCode } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/toast';
+import { BIN_URL_REGEX } from '@/lib/qr';
+import { cn } from '@/lib/utils';
+import { changeCode, lookupBinByCodeSafe } from './useBins';
+
+interface ChangeCodeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: 'adopt' | 'reassign';
+  currentBin: { id: string; name: string };
+}
+
+type Step = 'input' | 'confirm' | 'submitting';
+type InputMode = 'manual' | 'scan';
+
+interface LookupResult {
+  code: string;
+  claimed: boolean;
+  binName?: string;
+}
+
+const CODE_REGEX = /^[A-Z0-9]{4,8}$/;
+
+export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: ChangeCodeDialogProps) {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const [step, setStep] = useState<Step>('input');
+  const [inputMode, setInputMode] = useState<InputMode>('manual');
+  const [code, setCode] = useState('');
+  const [lookupResult, setLookupResult] = useState<LookupResult | null>(null);
+  const [lookingUp, setLookingUp] = useState(false);
+  const [error, setError] = useState('');
+
+  // Reset state when dialog opens/closes
+  useEffect(() => {
+    if (open) {
+      setStep('input');
+      setInputMode('manual');
+      setCode('');
+      setLookupResult(null);
+      setLookingUp(false);
+      setError('');
+    }
+  }, [open]);
+
+  const isValidCode = CODE_REGEX.test(code) && code !== currentBin.id;
+
+  async function handleLookup() {
+    if (!isValidCode) return;
+    setLookingUp(true);
+    setError('');
+
+    try {
+      const result = await lookupBinByCodeSafe(code);
+
+      if (result.status === 'forbidden') {
+        setError('You do not have admin access to the location that owns this code.');
+        setLookingUp(false);
+        return;
+      }
+
+      setLookupResult({
+        code,
+        claimed: result.status === 'found',
+        binName: result.bin?.name,
+      });
+      setStep('confirm');
+    } catch {
+      setError('Failed to look up code. Please try again.');
+    } finally {
+      setLookingUp(false);
+    }
+  }
+
+  async function handleConfirm() {
+    if (!lookupResult) return;
+    setStep('submitting');
+
+    try {
+      // In adopt mode: current bin adopts the entered code
+      // In reassign mode: the entered code's bin adopts current bin's code
+      const targetBinId = mode === 'adopt' ? currentBin.id : lookupResult.code;
+      const newCode = mode === 'adopt' ? lookupResult.code : currentBin.id;
+
+      const result = await changeCode(targetBinId, newCode);
+
+      onOpenChange(false);
+      showToast({ message: `Code changed to ${result.id}` });
+
+      // Navigate to the bin with its new code
+      navigate(`/bin/${result.id}`, { replace: true });
+    } catch {
+      setError('Failed to change code. Please try again.');
+      setStep('confirm');
+    }
+  }
+
+  // Scanner callback
+  const handleScan = useCallback((decodedText: string) => {
+    const match = decodedText.match(BIN_URL_REGEX);
+    if (match) {
+      const scannedCode = match[1].toUpperCase();
+      setCode(scannedCode);
+      setInputMode('manual');
+    }
+  }, []);
+
+  const title = mode === 'adopt' ? 'Change Code' : 'Reassign Code';
+  const description = mode === 'adopt'
+    ? 'Scan or enter the code from the label you want this bin to use.'
+    : `Enter the code of the bin that should receive code ${currentBin.id}.`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {step === 'input' && (
+          <div className="space-y-4 py-2">
+            {/* Input mode toggle */}
+            <div className="flex gap-1 p-1 rounded-lg bg-[var(--bg-flat)]">
+              <button
+                type="button"
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[13px] font-medium transition-colors',
+                  inputMode === 'manual'
+                    ? 'bg-[var(--bg-card)] text-[var(--text-primary)]'
+                    : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                )}
+                onClick={() => setInputMode('manual')}
+              >
+                <Keyboard className="h-3.5 w-3.5" />
+                Enter Code
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[13px] font-medium transition-colors',
+                  inputMode === 'scan'
+                    ? 'bg-[var(--bg-card)] text-[var(--text-primary)]'
+                    : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                )}
+                onClick={() => setInputMode('scan')}
+              >
+                <QrCode className="h-3.5 w-3.5" />
+                Scan QR
+              </button>
+            </div>
+
+            {inputMode === 'manual' ? (
+              <div className="space-y-3">
+                <input
+                  type="text"
+                  value={code}
+                  onChange={(e) => {
+                    setCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8));
+                    setError('');
+                  }}
+                  placeholder="Enter code..."
+                  maxLength={8}
+                  className="w-full rounded-lg border border-[var(--border-flat)] bg-[var(--bg-card)] px-3 py-2 text-sm font-mono tracking-wider text-center uppercase placeholder:text-[var(--text-tertiary)] outline-none focus:border-[var(--border-focus)]"
+                  autoFocus
+                  onKeyDown={(e) => { if (e.key === 'Enter' && isValidCode && !lookingUp) handleLookup(); }}
+                />
+                {code && code === currentBin.id && (
+                  <p className="text-[13px] text-[var(--destructive)]">This is already this bin&apos;s code.</p>
+                )}
+              </div>
+            ) : (
+              <ScannerPanel onScan={handleScan} />
+            )}
+
+            {error && (
+              <p className="text-[13px] text-[var(--destructive)]">{error}</p>
+            )}
+          </div>
+        )}
+
+        {step === 'confirm' && lookupResult && (
+          <div className="py-4 space-y-3">
+            <p className="text-sm text-[var(--text-primary)]">
+              {mode === 'adopt' ? (
+                lookupResult.claimed ? (
+                  <>Code <span className="font-mono font-semibold">{lookupResult.code}</span> belongs to &apos;{lookupResult.binName}&apos;. Adopting it will <strong>permanently delete</strong> that bin and change this bin&apos;s code from <span className="font-mono">{currentBin.id}</span> to <span className="font-mono">{lookupResult.code}</span>.</>
+                ) : (
+                  <>Change this bin&apos;s code from <span className="font-mono">{currentBin.id}</span> to <span className="font-mono font-semibold">{lookupResult.code}</span>?</>
+                )
+              ) : (
+                <>Code <span className="font-mono font-semibold">{currentBin.id}</span> will move to &apos;{lookupResult.binName}&apos;. This bin (&apos;{currentBin.name}&apos;) will be <strong>permanently deleted</strong>.</>
+              )}
+            </p>
+            {error && (
+              <p className="text-[13px] text-[var(--destructive)]">{error}</p>
+            )}
+          </div>
+        )}
+
+        {step === 'submitting' && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
+          </div>
+        )}
+
+        <DialogFooter>
+          {step === 'input' && (
+            <>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+              <Button
+                onClick={handleLookup}
+                disabled={!isValidCode || lookingUp}
+                aria-label="Look up"
+              >
+                {lookingUp ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Look Up'}
+              </Button>
+            </>
+          )}
+          {step === 'confirm' && (
+            <>
+              <Button variant="ghost" onClick={() => { setStep('input'); setError(''); }}>Back</Button>
+              <Button
+                onClick={handleConfirm}
+                variant={mode === 'reassign' || lookupResult?.claimed ? 'destructive' : 'default'}
+              >
+                {mode === 'adopt' ? 'Change Code' : 'Reassign'}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Lazy-loaded QR scanner panel. Only mounts the camera when this tab is active. */
+function ScannerPanel({ onScan }: { onScan: (text: string) => void }) {
+  const scannerRef = useRef<HTMLDivElement>(null);
+  const html5QrRef = useRef<unknown>(null);
+  const [scanError, setScanError] = useState('');
+
+  useEffect(() => {
+    let stopped = false;
+
+    async function startScanner() {
+      const { Html5Qrcode } = await import('html5-qrcode');
+      if (stopped || !scannerRef.current) return;
+
+      const scanner = new Html5Qrcode(scannerRef.current.id);
+      html5QrRef.current = scanner;
+
+      try {
+        await scanner.start(
+          { facingMode: 'environment' },
+          { fps: 10, qrbox: { width: 250, height: 250 } },
+          (decodedText) => {
+            onScan(decodedText);
+            scanner.stop().catch(() => {});
+          },
+          () => {},
+        );
+      } catch {
+        setScanError('Camera access denied or not available.');
+      }
+    }
+
+    startScanner();
+
+    return () => {
+      stopped = true;
+      const scanner = html5QrRef.current as { stop?: () => Promise<void> } | null;
+      scanner?.stop?.().catch(() => {});
+    };
+  }, [onScan]);
+
+  return (
+    <div className="space-y-2">
+      <div
+        id="change-code-scanner"
+        ref={scannerRef}
+        className="w-full aspect-square max-h-[300px] rounded-lg overflow-hidden bg-black"
+      />
+      {scanError && (
+        <p className="text-[13px] text-[var(--destructive)]">{scanError}</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/bins/ChangeCodeDialog.tsx
+++ b/src/features/bins/ChangeCodeDialog.tsx
@@ -116,8 +116,13 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
     ? 'Scan or enter the code from the label you want this bin to use.'
     : `Enter the code of the bin that should receive code ${currentBin.id}.`;
 
+  const handleOpenChange = (next: boolean) => {
+    if (step === 'submitting') return;
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -167,7 +172,8 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
                   }}
                   placeholder="Enter code..."
                   maxLength={8}
-                  className="w-full rounded-lg border border-[var(--border-flat)] bg-[var(--bg-card)] px-3 py-2 text-sm font-mono tracking-wider text-center uppercase placeholder:text-[var(--text-tertiary)] outline-none focus:border-[var(--border-focus)]"
+                  className="w-full rounded-[var(--radius-sm)] border border-[var(--border-flat)] bg-[var(--bg-input)] px-3.5 py-2.5 text-base font-mono tracking-wider text-center uppercase text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                  autoComplete="off"
                   autoFocus
                   onKeyDown={(e) => { if (e.key === 'Enter' && isValidCode && !lookingUp) handleLookup(); }}
                 />
@@ -210,31 +216,33 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
           </div>
         )}
 
-        <DialogFooter>
-          {step === 'input' && (
-            <>
-              <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
-              <Button
-                onClick={handleLookup}
-                disabled={!isValidCode || lookingUp}
-                aria-label="Look up"
-              >
-                {lookingUp ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Look Up'}
-              </Button>
-            </>
-          )}
-          {step === 'confirm' && (
-            <>
-              <Button variant="ghost" onClick={() => { setStep('input'); setError(''); }}>Back</Button>
-              <Button
-                onClick={handleConfirm}
-                variant={mode === 'reassign' || lookupResult?.claimed ? 'destructive' : 'default'}
-              >
-                {mode === 'adopt' ? 'Change Code' : 'Reassign'}
-              </Button>
-            </>
-          )}
-        </DialogFooter>
+        {step !== 'submitting' && (
+          <DialogFooter>
+            {step === 'input' && (
+              <>
+                <Button variant="ghost" onClick={() => handleOpenChange(false)}>Cancel</Button>
+                <Button
+                  onClick={handleLookup}
+                  disabled={!isValidCode || lookingUp}
+                  aria-label="Look up"
+                >
+                  {lookingUp ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Look Up'}
+                </Button>
+              </>
+            )}
+            {step === 'confirm' && (
+              <>
+                <Button variant="ghost" onClick={() => { setStep('input'); setError(''); }}>Back</Button>
+                <Button
+                  onClick={handleConfirm}
+                  variant={mode === 'reassign' || lookupResult?.claimed ? 'destructive' : 'default'}
+                >
+                  {mode === 'adopt' ? 'Change Code' : 'Reassign'}
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/features/bins/ChangeCodeDialog.tsx
+++ b/src/features/bins/ChangeCodeDialog.tsx
@@ -1,10 +1,11 @@
 import { Keyboard, Loader2, QrCode } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useToast } from '@/components/ui/toast';
-import { BIN_URL_REGEX } from '@/lib/qr';
+import { Html5QrcodePlugin } from '@/features/qrcode/Html5QrcodePlugin';
+import { BIN_CODE_REGEX, BIN_URL_REGEX } from '@/lib/qr';
 import { cn } from '@/lib/utils';
 import { changeCode, lookupBinByCodeSafe } from './useBins';
 
@@ -23,8 +24,6 @@ interface LookupResult {
   claimed: boolean;
   binName?: string;
 }
-
-const CODE_REGEX = /^[A-Z0-9]{4,8}$/;
 
 export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: ChangeCodeDialogProps) {
   const navigate = useNavigate();
@@ -49,7 +48,7 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
     }
   }, [open]);
 
-  const isValidCode = CODE_REGEX.test(code) && code !== currentBin.id;
+  const isValidCode = BIN_CODE_REGEX.test(code) && code !== currentBin.id;
 
   async function handleLookup() {
     if (!isValidCode) return;
@@ -182,7 +181,7 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
                 )}
               </div>
             ) : (
-              <ScannerPanel onScan={handleScan} />
+              <Html5QrcodePlugin onScanSuccess={handleScan} />
             )}
 
             {error && (
@@ -245,59 +244,5 @@ export function ChangeCodeDialog({ open, onOpenChange, mode, currentBin }: Chang
         )}
       </DialogContent>
     </Dialog>
-  );
-}
-
-/** Lazy-loaded QR scanner panel. Only mounts the camera when this tab is active. */
-function ScannerPanel({ onScan }: { onScan: (text: string) => void }) {
-  const scannerRef = useRef<HTMLDivElement>(null);
-  const html5QrRef = useRef<unknown>(null);
-  const [scanError, setScanError] = useState('');
-
-  useEffect(() => {
-    let stopped = false;
-
-    async function startScanner() {
-      const { Html5Qrcode } = await import('html5-qrcode');
-      if (stopped || !scannerRef.current) return;
-
-      const scanner = new Html5Qrcode(scannerRef.current.id);
-      html5QrRef.current = scanner;
-
-      try {
-        await scanner.start(
-          { facingMode: 'environment' },
-          { fps: 10, qrbox: { width: 250, height: 250 } },
-          (decodedText) => {
-            onScan(decodedText);
-            scanner.stop().catch(() => {});
-          },
-          () => {},
-        );
-      } catch {
-        setScanError('Camera access denied or not available.');
-      }
-    }
-
-    startScanner();
-
-    return () => {
-      stopped = true;
-      const scanner = html5QrRef.current as { stop?: () => Promise<void> } | null;
-      scanner?.stop?.().catch(() => {});
-    };
-  }, [onScan]);
-
-  return (
-    <div className="space-y-2">
-      <div
-        id="change-code-scanner"
-        ref={scannerRef}
-        className="w-full aspect-square max-h-[300px] rounded-lg overflow-hidden bg-black"
-      />
-      {scanError && (
-        <p className="text-[13px] text-[var(--destructive)]">{scanError}</p>
-      )}
-    </div>
   );
 }

--- a/src/features/bins/__tests__/ChangeCodeDialog.test.tsx
+++ b/src/features/bins/__tests__/ChangeCodeDialog.test.tsx
@@ -31,13 +31,12 @@ vi.mock('react-router-dom', async () => {
 describe('ChangeCodeDialog', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it('renders adopt mode title', () => {
+  it('renders with Change Code title', () => {
     render(
       <MemoryRouter>
         <ChangeCodeDialog
           open={true}
           onOpenChange={() => {}}
-          mode="adopt"
           currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
         />
       </MemoryRouter>
@@ -45,18 +44,18 @@ describe('ChangeCodeDialog', () => {
     expect(screen.getByText('Change Code')).toBeTruthy();
   });
 
-  it('renders reassign mode title', () => {
+  it('shows mode selector with both options', () => {
     render(
       <MemoryRouter>
         <ChangeCodeDialog
           open={true}
           onOpenChange={() => {}}
-          mode="reassign"
           currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
         />
       </MemoryRouter>
     );
-    expect(screen.getByText('Reassign Code')).toBeTruthy();
+    expect(screen.getByText('Use a new code')).toBeTruthy();
+    expect(screen.getByText('Give code away')).toBeTruthy();
   });
 
   it('auto-uppercases manual input', () => {
@@ -65,7 +64,6 @@ describe('ChangeCodeDialog', () => {
         <ChangeCodeDialog
           open={true}
           onOpenChange={() => {}}
-          mode="adopt"
           currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
         />
       </MemoryRouter>
@@ -81,7 +79,6 @@ describe('ChangeCodeDialog', () => {
         <ChangeCodeDialog
           open={true}
           onOpenChange={() => {}}
-          mode="adopt"
           currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
         />
       </MemoryRouter>

--- a/src/features/bins/__tests__/ChangeCodeDialog.test.tsx
+++ b/src/features/bins/__tests__/ChangeCodeDialog.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ChangeCodeDialog } from '../ChangeCodeDialog';
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({ activeLocationId: 'loc1', token: 'test-token', user: { id: 'u1' } }),
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+describe('ChangeCodeDialog', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders adopt mode title', () => {
+    render(
+      <MemoryRouter>
+        <ChangeCodeDialog
+          open={true}
+          onOpenChange={() => {}}
+          mode="adopt"
+          currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Change Code')).toBeTruthy();
+  });
+
+  it('renders reassign mode title', () => {
+    render(
+      <MemoryRouter>
+        <ChangeCodeDialog
+          open={true}
+          onOpenChange={() => {}}
+          mode="reassign"
+          currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Reassign Code')).toBeTruthy();
+  });
+
+  it('auto-uppercases manual input', () => {
+    render(
+      <MemoryRouter>
+        <ChangeCodeDialog
+          open={true}
+          onOpenChange={() => {}}
+          mode="adopt"
+          currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
+        />
+      </MemoryRouter>
+    );
+    const input = screen.getByPlaceholderText('Enter code...');
+    fireEvent.change(input, { target: { value: 'abcxyz' } });
+    expect((input as HTMLInputElement).value).toBe('ABCXYZ');
+  });
+
+  it('disables lookup button for invalid codes', () => {
+    render(
+      <MemoryRouter>
+        <ChangeCodeDialog
+          open={true}
+          onOpenChange={() => {}}
+          mode="adopt"
+          currentBin={{ id: 'ABCDEF', name: 'My Bin' }}
+        />
+      </MemoryRouter>
+    );
+    const input = screen.getByPlaceholderText('Enter code...');
+    fireEvent.change(input, { target: { value: 'AB' } });
+    const btn = screen.getByRole('button', { name: /look up/i });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/src/features/bins/__tests__/ChangeCodeDialog.test.tsx
+++ b/src/features/bins/__tests__/ChangeCodeDialog.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChangeCodeDialog } from '../ChangeCodeDialog';
 
 vi.mock('@/lib/api', () => ({

--- a/src/features/bins/useBinDetailActions.ts
+++ b/src/features/bins/useBinDetailActions.ts
@@ -33,7 +33,7 @@ export function useBinDetailActions(bin: Bin | null | undefined, id: string | un
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
   const [aiSetupOpen, setAiSetupOpen] = useState(false);
-  const [changeCodeMode, setChangeCodeMode] = useState<'adopt' | 'reassign' | null>(null);
+  const [changeCodeOpen, setChangeCodeOpen] = useState(false);
 
   const quickAdd = useQuickAdd({
     binId: id,
@@ -197,7 +197,7 @@ export function useBinDetailActions(bin: Bin | null | undefined, id: string | un
     deleteOpen, setDeleteOpen,
     moveOpen, setMoveOpen,
     aiSetupOpen, setAiSetupOpen,
-    changeCodeMode, setChangeCodeMode,
+    changeCodeOpen, setChangeCodeOpen,
     isAdmin,
   };
 }

--- a/src/features/bins/useBinDetailActions.ts
+++ b/src/features/bins/useBinDetailActions.ts
@@ -33,6 +33,7 @@ export function useBinDetailActions(bin: Bin | null | undefined, id: string | un
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
   const [aiSetupOpen, setAiSetupOpen] = useState(false);
+  const [changeCodeMode, setChangeCodeMode] = useState<'adopt' | 'reassign' | null>(null);
 
   const quickAdd = useQuickAdd({
     binId: id,
@@ -196,5 +197,7 @@ export function useBinDetailActions(bin: Bin | null | undefined, id: string | un
     deleteOpen, setDeleteOpen,
     moveOpen, setMoveOpen,
     aiSetupOpen, setAiSetupOpen,
+    changeCodeMode, setChangeCodeMode,
+    isAdmin,
   };
 }

--- a/src/features/bins/useBins.ts
+++ b/src/features/bins/useBins.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { apiFetch } from '@/lib/api';
+import { ApiError, apiFetch } from '@/lib/api';
 import { useAuth } from '@/lib/auth';
 import { Events, notify, useRefreshOn } from '@/lib/eventBus';
 import { useListData } from '@/lib/useListData';
@@ -329,6 +329,32 @@ export async function moveBin(id: string, locationId: string): Promise<void> {
 
 export async function lookupBinByCode(shortCode: string): Promise<Bin> {
   return apiFetch<Bin>(`/api/bins/${encodeURIComponent(shortCode.toUpperCase())}`);
+}
+
+/** Look up a bin by code. Returns the bin if found, null if not found / deleted / forbidden. */
+export async function lookupBinByCodeSafe(code: string): Promise<{ bin: Bin | null; status: 'found' | 'not_found' | 'deleted' | 'forbidden' }> {
+  try {
+    const bin = await apiFetch<Bin>(`/api/bins/${encodeURIComponent(code.toUpperCase())}`);
+    return { bin, status: 'found' };
+  } catch (err) {
+    if (err instanceof ApiError) {
+      if (err.status === 404) return { bin: null, status: 'not_found' };
+      if (err.status === 410) return { bin: null, status: 'deleted' };
+      if (err.status === 403) return { bin: null, status: 'forbidden' };
+    }
+    throw err;
+  }
+}
+
+export async function changeCode(binId: string, newCode: string): Promise<Bin> {
+  const result = await apiFetch<Bin>(`/api/bins/${encodeURIComponent(binId)}/change-code`, {
+    method: 'POST',
+    body: { code: newCode.toUpperCase() },
+  });
+  notifyBinsChanged();
+  notify(Events.PINS);
+  notify(Events.SCAN_HISTORY);
+  return result;
 }
 
 export function useTrashBins() {

--- a/src/lib/qr.ts
+++ b/src/lib/qr.ts
@@ -3,6 +3,8 @@ import { getBinQrPayload } from './constants';
 
 export const BIN_URL_REGEX = /(?:openbin:\/\/bin\/|https?:\/\/[^/]+(?:\/[^/]+)*\/bin\/)([A-Z0-9]{4,8})(?:[/?#]|$)/i;
 
+export const BIN_CODE_REGEX = /^[A-Z0-9]{4,8}$/;
+
 export interface QRColorOptions {
   dark: string;
   light: string;


### PR DESCRIPTION
## Summary

- Adds `POST /api/bins/:id/change-code` endpoint that lets admins change a bin's shortcode (primary key), with support for adopting codes from other bins (permanently deleting the donor)
- Adds `ChangeCodeDialog` with QR scan and manual entry, unified adopt/reassign mode toggle via `OptionGroup`
- Includes cross-location admin permission checks, transaction-safe PK swap with FK updates, and photo directory renaming
- Adds server + client tests, OpenAPI spec, and API/user guide documentation

## Test plan

- [ ] Run `cd server && npx vitest run src/__tests__/changeCode.test.ts` (16 tests)
- [ ] Run `npx vitest run src/features/bins/__tests__/ChangeCodeDialog.test.tsx` (4 tests)
- [ ] As admin, open bin detail → overflow menu → "Change Code" → enter an unclaimed code → confirm
- [ ] As admin, adopt a code belonging to another bin → verify donor bin is deleted
- [ ] As admin, use "Give code away" mode → verify current bin's code transfers to target
- [ ] Verify non-admin users cannot see the "Change Code" menu item
- [ ] Verify cross-location code change requires admin in both locations