### PR TITLE
feat: bulk AI integration for bin list

### DIFF
--- a/data
+++ b/data
@@ -1,1 +1,0 @@
-/home/akifbayram/qrcode/data

--- a/data
+++ b/data
@@ -1,0 +1,1 @@
+/home/akifbayram/qrcode/data

--- a/server/src/lib/aiContext.ts
+++ b/server/src/lib/aiContext.ts
@@ -11,8 +11,12 @@ export const AVAILABLE_ICONS = [
 ];
 
 /** Fetch bins, areas, trash, and custom field data for a location. */
+function appendInClause(sql: string, column: string, startIndex: number, ids: string[]): { sql: string; params: string[] } {
+  const placeholders = ids.map((_, i) => `$${startIndex + i}`).join(', ');
+  return { sql: `${sql} AND ${column} IN (${placeholders})`, params: ids };
+}
+
 async function fetchLocationData(locationId: string, userId: string, binIds?: string[]) {
-  // Build bins query — optionally scoped to specific bin IDs
   let binsSql = `SELECT b.id, b.name,
         COALESCE((SELECT json_group_array(json_object('id', bi.id, 'name', bi.name, 'quantity', bi.quantity)) FROM (SELECT id, name, quantity FROM bin_items bi WHERE bi.bin_id = b.id ORDER BY bi.position) bi), '[]') AS items,
         b.tags, b.area_id, COALESCE(a.name, '') AS area_name, b.notes, b.icon, b.color,
@@ -25,11 +29,11 @@ async function fetchLocationData(locationId: string, userId: string, binIds?: st
        WHERE b.location_id = $1 AND b.deleted_at IS NULL`;
   const binsParams: string[] = [locationId, userId];
   if (binIds?.length) {
-    binsSql += ` AND b.id IN (${binIds.map((_, i) => `$${3 + i}`).join(', ')})`;
-    binsParams.push(...binIds);
+    const inClause = appendInClause(binsSql, 'b.id', 3, binIds);
+    binsSql = inClause.sql;
+    binsParams.push(...inClause.params);
   }
 
-  // Build custom fields query — scoped to same bins when filtering
   let cfSql = `SELECT v.bin_id, f.name AS field_name, v.value
        FROM bin_custom_field_values v
        JOIN location_custom_fields f ON f.id = v.field_id
@@ -37,8 +41,9 @@ async function fetchLocationData(locationId: string, userId: string, binIds?: st
        WHERE f.location_id = $1 AND b.deleted_at IS NULL`;
   const cfParams: string[] = [locationId];
   if (binIds?.length) {
-    cfSql += ` AND v.bin_id IN (${binIds.map((_, i) => `$${2 + i}`).join(', ')})`;
-    cfParams.push(...binIds);
+    const inClause = appendInClause(cfSql, 'v.bin_id', 2, binIds);
+    cfSql = inClause.sql;
+    cfParams.push(...inClause.params);
   }
 
   const [binsResult, areasResult, trashResult, cfResult] = await Promise.all([

--- a/server/src/lib/aiContext.ts
+++ b/server/src/lib/aiContext.ts
@@ -11,10 +11,9 @@ export const AVAILABLE_ICONS = [
 ];
 
 /** Fetch bins, areas, trash, and custom field data for a location. */
-async function fetchLocationData(locationId: string, userId: string) {
-  const [binsResult, areasResult, trashResult, cfResult] = await Promise.all([
-    query(
-      `SELECT b.id, b.name,
+async function fetchLocationData(locationId: string, userId: string, binIds?: string[]) {
+  // Build bins query — optionally scoped to specific bin IDs
+  let binsSql = `SELECT b.id, b.name,
         COALESCE((SELECT json_group_array(json_object('id', bi.id, 'name', bi.name, 'quantity', bi.quantity)) FROM (SELECT id, name, quantity FROM bin_items bi WHERE bi.bin_id = b.id ORDER BY bi.position) bi), '[]') AS items,
         b.tags, b.area_id, COALESCE(a.name, '') AS area_name, b.notes, b.icon, b.color,
         b.visibility,
@@ -23,9 +22,27 @@ async function fetchLocationData(locationId: string, userId: string) {
        FROM bins b
        LEFT JOIN areas a ON a.id = b.area_id
        LEFT JOIN pinned_bins pb ON pb.bin_id = b.id AND pb.user_id = $2
-       WHERE b.location_id = $1 AND b.deleted_at IS NULL`,
-      [locationId, userId]
-    ),
+       WHERE b.location_id = $1 AND b.deleted_at IS NULL`;
+  const binsParams: string[] = [locationId, userId];
+  if (binIds?.length) {
+    binsSql += ` AND b.id IN (${binIds.map((_, i) => `$${3 + i}`).join(', ')})`;
+    binsParams.push(...binIds);
+  }
+
+  // Build custom fields query — scoped to same bins when filtering
+  let cfSql = `SELECT v.bin_id, f.name AS field_name, v.value
+       FROM bin_custom_field_values v
+       JOIN location_custom_fields f ON f.id = v.field_id
+       JOIN bins b ON b.id = v.bin_id
+       WHERE f.location_id = $1 AND b.deleted_at IS NULL`;
+  const cfParams: string[] = [locationId];
+  if (binIds?.length) {
+    cfSql += ` AND v.bin_id IN (${binIds.map((_, i) => `$${2 + i}`).join(', ')})`;
+    cfParams.push(...binIds);
+  }
+
+  const [binsResult, areasResult, trashResult, cfResult] = await Promise.all([
+    query(binsSql, binsParams),
     query(
       'SELECT id, name FROM areas WHERE location_id = $1',
       [locationId]
@@ -34,14 +51,7 @@ async function fetchLocationData(locationId: string, userId: string) {
       'SELECT id, name FROM bins WHERE location_id = $1 AND deleted_at IS NOT NULL ORDER BY deleted_at DESC LIMIT 20',
       [locationId]
     ),
-    query<{ bin_id: string; field_name: string; value: string }>(
-      `SELECT v.bin_id, f.name AS field_name, v.value
-       FROM bin_custom_field_values v
-       JOIN location_custom_fields f ON f.id = v.field_id
-       JOIN bins b ON b.id = v.bin_id
-       WHERE f.location_id = $1 AND b.deleted_at IS NULL`,
-      [locationId]
-    ),
+    query<{ bin_id: string; field_name: string; value: string }>(cfSql, cfParams),
   ]);
 
   // Build a map: binId -> Record<fieldName, value>
@@ -61,8 +71,8 @@ function truncateNotes(notes: unknown): string {
 }
 
 /** Build context for command/execute endpoints. */
-export async function buildCommandContext(locationId: string, userId: string): Promise<CommandRequest['context']> {
-  const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId);
+export async function buildCommandContext(locationId: string, userId: string, binIds?: string[]): Promise<CommandRequest['context']> {
+  const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId, binIds);
 
   const bins = binsResult.rows.map((r) => {
     const binId = r.id as string;
@@ -98,8 +108,8 @@ export async function buildCommandContext(locationId: string, userId: string): P
 }
 
 /** Build context for the query (read-only) endpoint. */
-export async function buildInventoryContext(locationId: string, userId: string): Promise<InventoryContext> {
-  const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId);
+export async function buildInventoryContext(locationId: string, userId: string, binIds?: string[]): Promise<InventoryContext> {
+  const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId, binIds);
 
   return {
     bins: binsResult.rows.map((r) => {

--- a/server/src/lib/commandParser.ts
+++ b/server/src/lib/commandParser.ts
@@ -120,7 +120,7 @@ ${JSON.stringify({ bins, areas, trash_bins })}
  * Build a unified system prompt that handles both commands AND queries.
  * The AI returns `{ actions, interpretation }` for commands or `{ answer, matches }` for queries.
  */
-export function buildUnifiedSystemPrompt(request: CommandRequest, customCommandPrompt?: string, customQueryPrompt?: string, isDemoUser?: boolean): string {
+export function buildUnifiedSystemPrompt(request: CommandRequest, customCommandPrompt?: string, customQueryPrompt?: string, isDemoUser?: boolean, isScoped?: boolean): string {
   // Build the command half (action types, rules, examples)
   const commandPrompt = buildSystemPrompt(request, customCommandPrompt, isDemoUser);
 
@@ -145,7 +145,12 @@ Query rules:
 - When including trash bins in matches, set "is_trashed": true so the UI can link to the trash page instead of the bin detail page.
 
 ---
-
+${isScoped ? `
+SELECTION SCOPE:
+The user has selected specific bins to focus on. The inventory context below contains ONLY these selected bins.
+- For commands: apply actions only to these bins unless the user explicitly references other bins by name.
+- For questions: answer based only on the bins provided below.
+` : ''}
 RESPONSE FORMAT:
 - If the user input is a COMMAND (create, move, add, delete, rename, etc.), respond with: {"actions":[...],"interpretation":"..."}
 - If the user input is a QUESTION (where is, what's in, how many, do I have, etc.), respond with: {"answer":"...","matches":[{"bin_id":"...","name":"...","area_name":"...","items":["..."],"tags":["..."],"relevance":"...","is_trashed":false}]}

--- a/server/src/routes/aiStream.ts
+++ b/server/src/routes/aiStream.ts
@@ -70,6 +70,16 @@ function streamOpts(settings: UserAiSettings, overrides?: { maxTokens?: number; 
   };
 }
 
+/** Validate and sanitize optional binIds from request body. */
+function validateBinIds(binIds: unknown): string[] | undefined {
+  if (!binIds) return undefined;
+  if (!Array.isArray(binIds)) return undefined;
+  const valid = binIds
+    .filter((id): id is string => typeof id === 'string' && /^[a-zA-Z0-9]{1,10}$/.test(id))
+    .slice(0, 100);
+  return valid.length > 0 ? valid : undefined;
+}
+
 // POST /api/ai/query/stream
 streamRouter.post('/query/stream', aiLimiter, requirePro(), requireLocationMember(), aiRouteHandler('stream query', async (req, res) => {
   const question = validateTextInput(req.body.question, 'question');
@@ -110,15 +120,24 @@ streamRouter.post('/command/stream', aiLimiter, requirePro(), requireLocationMem
 // POST /api/ai/ask/stream — unified command+query endpoint
 streamRouter.post('/ask/stream', aiLimiter, requirePro(), requireLocationMember(), aiRouteHandler('stream ask', async (req, res) => {
   const text = validateTextInput(req.body.text, 'text');
-  const { locationId } = req.body;
+  const { locationId, binIds: rawBinIds } = req.body;
+  const binIds = validateBinIds(rawBinIds);
+
   const [{ settings, model }, context] = await Promise.all([
     resolveUserModel(req.user!.id, 'command', isDemoUser(req)),
-    buildCommandContext(locationId, req.user!.id),
+    buildCommandContext(locationId, req.user!.id, binIds),
   ]);
+
+  if (binIds?.length && context.bins.length === 0) {
+    const { ValidationError } = await import('../lib/httpErrors.js');
+    throw new ValidationError('No matching bins found for the provided IDs');
+  }
+
+  const isScoped = (binIds?.length ?? 0) > 0;
   const request: CommandRequest = { text, context };
 
   await pipeAiStreamToResponse(res, model, {
-    system: buildUnifiedSystemPrompt(request, settings.command_prompt ?? undefined, settings.query_prompt ?? undefined, isDemoUser(req)),
+    system: buildUnifiedSystemPrompt(request, settings.command_prompt ?? undefined, settings.query_prompt ?? undefined, isDemoUser(req), isScoped),
     userContent: buildCommandUserMsg(request),
     ...streamOpts(settings, { maxTokens: 2500, temperature: 0.2 }),
   });

--- a/src/features/ai/CommandIdleInput.tsx
+++ b/src/features/ai/CommandIdleInput.tsx
@@ -15,6 +15,7 @@ interface CommandIdleInputProps {
   onParse: () => void;
   onPhotoClick: () => void;
   onCameraClick?: () => void;
+  isScoped?: boolean;
 }
 
 export function CommandIdleInput({
@@ -27,8 +28,29 @@ export function CommandIdleInput({
   onParse,
   onPhotoClick,
   onCameraClick,
+  isScoped,
 }: CommandIdleInputProps) {
   const t = useTerminology();
+
+  const defaultExamples = [
+    { label: 'Add/remove items', example: 'Add screwdriver to the tools bin' },
+    { label: 'Organize', example: 'Move batteries from kitchen to garage' },
+    { label: `Manage ${t.bins}`, example: `Create a ${t.bin} called Holiday Decorations in the attic` },
+    { label: 'Quick actions', example: `Duplicate the tools ${t.bin}` },
+    { label: `Manage ${t.areas}`, example: `Rename the garage ${t.area} to workshop` },
+    { label: 'Find things', example: 'Where is the glass cleaner?' },
+    { label: 'Search trash', example: "What's in my trash?" },
+  ];
+
+  const scopedExamples = [
+    { label: 'Auto-tag', example: 'Auto-tag these based on their contents' },
+    { label: 'Find common', example: 'What do these have in common?' },
+    { label: 'Organize', example: `Move all of these to the Garage ${t.area}` },
+    { label: 'Rename', example: 'Suggest better names for these' },
+    { label: 'Search', example: 'Which of these contain electronics?' },
+  ];
+
+  const examples = isScoped ? scopedExamples : defaultExamples;
 
   return (
     <div className="space-y-3">
@@ -83,15 +105,7 @@ export function CommandIdleInput({
         </button>
         {examplesOpen && (
           <div className="grid gap-1 mt-1.5">
-            {[
-              { label: 'Add/remove items', example: 'Add screwdriver to the tools bin' },
-              { label: 'Organize', example: 'Move batteries from kitchen to garage' },
-              { label: `Manage ${t.bins}`, example: `Create a ${t.bin} called Holiday Decorations in the attic` },
-              { label: 'Quick actions', example: `Duplicate the tools ${t.bin}` },
-              { label: `Manage ${t.areas}`, example: `Rename the garage ${t.area} to workshop` },
-              { label: 'Find things', example: 'Where is the glass cleaner?' },
-              { label: 'Search trash', example: "What's in my trash?" },
-            ].map(({ label, example }) => (
+            {examples.map(({ label, example }) => (
               <p key={label}>
                 <span className="text-[var(--text-secondary)]">{label}</span>
                 {' — '}

--- a/src/features/ai/CommandIdleInput.tsx
+++ b/src/features/ai/CommandIdleInput.tsx
@@ -1,5 +1,5 @@
 import { Camera, ChevronDown, ImagePlus, Sparkles } from 'lucide-react';
-import type { Dispatch, SetStateAction } from 'react';
+import { type Dispatch, type SetStateAction, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useTerminology } from '@/lib/terminology';
@@ -32,7 +32,13 @@ export function CommandIdleInput({
 }: CommandIdleInputProps) {
   const t = useTerminology();
 
-  const defaultExamples = [
+  const examples = useMemo(() => isScoped ? [
+    { label: 'Auto-tag', example: 'Auto-tag these based on their contents' },
+    { label: 'Find common', example: 'What do these have in common?' },
+    { label: 'Organize', example: `Move all of these to the Garage ${t.area}` },
+    { label: 'Rename', example: 'Suggest better names for these' },
+    { label: 'Search', example: 'Which of these contain electronics?' },
+  ] : [
     { label: 'Add/remove items', example: 'Add screwdriver to the tools bin' },
     { label: 'Organize', example: 'Move batteries from kitchen to garage' },
     { label: `Manage ${t.bins}`, example: `Create a ${t.bin} called Holiday Decorations in the attic` },
@@ -40,17 +46,7 @@ export function CommandIdleInput({
     { label: `Manage ${t.areas}`, example: `Rename the garage ${t.area} to workshop` },
     { label: 'Find things', example: 'Where is the glass cleaner?' },
     { label: 'Search trash', example: "What's in my trash?" },
-  ];
-
-  const scopedExamples = [
-    { label: 'Auto-tag', example: 'Auto-tag these based on their contents' },
-    { label: 'Find common', example: 'What do these have in common?' },
-    { label: 'Organize', example: `Move all of these to the Garage ${t.area}` },
-    { label: 'Rename', example: 'Suggest better names for these' },
-    { label: 'Search', example: 'Which of these contain electronics?' },
-  ];
-
-  const examples = isScoped ? scopedExamples : defaultExamples;
+  ], [isScoped, t]);
 
   return (
     <div className="space-y-3">

--- a/src/features/ai/CommandInput.tsx
+++ b/src/features/ai/CommandInput.tsx
@@ -117,7 +117,7 @@ export function CommandInput({ open, onOpenChange, autoTriggerPhoto, selectedBin
         <input ref={fileInputRef} type="file" accept="image/*" multiple className="hidden" onChange={handlePhotoSelect} />
 
         {scopeInfo.isScoped && !photoMode && (
-          <div className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] bg-[var(--ai-accent)]/10 border border-[var(--ai-accent)]/20 px-3 py-2 text-[13px]">
+          <div className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] bg-[var(--ai-accent)]/10 border border-[var(--ai-accent)]/20 px-3 py-2 mb-1 text-[13px]">
             <span className="text-[var(--text-secondary)]">
               Focused on {scopeInfo.binCount} selected {scopeInfo.binCount === 1 ? t.bin : t.bins}
             </span>

--- a/src/features/ai/CommandInput.tsx
+++ b/src/features/ai/CommandInput.tsx
@@ -4,6 +4,7 @@ import { AiProgressBar } from '@/components/ui/ai-progress-bar';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { takeCapturedPhotos } from '@/features/capture/capturedPhotos';
+import { useTerminology } from '@/lib/terminology';
 import { CommandActionPreview } from './CommandActionPreview';
 import { CommandIdleInput } from './CommandIdleInput';
 import { CommandSuccess } from './CommandSuccess';
@@ -17,10 +18,12 @@ interface CommandInputProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   autoTriggerPhoto?: boolean;
+  selectedBinIds?: string[];
 }
 
-export function CommandInput({ open, onOpenChange, autoTriggerPhoto }: CommandInputProps) {
+export function CommandInput({ open, onOpenChange, autoTriggerPhoto, selectedBinIds }: CommandInputProps) {
   const navigate = useNavigate();
+  const t = useTerminology();
 
   const {
     text, setText,
@@ -38,7 +41,8 @@ export function CommandInput({ open, onOpenChange, autoTriggerPhoto }: CommandIn
     handleParse, handleBack, toggleAction,
     handleClose, handlePhotoSelect, handleBinClick,
     handleExecuteComplete, handleAskAnother, handleFollowUp,
-  } = useCommandInputState(onOpenChange);
+    scopeInfo,
+  } = useCommandInputState(onOpenChange, selectedBinIds);
 
   const { isExecuting, executingProgress, executeActions } = useActionExecutor({
     actions,
@@ -111,6 +115,21 @@ export function CommandInput({ open, onOpenChange, autoTriggerPhoto }: CommandIn
         </DialogHeader>
 
         <input ref={fileInputRef} type="file" accept="image/*" multiple className="hidden" onChange={handlePhotoSelect} />
+
+        {scopeInfo.isScoped && !photoMode && (
+          <div className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] bg-[var(--bg-secondary)] border border-[var(--border-primary)] px-3 py-2 text-[13px]">
+            <span className="text-[var(--text-secondary)]">
+              Focused on {scopeInfo.binCount} selected {scopeInfo.binCount === 1 ? t.bin : t.bins}
+            </span>
+            <button
+              type="button"
+              className="text-[var(--accent)] hover:underline whitespace-nowrap"
+              onClick={scopeInfo.clearScope}
+            >
+              Use all {t.bins} instead
+            </button>
+          </div>
+        )}
 
         {photoMode ? (
           <div key="photo" className="ai-content-enter">
@@ -188,6 +207,7 @@ export function CommandInput({ open, onOpenChange, autoTriggerPhoto }: CommandIn
               onParse={handleParse}
               onPhotoClick={() => fileInputRef.current?.click()}
               onCameraClick={handleCameraClick}
+              isScoped={scopeInfo.isScoped}
             />
           </div>
         )}

--- a/src/features/ai/CommandInput.tsx
+++ b/src/features/ai/CommandInput.tsx
@@ -117,13 +117,13 @@ export function CommandInput({ open, onOpenChange, autoTriggerPhoto, selectedBin
         <input ref={fileInputRef} type="file" accept="image/*" multiple className="hidden" onChange={handlePhotoSelect} />
 
         {scopeInfo.isScoped && !photoMode && (
-          <div className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] bg-[var(--bg-secondary)] border border-[var(--border-primary)] px-3 py-2 text-[13px]">
+          <div className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] bg-[var(--ai-accent)]/10 border border-[var(--ai-accent)]/20 px-3 py-2 text-[13px]">
             <span className="text-[var(--text-secondary)]">
               Focused on {scopeInfo.binCount} selected {scopeInfo.binCount === 1 ? t.bin : t.bins}
             </span>
             <button
               type="button"
-              className="text-[var(--accent)] hover:underline whitespace-nowrap"
+              className="text-[var(--ai-accent)] hover:underline whitespace-nowrap transition-colors"
               onClick={scopeInfo.clearScope}
             >
               Use all {t.bins} instead

--- a/src/features/ai/useCommandInputState.ts
+++ b/src/features/ai/useCommandInputState.ts
@@ -40,6 +40,7 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void, sele
     };
   }, [selectedBinIds, scopeOverride]);
 
+  const effectiveBinIds = scopeInfo.isScoped ? selectedBinIds : undefined;
   const isAiReady = settings !== null;
 
   // Derive querying state from streaming + query result
@@ -87,7 +88,6 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void, sele
     setQueryResult(null);
 
     try {
-      const effectiveBinIds = scopeInfo.isScoped ? selectedBinIds : undefined;
       const result = await ask({ text: text.trim(), locationId: activeLocationId, binIds: effectiveBinIds });
       if (result) applyAskResult(result);
     } catch (err) {

--- a/src/features/ai/useCommandInputState.ts
+++ b/src/features/ai/useCommandInputState.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/components/ui/toast';
 import { useAuth } from '@/lib/auth';
@@ -12,7 +12,7 @@ import { useStreamingAsk } from './useStreamingAsk';
 
 type State = 'idle' | 'parsing' | 'preview' | 'executing' | 'querying' | 'query-result' | 'success';
 
-export function useCommandInputState(onOpenChange: (open: boolean) => void) {
+export function useCommandInputState(onOpenChange: (open: boolean) => void, selectedBinIds?: string[]) {
   const t = useTerminology();
   const { activeLocationId } = useAuth();
   const navigate = useNavigate();
@@ -29,6 +29,16 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void) {
   const [examplesOpen, setExamplesOpen] = useState(false);
   const [executionResult, setExecutionResult] = useState<ExecutionResult | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [scopeOverride, setScopeOverride] = useState(false);
+
+  const scopeInfo = useMemo(() => {
+    const isScoped = !scopeOverride && (selectedBinIds?.length ?? 0) > 0;
+    return {
+      binCount: selectedBinIds?.length ?? 0,
+      isScoped,
+      clearScope: () => setScopeOverride(true),
+    };
+  }, [selectedBinIds, scopeOverride]);
 
   const isAiReady = settings !== null;
 
@@ -77,7 +87,8 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void) {
     setQueryResult(null);
 
     try {
-      const result = await ask({ text: text.trim(), locationId: activeLocationId });
+      const effectiveBinIds = scopeInfo.isScoped ? selectedBinIds : undefined;
+      const result = await ask({ text: text.trim(), locationId: activeLocationId, binIds: effectiveBinIds });
       if (result) applyAskResult(result);
     } catch (err) {
       showToast({ message: mapAiError(err, 'Request failed') });
@@ -114,6 +125,7 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void) {
       setExecutionResult(null);
       setPhotoMode(false);
       setInitialFiles([]);
+      setScopeOverride(false);
     }
     onOpenChange(v);
   }
@@ -164,7 +176,8 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void) {
     setText(followUpText);
 
     try {
-      const result = await ask({ text: contextPrefix + followUpText, locationId: activeLocationId });
+      const effectiveBinIds = scopeInfo.isScoped ? selectedBinIds : undefined;
+      const result = await ask({ text: contextPrefix + followUpText, locationId: activeLocationId, binIds: effectiveBinIds });
       if (result) applyAskResult(result);
     } catch (err) {
       showToast({ message: mapAiError(err, 'Request failed') });
@@ -214,6 +227,7 @@ export function useCommandInputState(onOpenChange: (open: boolean) => void) {
     handleExecuteComplete,
     handleAskAnother,
     handleFollowUp,
+    scopeInfo,
   };
 }
 

--- a/src/features/ai/useStreamingAsk.ts
+++ b/src/features/ai/useStreamingAsk.ts
@@ -57,7 +57,7 @@ export function useStreamingAsk() {
   );
 
   const ask = useCallback(
-    (options: { text: string; locationId: string }) => stream(options),
+    (options: { text: string; locationId: string; binIds?: string[] }) => stream(options),
     [stream]
   );
 

--- a/src/features/bins/BinListDialogs.tsx
+++ b/src/features/bins/BinListDialogs.tsx
@@ -38,6 +38,7 @@ interface BinListDialogsProps {
   bulk: { isOpen: (d: BulkDialog) => boolean; open: (d: BulkDialog) => void; close: () => void };
   selectedIds: Set<string>;
   clearSelection: () => void;
+  selectedBinIds?: string[];
 }
 
 export function BinListDialogs({
@@ -48,7 +49,7 @@ export function BinListDialogs({
   aiEnabled, allTags, areas,
   filters, setFilters,
   sort, setSort, sortDir, setSortDir, search,
-  bulk, selectedIds, clearSelection,
+  bulk, selectedIds, clearSelection, selectedBinIds,
 }: BinListDialogsProps) {
   const commandMounted = useRef(false);
   if (commandOpen) commandMounted.current = true;
@@ -122,7 +123,7 @@ export function BinListDialogs({
       />
       {aiEnabled && commandMounted.current && (
         <Suspense fallback={null}>
-          <CommandInput open={commandOpen} onOpenChange={setCommandOpen} />
+          <CommandInput open={commandOpen} onOpenChange={setCommandOpen} selectedBinIds={selectedBinIds} />
         </Suspense>
       )}
     </>

--- a/src/features/bins/BinListPage.tsx
+++ b/src/features/bins/BinListPage.tsx
@@ -346,6 +346,7 @@ export function BinListPage() {
         bulk={bulk}
         selectedIds={selectedIds}
         clearSelection={clearSelection}
+        selectedBinIds={selectedIds.size > 0 ? [...selectedIds] : undefined}
       />
 
       <DeleteBinDialog
@@ -375,6 +376,9 @@ export function BinListPage() {
           onPasteStyle={handlePasteStyle}
           canCopyStyle={selectedIds.size === 1}
           canPasteStyle={copiedStyle !== null}
+          aiEnabled={aiEnabled}
+          onAskAi={() => setCommandOpen(true)}
+          onReorganize={() => navigate(`/reorganize?ids=${[...selectedIds].join(',')}`)}
         />
       )}
     </div>

--- a/src/features/bins/BinListPage.tsx
+++ b/src/features/bins/BinListPage.tsx
@@ -5,7 +5,7 @@ import {
   ScanLine,
   Sparkles,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
@@ -98,6 +98,7 @@ export function BinListPage() {
   const { selectedIds, selectable, toggleSelect, clearSelection } = useBulkSelection(bins, [debouncedSearch, sort, sortDir, filters]);
   const { bulkDelete, bulkPinToggle, bulkDuplicate, pinLabel } = useBulkActions(bins, selectedIds, clearSelection, showToast, t);
 
+  const selectedBinIds = useMemo(() => selectedIds.size > 0 ? [...selectedIds] : undefined, [selectedIds]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [copiedStyle, setCopiedStyle] = useState<{ icon: string; color: string; card_style: string } | null>(null);
 
@@ -346,7 +347,7 @@ export function BinListPage() {
         bulk={bulk}
         selectedIds={selectedIds}
         clearSelection={clearSelection}
-        selectedBinIds={selectedIds.size > 0 ? [...selectedIds] : undefined}
+        selectedBinIds={selectedBinIds}
       />
 
       <DeleteBinDialog

--- a/src/features/bins/BulkActionBar.tsx
+++ b/src/features/bins/BulkActionBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, CheckCircle2, Clipboard, ClipboardPaste, Copy, Eye, List, MapPin, MoreHorizontal, Paintbrush, Pin, Tag, Trash2, X } from 'lucide-react';
+import { ArrowRightLeft, CheckCircle2, Clipboard, ClipboardPaste, Copy, Eye, List, MapPin, MoreHorizontal, Paintbrush, Pin, Shuffle, Sparkles, Tag, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -24,9 +24,12 @@ interface BulkActionBarProps {
   onCustomFields?: () => void;
   canCopyStyle?: boolean;
   canPasteStyle?: boolean;
+  aiEnabled?: boolean;
+  onAskAi?: () => void;
+  onReorganize?: () => void;
 }
 
-export function BulkActionBar({ selectedCount, isAdmin, canWrite = true, onTag, onMove, onDelete, onClear, onAppearance, onVisibility, onMoveLocation, onPin, onDuplicate, pinLabel, onCustomFields, onCopyStyle, onPasteStyle, canCopyStyle, canPasteStyle }: BulkActionBarProps) {
+export function BulkActionBar({ selectedCount, isAdmin, canWrite = true, onTag, onMove, onDelete, onClear, onAppearance, onVisibility, onMoveLocation, onPin, onDuplicate, pinLabel, onCustomFields, onCopyStyle, onPasteStyle, canCopyStyle, canPasteStyle, aiEnabled, onAskAi, onReorganize }: BulkActionBarProps) {
   const [moreOpen, setMoreOpen] = useState(false);
   const [visible, setVisible] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
@@ -98,6 +101,20 @@ export function BulkActionBar({ selectedCount, isAdmin, canWrite = true, onTag, 
           </Button>
         </Tooltip>
       )}
+      {aiEnabled && onAskAi && (
+        <Tooltip content="AI" side="top">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 px-2 sm:px-3"
+            onClick={onAskAi}
+            aria-label="AI"
+          >
+            <Sparkles className="h-3.5 w-3.5 sm:mr-1.5" />
+            <span className="hidden sm:inline">AI</span>
+          </Button>
+        </Tooltip>
+      )}
       {isAdmin && (
         <div className="relative" ref={moreRef}>
           <Tooltip content="More actions" side="top">
@@ -153,6 +170,16 @@ export function BulkActionBar({ selectedCount, isAdmin, canWrite = true, onTag, 
                 <Copy className="h-4 w-4 text-[var(--text-tertiary)]" />
                 Duplicate
               </button>
+              {aiEnabled && onReorganize && (
+                <button
+                  type="button"
+                  className="flex items-center gap-2.5 w-full px-3.5 py-2 text-[13px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
+                  onClick={() => handleMoreAction(onReorganize)}
+                >
+                  <Shuffle className="h-4 w-4 text-[var(--text-tertiary)]" />
+                  Reorganize
+                </button>
+              )}
               {onCustomFields && (
                 <button
                   type="button"

--- a/src/features/bins/BulkActionBar.tsx
+++ b/src/features/bins/BulkActionBar.tsx
@@ -101,7 +101,7 @@ export function BulkActionBar({ selectedCount, isAdmin, canWrite = true, onTag, 
           </Button>
         </Tooltip>
       )}
-      {aiEnabled && onAskAi && (
+      {aiEnabled && canWrite && onAskAi && (
         <Tooltip content="AI" side="top">
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary

- Adds AI and Reorganize actions to the bulk action bar in `BinListPage`
- Scopes AI context to selected bins via `binIds` filtering through the ask/stream pipeline
- Adds a context banner to `CommandInput` showing the number of selected bins
- Guards AI button behind `canWrite` permission check

## Test plan

- [ ] Select multiple bins in bin list view
- [ ] Click AI button in bulk action bar — verify context banner shows selected bin count
- [ ] Submit an AI query — verify response is scoped to selected bins only
- [ ] Click Reorganize in bulk action bar — verify it opens with selected bins
- [ ] Verify AI button is hidden for viewer-role users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI commands now support scoping to selected bins with a "Focused on N selected bins" indicator and ability to clear scope
  * New "AI" button in bulk action bar for quick AI access to selected bins
  * New "Reorganize" option in bulk action menu
  * AI command suggestions and validation now dynamically adapt based on bin scoping
  * Added validation for bin selection inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->