### PR TITLE
feat: externalize commercial config for private deploy repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,36 +75,3 @@
 # CORS_ORIGIN=http://localhost:5173  # Only needed for non-Docker dev setups
 # TRUST_PROXY=false                  # Set to true when behind a reverse proxy (nginx, Caddy, etc.)
 # FRAME_ANCESTORS=                    # Space-separated origins allowed to embed in iframe
-
-# ── Cloud / Commercial ───────────────────────
-# These settings are only relevant for managed cloud deployments (SELF_HOSTED=false).
-# Self-hosted users can ignore this entire section.
-# SELF_HOSTED=true                    # Set to false for managed cloud deployments
-# MANAGER_URL=                        # Subscription manager service URL
-# SUBSCRIPTION_JWT_SECRET=            # Shared secret for user↔manager JWT tokens
-# SUBSCRIPTION_WEBHOOK_SECRET=        # Shared secret for manager→app webhook JWT
-# TRIAL_PERIOD_DAYS=7                 # Pro trial length (1–90)
-
-# ── Plan Limits (cloud only) ─────────────────
-# Override plan feature gates and limits. Only applies when SELF_HOSTED=false.
-# Set numeric limits to 0 for unlimited.
-# PLAN_LITE_AI=false
-# PLAN_LITE_API_KEYS=false
-# PLAN_LITE_CUSTOM_FIELDS=false
-# PLAN_LITE_FULL_EXPORT=false
-# PLAN_LITE_REORGANIZE=false
-# PLAN_LITE_BIN_SHARING=false
-# PLAN_LITE_MAX_LOCATIONS=1
-# PLAN_LITE_MAX_STORAGE_MB=100
-# PLAN_LITE_MAX_MEMBERS=1
-# PLAN_LITE_ACTIVITY_RETENTION_DAYS=30
-# PLAN_PRO_MAX_STORAGE_MB=5000
-# PLAN_PRO_ACTIVITY_RETENTION_DAYS=90
-
-# ── Email Templates ──────────────────────────
-# EMAIL_TEMPLATE_DIR=                 # Path to directory of JSON template overrides
-
-# ── Demo Mode ────────────────────────────────
-# DEMO_MODE=false
-# DEMO_SEED_PATH=                     # Path to JSON file with demo seed data
-# DEMO_USERNAMES=                     # Comma-separated demo usernames

--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,36 @@
 # CORS_ORIGIN=http://localhost:5173  # Only needed for non-Docker dev setups
 # TRUST_PROXY=false                  # Set to true when behind a reverse proxy (nginx, Caddy, etc.)
 # FRAME_ANCESTORS=                    # Space-separated origins allowed to embed in iframe
+
+# ── Cloud / Commercial ───────────────────────
+# These settings are only relevant for managed cloud deployments (SELF_HOSTED=false).
+# Self-hosted users can ignore this entire section.
+# SELF_HOSTED=true                    # Set to false for managed cloud deployments
+# MANAGER_URL=                        # Subscription manager service URL
+# SUBSCRIPTION_JWT_SECRET=            # Shared secret for user↔manager JWT tokens
+# SUBSCRIPTION_WEBHOOK_SECRET=        # Shared secret for manager→app webhook JWT
+# TRIAL_PERIOD_DAYS=7                 # Pro trial length (1–90)
+
+# ── Plan Limits (cloud only) ─────────────────
+# Override plan feature gates and limits. Only applies when SELF_HOSTED=false.
+# Set numeric limits to 0 for unlimited.
+# PLAN_LITE_AI=false
+# PLAN_LITE_API_KEYS=false
+# PLAN_LITE_CUSTOM_FIELDS=false
+# PLAN_LITE_FULL_EXPORT=false
+# PLAN_LITE_REORGANIZE=false
+# PLAN_LITE_BIN_SHARING=false
+# PLAN_LITE_MAX_LOCATIONS=1
+# PLAN_LITE_MAX_STORAGE_MB=100
+# PLAN_LITE_MAX_MEMBERS=1
+# PLAN_LITE_ACTIVITY_RETENTION_DAYS=30
+# PLAN_PRO_MAX_STORAGE_MB=5000
+# PLAN_PRO_ACTIVITY_RETENTION_DAYS=90
+
+# ── Email Templates ──────────────────────────
+# EMAIL_TEMPLATE_DIR=                 # Path to directory of JSON template overrides
+
+# ── Demo Mode ────────────────────────────────
+# DEMO_MODE=false
+# DEMO_SEED_PATH=                     # Path to JSON file with demo seed data
+# DEMO_USERNAMES=                     # Comma-separated demo usernames

--- a/docs/specs/2026-04-01-commercial-externalization-design.md
+++ b/docs/specs/2026-04-01-commercial-externalization-design.md
@@ -1,0 +1,210 @@
+# Commercial Configuration Externalization
+
+Externalize hardcoded commercial values from the public OpenBin repo so they can be managed in a private deploy repo. Three independent areas: plan limits, email templates, and demo seed data.
+
+## Approach
+
+Extend the existing `config.ts` env var pattern. Plan limits become env vars with current values as defaults. Email templates and demo data become loadable from external files via path env vars. All changes are backwards compatible — existing deployments need zero configuration changes.
+
+## 1. Plan Limits via Env Vars
+
+### Problem
+
+`planGate.ts` hardcodes Lite/Pro feature limits (1 location, 100MB storage, etc.). These are pricing/packaging decisions that belong in the private deploy repo.
+
+### Env Vars
+
+| Env Var | Default | Type |
+|---|---|---|
+| `PLAN_LITE_AI` | `false` | boolean |
+| `PLAN_LITE_API_KEYS` | `false` | boolean |
+| `PLAN_LITE_CUSTOM_FIELDS` | `false` | boolean |
+| `PLAN_LITE_FULL_EXPORT` | `false` | boolean |
+| `PLAN_LITE_REORGANIZE` | `false` | boolean |
+| `PLAN_LITE_BIN_SHARING` | `false` | boolean |
+| `PLAN_LITE_MAX_LOCATIONS` | `1` | number (null = unlimited) |
+| `PLAN_LITE_MAX_STORAGE_MB` | `100` | number (null = unlimited) |
+| `PLAN_LITE_MAX_MEMBERS` | `1` | number (null = unlimited) |
+| `PLAN_LITE_ACTIVITY_RETENTION_DAYS` | `30` | number (null = unlimited) |
+| `PLAN_PRO_MAX_STORAGE_MB` | `5000` | number (null = unlimited) |
+| `PLAN_PRO_ACTIVITY_RETENTION_DAYS` | `90` | number (null = unlimited) |
+
+### Files Changed
+
+- **`server/src/lib/config.ts`**: Add `planLimits` object parsed from env vars.
+- **`server/src/lib/planGate.ts`**: Replace hardcoded values in `getFeatureMap()` with `config.planLimits.*`.
+
+### Behavior
+
+- Self-hosted mode unchanged: `isSelfHosted()` returns `UNRESTRICTED`, bypassing plan limits entirely.
+- Pro features remain unrestricted except for storage and activity retention.
+- Defaults match current hardcoded values — no behavior change without explicit env var overrides.
+- For numeric limits, `0` or empty string means unlimited (maps to `null` in `PlanFeatures`). This lets the deploy repo override a limit to "no limit" without code changes.
+
+## 2. Email Templates from External Directory
+
+### Problem
+
+`emailTemplates.ts` contains 11 template functions with hardcoded HTML/text for lifecycle emails (trial expiring, upgrade nudges, etc.). The copy and conversion funnel strategy is commercial IP.
+
+### Env Var
+
+| Env Var | Default | Purpose |
+|---|---|---|
+| `EMAIL_TEMPLATE_DIR` | `null` | Path to directory of template override JSON files |
+
+### Template File Format
+
+Each template is a JSON file named after its type (e.g., `welcome.json`):
+
+```json
+{
+  "subject": "Welcome to OpenBin",
+  "html": "<html>...{{displayName}}...{{loginUrl}}...</html>",
+  "text": "Hi {{displayName}},\n\nWelcome..."
+}
+```
+
+Simple `{{variable}}` placeholder substitution. No template engine dependency.
+
+### Template Types (11 total)
+
+| Type | Variables |
+|---|---|
+| `welcome` | `displayName`, `loginUrl` |
+| `trial_expiring` | `displayName`, `expiryDate`, `upgradeUrl` |
+| `trial_expired` | `displayName`, `upgradeUrl` |
+| `subscription_confirmed` | `displayName`, `plan`, `activeUntil` |
+| `subscription_expired` | `displayName`, `upgradeUrl` |
+| `subscription_expiring` | `displayName`, `expiryDate`, `upgradeUrl` |
+| `explore_features` | `displayName`, `dashboardUrl` |
+| `post_trial_early` | `displayName`, `upgradeUrl` |
+| `post_trial_late` | `displayName`, `upgradeUrl` |
+| `password_reset` | `displayName`, `resetUrl` |
+| `downgrade_impact` | `displayName`, `upgradeUrl`, `impactHtml`, `impactText` |
+
+Note: `downgrade_impact` is special — the impact details (location/member/storage overages) are computed at send time and passed as pre-rendered `impactHtml`/`impactText` variables, since the logic is complex and data-dependent.
+
+### Loading Behavior
+
+1. On startup, if `EMAIL_TEMPLATE_DIR` is set, read all `.json` files from the directory into a `Map<string, template>`.
+2. Per-send: if an override exists for that template type, use it with variable substitution. Otherwise fall back to the built-in template function.
+3. Invalid/missing files log a warning but don't crash — graceful degradation to built-in templates.
+
+### Files Changed
+
+- **`server/src/lib/config.ts`**: Add `emailTemplateDir`.
+- **New `server/src/lib/emailTemplateLoader.ts`**: Reads directory on startup, provides `getTemplateOverride(type, variables)` function.
+- **`server/src/lib/emailSender.ts`**: Each `fire*` function checks for an override before calling the built-in template function.
+
+Built-in templates stay in the repo as working defaults.
+
+## 3. Demo Seed Data from External File
+
+### Problem
+
+`demoSeedData.ts` contains ~400+ lines of inline demo data (50+ bins, 5 users, areas, tags, etc.). This content is specific to the commercial demo instance.
+
+### Env Var
+
+| Env Var | Default | Purpose |
+|---|---|---|
+| `DEMO_SEED_PATH` | `null` | Path to a JSON file containing all demo data |
+
+### JSON File Structure
+
+```json
+{
+  "users": { "demo": "Demo User", "sarah": "Sarah Chen" },
+  "locations": { "home": "Our House", "storage": "Self Storage Unit" },
+  "homeAreas": ["Kitchen", "Garage"],
+  "nestedAreas": { "Kitchen": ["Pantry", "Under Sink"] },
+  "storageAreas": ["Unit A"],
+  "bins": [
+    {
+      "name": "Spice Rack",
+      "location": "home",
+      "area": "Kitchen",
+      "items": ["Cumin", { "name": "Salt", "quantity": 2 }],
+      "tags": ["cooking"],
+      "notes": "Top shelf spices",
+      "icon": "...",
+      "color": "#...",
+      "cardStyle": "...",
+      "createdBy": "demo",
+      "visibility": "location"
+    }
+  ],
+  "trashedBins": [],
+  "tagColors": { "cooking": "#e74c3c" },
+  "pinnedBinNames": ["Spice Rack"],
+  "pinnedBinNamesPat": [],
+  "scannedBinNames": { "demo": ["Spice Rack"], "sarah": [] },
+  "customFieldDefinitions": [{ "name": "Location Bought", "position": 0 }],
+  "customFieldValues": { "Spice Rack": { "Location Bought": "Amazon" } },
+  "activityEntries": []
+}
+```
+
+### Loading Behavior
+
+1. At the top of `seedDemoData()`, if `DEMO_SEED_PATH` is set, read and parse the JSON file.
+2. If not set, fall back to the existing inline `demoSeedData.ts` constants.
+3. JSON validation: check required top-level keys exist. Log error and skip seeding if malformed.
+4. `demoSeed.ts` gets a thin adapter function that normalizes both sources into the same shape consumed by the existing seeding functions.
+
+### Files Changed
+
+- **`server/src/lib/config.ts`**: Add `demoSeedPath`.
+- **`server/src/lib/demoSeed.ts`**: Add conditional loading at the top of `seedDemoData()`. Existing seeding logic unchanged.
+- **`server/src/lib/demoSeedData.ts`**: No changes. Remains the built-in default.
+
+### Export Helper
+
+Add a Node script at `server/scripts/export-demo-data.ts` that imports the inline constants from `demoSeedData.ts` and writes them as JSON to stdout. Usage: `npx tsx server/scripts/export-demo-data.ts > demo-data.json`.
+
+## Private Deploy Repo Structure
+
+After implementation, the private `openbin-deploy` repo would contain:
+
+```
+openbin-deploy/
+├── docker-compose.yml       # Orchestrates all services
+├── Caddyfile                # Reverse proxy with auto-TLS
+├── .env.production          # Plan limits + all secrets
+├── email-templates/         # JSON template overrides
+│   ├── welcome.json
+│   ├── trial_expiring.json
+│   ├── trial_expired.json
+│   └── ...
+├── demo-data.json           # Demo seed data
+└── .github/workflows/
+    └── deploy.yml           # CD pipeline
+```
+
+Docker compose mounts the templates and demo data into the container:
+
+```yaml
+services:
+  openbin:
+    image: ghcr.io/akifbayram/openbin:latest
+    volumes:
+      - ./email-templates:/app/email-templates:ro
+      - ./demo-data.json:/app/demo-data.json:ro
+    environment:
+      EMAIL_TEMPLATE_DIR: /app/email-templates
+      DEMO_SEED_PATH: /app/demo-data.json
+      # Plan limits from .env.production
+```
+
+## Testing
+
+- **Plan limits**: Unit test `getFeatureMap()` with mocked config values to verify env vars flow through.
+- **Email templates**: Unit test `getTemplateOverride()` with a temp directory containing test JSON files.
+- **Demo seed**: Existing demo seed tests continue to pass (they use inline defaults). Add a test that loads from a JSON file.
+
+## Not in Scope
+
+- Extracting email template _code_ (the `wrap()`, `btn()`, `featureCard()` helpers) — only the content is externalized.
+- Moving plan/subscription _logic_ (trial checker, webhook routes) — those stay in the app, gated by `SELF_HOSTED`.
+- Creating the private deploy repo itself — that's a separate task.

--- a/server/scripts/export-demo-data.ts
+++ b/server/scripts/export-demo-data.ts
@@ -1,0 +1,43 @@
+import {
+  CUSTOM_FIELD_DEFINITIONS,
+  CUSTOM_FIELD_VALUES,
+  DEMO_ACTIVITY_ENTRIES,
+  DEMO_BINS,
+  DEMO_USERS,
+  HOME_AREAS,
+  NESTED_AREAS,
+  PINNED_BIN_NAMES,
+  PINNED_BIN_NAMES_PAT,
+  SCANNED_BIN_NAMES,
+  SCANNED_BIN_NAMES_ALEX,
+  SCANNED_BIN_NAMES_PAT,
+  SCANNED_BIN_NAMES_SARAH,
+  STORAGE_AREAS,
+  TAG_COLORS,
+  TRASHED_BINS,
+} from '../src/lib/demoSeedData.js';
+
+const data = {
+  users: DEMO_USERS,
+  locations: { home: 'Our House', storage: 'Self Storage Unit' },
+  homeAreas: HOME_AREAS,
+  nestedAreas: NESTED_AREAS,
+  storageAreas: STORAGE_AREAS,
+  bins: DEMO_BINS,
+  trashedBins: TRASHED_BINS,
+  tagColors: TAG_COLORS,
+  pinnedBinNames: PINNED_BIN_NAMES,
+  pinnedBinNamesPat: PINNED_BIN_NAMES_PAT,
+  scannedBinNames: {
+    demo: SCANNED_BIN_NAMES,
+    sarah: SCANNED_BIN_NAMES_SARAH,
+    alex: SCANNED_BIN_NAMES_ALEX,
+    pat: SCANNED_BIN_NAMES_PAT,
+  },
+  customFieldDefinitions: CUSTOM_FIELD_DEFINITIONS,
+  customFieldValues: CUSTOM_FIELD_VALUES,
+  activityEntries: DEMO_ACTIVITY_ENTRIES,
+};
+
+process.stdout.write(JSON.stringify(data, null, 2));
+process.stdout.write('\n');

--- a/server/src/__tests__/planGate.test.ts
+++ b/server/src/__tests__/planGate.test.ts
@@ -8,6 +8,20 @@ vi.mock('../lib/config.js', () => ({
     managerUrl: null as string | null,
     subscriptionJwtSecret: null as string | null,
     jwtSecret: 'test-jwt-secret',
+    planLimits: {
+      liteAi: false,
+      liteApiKeys: false,
+      liteCustomFields: false,
+      liteFullExport: false,
+      liteReorganize: false,
+      liteBinSharing: false,
+      liteMaxLocations: 1,
+      liteMaxStorageMb: 100,
+      liteMaxMembers: 1,
+      liteActivityRetentionDays: 30,
+      proMaxStorageMb: 5000,
+      proActivityRetentionDays: 90,
+    },
   },
 }));
 
@@ -35,6 +49,22 @@ import {
   Plan,
   SubStatus,
 } from '../lib/planGate.js';
+
+// Default plan limits matching config.ts defaults
+const DEFAULT_PLAN_LIMITS = {
+  liteAi: false,
+  liteApiKeys: false,
+  liteCustomFields: false,
+  liteFullExport: false,
+  liteReorganize: false,
+  liteBinSharing: false,
+  liteMaxLocations: 1,
+  liteMaxStorageMb: 100,
+  liteMaxMembers: 1,
+  liteActivityRetentionDays: 30,
+  proMaxStorageMb: 5000,
+  proActivityRetentionDays: 90,
+};
 
 // Helper to set config values for tests
 function setConfig(overrides: Partial<typeof config>) {
@@ -192,6 +222,86 @@ describe('getFeatureMap()', () => {
   });
 });
 
+describe('getFeatureMap() with custom plan limits', () => {
+  it('uses custom Lite limits from config', () => {
+    setConfig({
+      selfHosted: false,
+      planLimits: {
+        liteAi: true,
+        liteApiKeys: true,
+        liteCustomFields: false,
+        liteFullExport: false,
+        liteReorganize: false,
+        liteBinSharing: false,
+        liteMaxLocations: 3,
+        liteMaxStorageMb: 500,
+        liteMaxMembers: 5,
+        liteActivityRetentionDays: 60,
+        proMaxStorageMb: 5000,
+        proActivityRetentionDays: 90,
+      },
+    });
+    const features = getFeatureMap(Plan.LITE);
+    expect(features.ai).toBe(true);
+    expect(features.apiKeys).toBe(true);
+    expect(features.customFields).toBe(false);
+    expect(features.maxLocations).toBe(3);
+    expect(features.maxPhotoStorageMb).toBe(500);
+    expect(features.maxMembersPerLocation).toBe(5);
+    expect(features.activityRetentionDays).toBe(60);
+  });
+
+  it('uses custom Pro limits from config', () => {
+    setConfig({
+      selfHosted: false,
+      planLimits: {
+        liteAi: false,
+        liteApiKeys: false,
+        liteCustomFields: false,
+        liteFullExport: false,
+        liteReorganize: false,
+        liteBinSharing: false,
+        liteMaxLocations: 1,
+        liteMaxStorageMb: 100,
+        liteMaxMembers: 1,
+        liteActivityRetentionDays: 30,
+        proMaxStorageMb: 10000,
+        proActivityRetentionDays: 365,
+      },
+    });
+    const features = getFeatureMap(Plan.PRO);
+    expect(features.maxPhotoStorageMb).toBe(10000);
+    expect(features.activityRetentionDays).toBe(365);
+    expect(features.maxLocations).toBe(null);
+    expect(features.ai).toBe(true);
+  });
+
+  it('null plan limits mean unlimited', () => {
+    setConfig({
+      selfHosted: false,
+      planLimits: {
+        liteAi: false,
+        liteApiKeys: false,
+        liteCustomFields: false,
+        liteFullExport: false,
+        liteReorganize: false,
+        liteBinSharing: false,
+        liteMaxLocations: null,
+        liteMaxStorageMb: null,
+        liteMaxMembers: null,
+        liteActivityRetentionDays: null,
+        proMaxStorageMb: null,
+        proActivityRetentionDays: null,
+      },
+    });
+    const features = getFeatureMap(Plan.LITE);
+    expect(features.maxLocations).toBe(null);
+    expect(features.maxPhotoStorageMb).toBe(null);
+    expect(features.maxMembersPerLocation).toBe(null);
+    expect(features.activityRetentionDays).toBe(null);
+  });
+});
+
 describe('getUserPlanInfo()', () => {
   beforeEach(() => {
     vi.mocked(query).mockReset();
@@ -294,8 +404,11 @@ describe('generateUpgradeUrl()', () => {
 });
 
 describe('computeOverLimits()', () => {
+  beforeEach(() => {
+    setConfig({ selfHosted: false, planLimits: { ...DEFAULT_PLAN_LIMITS } });
+  });
+
   it('returns all false when under limits', () => {
-    setConfig({ selfHosted: false });
     const result = computeOverLimits(
       { locationCount: 1, photoStorageMb: 50, memberCounts: { loc1: 1 } },
       { ...getFeatureMap(Plan.LITE) },
@@ -304,7 +417,6 @@ describe('computeOverLimits()', () => {
   });
 
   it('returns locations=true when over location limit', () => {
-    setConfig({ selfHosted: false });
     const result = computeOverLimits(
       { locationCount: 3, photoStorageMb: 50, memberCounts: {} },
       { ...getFeatureMap(Plan.LITE) },
@@ -313,7 +425,6 @@ describe('computeOverLimits()', () => {
   });
 
   it('returns photos=true when over photo storage limit', () => {
-    setConfig({ selfHosted: false });
     const result = computeOverLimits(
       { locationCount: 1, photoStorageMb: 200, memberCounts: {} },
       { ...getFeatureMap(Plan.LITE) },
@@ -322,7 +433,6 @@ describe('computeOverLimits()', () => {
   });
 
   it('returns member locationIds when over member limit', () => {
-    setConfig({ selfHosted: false });
     const result = computeOverLimits(
       { locationCount: 1, photoStorageMb: 50, memberCounts: { loc1: 5, loc2: 1 } },
       { ...getFeatureMap(Plan.LITE) },
@@ -331,7 +441,6 @@ describe('computeOverLimits()', () => {
   });
 
   it('returns all false when limits are null (unlimited)', () => {
-    setConfig({ selfHosted: false });
     const result = computeOverLimits(
       { locationCount: 100, photoStorageMb: 9999, memberCounts: { loc1: 999 } },
       { ...getFeatureMap(Plan.PRO), maxPhotoStorageMb: null },
@@ -342,7 +451,7 @@ describe('computeOverLimits()', () => {
 
 describe('getUserOverLimits() with cache', () => {
   beforeEach(() => {
-    setConfig({ selfHosted: false });
+    setConfig({ selfHosted: false, planLimits: { ...DEFAULT_PLAN_LIMITS } });
     invalidateOverLimitCache('user1');
     vi.mocked(query).mockReset();
   });
@@ -381,7 +490,7 @@ describe('getUserOverLimits() with cache', () => {
 
 describe('checkLocationWritable()', () => {
   beforeEach(() => {
-    setConfig({ selfHosted: false });
+    setConfig({ selfHosted: false, planLimits: { ...DEFAULT_PLAN_LIMITS } });
     invalidateOverLimitCache('owner1');
     vi.mocked(query).mockReset();
   });
@@ -418,7 +527,7 @@ describe('checkLocationWritable()', () => {
 
 describe('getEffectiveMemberRole()', () => {
   beforeEach(() => {
-    setConfig({ selfHosted: false });
+    setConfig({ selfHosted: false, planLimits: { ...DEFAULT_PLAN_LIMITS } });
     invalidateOverLimitCache('owner1');
     vi.mocked(query).mockReset();
   });

--- a/server/src/lib/__tests__/emailTemplateLoader.test.ts
+++ b/server/src/lib/__tests__/emailTemplateLoader.test.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config.js', () => ({
+  config: {
+    emailTemplateDir: null as string | null,
+  },
+}));
+
+import { config } from '../config.js';
+import { _clearOverrides, getTemplateOverride, loadEmailTemplates } from '../emailTemplateLoader.js';
+
+function setConfig(overrides: Partial<typeof config>) {
+  Object.assign(config, overrides);
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'email-tpl-'));
+  _clearOverrides();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  _clearOverrides();
+});
+
+function writeTemplate(name: string, data: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(tmpDir, `${name}.json`), JSON.stringify(data));
+}
+
+describe('loadEmailTemplates()', () => {
+  it('does nothing when emailTemplateDir is null', () => {
+    setConfig({ emailTemplateDir: null });
+    loadEmailTemplates();
+    expect(getTemplateOverride('welcome', {})).toBeNull();
+  });
+
+  it('loads valid template files from directory', () => {
+    writeTemplate('welcome', {
+      subject: 'Hello {{displayName}}',
+      html: '<h1>Hi {{displayName}}</h1>',
+      text: 'Hi {{displayName}}',
+    });
+    setConfig({ emailTemplateDir: tmpDir });
+    loadEmailTemplates();
+    const result = getTemplateOverride('welcome', { displayName: 'Alice' });
+    expect(result).not.toBeNull();
+    expect(result!.subject).toBe('Hello Alice');
+    expect(result!.html).toBe('<h1>Hi Alice</h1>');
+    expect(result!.text).toBe('Hi Alice');
+  });
+
+  it('skips unknown template types', () => {
+    writeTemplate('unknown_type', {
+      subject: 'test',
+      html: 'test',
+      text: 'test',
+    });
+    setConfig({ emailTemplateDir: tmpDir });
+    loadEmailTemplates();
+    expect(getTemplateOverride('unknown_type', {})).toBeNull();
+  });
+
+  it('skips templates missing required fields', () => {
+    writeTemplate('welcome', { subject: 'test' });
+    setConfig({ emailTemplateDir: tmpDir });
+    loadEmailTemplates();
+    expect(getTemplateOverride('welcome', {})).toBeNull();
+  });
+
+  it('skips invalid JSON files', () => {
+    fs.writeFileSync(path.join(tmpDir, 'welcome.json'), 'not json');
+    setConfig({ emailTemplateDir: tmpDir });
+    loadEmailTemplates();
+    expect(getTemplateOverride('welcome', {})).toBeNull();
+  });
+
+  it('handles non-existent directory gracefully', () => {
+    setConfig({ emailTemplateDir: '/nonexistent/path' });
+    loadEmailTemplates();
+    expect(getTemplateOverride('welcome', {})).toBeNull();
+  });
+});
+
+describe('getTemplateOverride()', () => {
+  it('returns null when no override exists', () => {
+    expect(getTemplateOverride('trial_expiring', {})).toBeNull();
+  });
+
+  it('preserves unmatched placeholders', () => {
+    writeTemplate('trial_expiring', {
+      subject: 'Expiring {{displayName}}',
+      html: '{{displayName}} - {{unknown}}',
+      text: '{{displayName}} - {{unknown}}',
+    });
+    setConfig({ emailTemplateDir: tmpDir });
+    loadEmailTemplates();
+    const result = getTemplateOverride('trial_expiring', { displayName: 'Bob' });
+    expect(result!.html).toBe('Bob - {{unknown}}');
+  });
+
+  it('substitutes multiple variables', () => {
+    writeTemplate('password_reset', {
+      subject: 'Reset',
+      html: '{{displayName}} reset at {{resetUrl}}',
+      text: '{{displayName}} reset at {{resetUrl}}',
+    });
+    setConfig({ emailTemplateDir: tmpDir });
+    loadEmailTemplates();
+    const result = getTemplateOverride('password_reset', { displayName: 'Eve', resetUrl: 'https://example.com/reset' });
+    expect(result!.html).toBe('Eve reset at https://example.com/reset');
+  });
+});

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -94,6 +94,7 @@ export const config = Object.freeze({
   emailTemplateDir: process.env.EMAIL_TEMPLATE_DIR || null,
 
   demoMode: parseBool(process.env.DEMO_MODE, false),
+  demoSeedPath: process.env.DEMO_SEED_PATH || null,
   aiMock: parseBool(process.env.AI_MOCK, false),
   demoUsernames: new Set(
     (process.env.DEMO_USERNAMES || '')

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -91,6 +91,7 @@ export const config = Object.freeze({
   emailEnabled: parseBool(process.env.EMAIL_ENABLED, false),
   emailFrom: process.env.EMAIL_FROM || 'OpenBin <noreply@openbin.app>',
   resendApiKey: process.env.RESEND_API_KEY || null,
+  emailTemplateDir: process.env.EMAIL_TEMPLATE_DIR || null,
 
   demoMode: parseBool(process.env.DEMO_MODE, false),
   aiMock: parseBool(process.env.AI_MOCK, false),

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -8,6 +8,14 @@ function parseBool(value: string | undefined, fallback: boolean): boolean {
   return value === 'true' || value === '1';
 }
 
+function parseNullableInt(value: string | undefined, fallback: number | null): number | null {
+  if (value === undefined || value === '') return fallback;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) return fallback;
+  if (n === 0) return null; // 0 means unlimited
+  return n;
+}
+
 function clamp(value: number, min: number, max: number, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
   return Math.min(Math.max(value, min), max);
@@ -64,6 +72,21 @@ export const config = Object.freeze({
   subscriptionJwtSecret: process.env.SUBSCRIPTION_JWT_SECRET || null,
   subscriptionWebhookSecret: process.env.SUBSCRIPTION_WEBHOOK_SECRET || null,
   trialPeriodDays: clamp(parseInt(process.env.TRIAL_PERIOD_DAYS || '7', 10), 1, 90, 7),
+  // Plan limits (overridable for cloud deployments)
+  planLimits: Object.freeze({
+    liteAi: parseBool(process.env.PLAN_LITE_AI, false),
+    liteApiKeys: parseBool(process.env.PLAN_LITE_API_KEYS, false),
+    liteCustomFields: parseBool(process.env.PLAN_LITE_CUSTOM_FIELDS, false),
+    liteFullExport: parseBool(process.env.PLAN_LITE_FULL_EXPORT, false),
+    liteReorganize: parseBool(process.env.PLAN_LITE_REORGANIZE, false),
+    liteBinSharing: parseBool(process.env.PLAN_LITE_BIN_SHARING, false),
+    liteMaxLocations: parseNullableInt(process.env.PLAN_LITE_MAX_LOCATIONS, 1),
+    liteMaxStorageMb: parseNullableInt(process.env.PLAN_LITE_MAX_STORAGE_MB, 100),
+    liteMaxMembers: parseNullableInt(process.env.PLAN_LITE_MAX_MEMBERS, 1),
+    liteActivityRetentionDays: parseNullableInt(process.env.PLAN_LITE_ACTIVITY_RETENTION_DAYS, 30),
+    proMaxStorageMb: parseNullableInt(process.env.PLAN_PRO_MAX_STORAGE_MB, 5000),
+    proActivityRetentionDays: parseNullableInt(process.env.PLAN_PRO_ACTIVITY_RETENTION_DAYS, 90),
+  }),
   // Email (Resend)
   emailEnabled: parseBool(process.env.EMAIL_ENABLED, false),
   emailFrom: process.env.EMAIL_FROM || 'OpenBin <noreply@openbin.app>',

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -72,7 +72,6 @@ export const config = Object.freeze({
   subscriptionJwtSecret: process.env.SUBSCRIPTION_JWT_SECRET || null,
   subscriptionWebhookSecret: process.env.SUBSCRIPTION_WEBHOOK_SECRET || null,
   trialPeriodDays: clamp(parseInt(process.env.TRIAL_PERIOD_DAYS || '7', 10), 1, 90, 7),
-  // Plan limits (overridable for cloud deployments)
   planLimits: Object.freeze({
     liteAi: parseBool(process.env.PLAN_LITE_AI, false),
     liteApiKeys: parseBool(process.env.PLAN_LITE_API_KEYS, false),

--- a/server/src/lib/demoSeed.ts
+++ b/server/src/lib/demoSeed.ts
@@ -27,6 +27,8 @@ import { pushLog } from './logBuffer.js';
 import { createLogger } from './logger.js';
 import { generateShortCode } from './shortCode.js';
 
+const log = createLogger('demoSeed');
+
 interface ExternalDemoData {
   users: Record<string, string>;
   locations: { home: string; storage: string };
@@ -61,7 +63,6 @@ function loadExternalDemoData(): ExternalDemoData | null {
   const filePath = config.demoSeedPath;
   if (!filePath) return null;
 
-  const log = createLogger('demoSeed');
   try {
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
     for (const key of REQUIRED_KEYS) {
@@ -482,11 +483,9 @@ export async function seedDemoData(): Promise<void> {
     const storageBins = bins.filter((b) => b.location === 'storage').length;
     const totalAreas = homeAreaNames.length + Object.values(nestedAreaDefs).flat().length + storageAreaNames.length;
     const message = `Demo data seeded in ${elapsed}ms (${usernames.length} users, ${homeBins} + ${storageBins} bins, ${trashedBinsList.length} trashed, ${totalAreas} areas, ${cfDefs.length} custom fields, ${activityEntries.length} activity log entries across 2 locations)`;
-    const log = createLogger('demoSeed');
     log.info(message);
     pushLog({ level: 'info', message });
   } catch (err) {
-    const log = createLogger('demoSeed');
     log.error('Failed to seed demo data:', err instanceof Error ? err.message : err);
     pushLog({ level: 'error', message: `Demo seed failed: ${err}` });
     throw err;

--- a/server/src/lib/demoSeed.ts
+++ b/server/src/lib/demoSeed.ts
@@ -1,15 +1,15 @@
 import crypto from 'node:crypto';
+import fs from 'node:fs';
 import bcrypt from 'bcrypt';
 import type { TxQueryFn } from '../db.js';
 import { d, generateUuid, withTransaction } from '../db.js';
 import { config } from './config.js';
-import type { DemoMember } from './demoSeedData.js';
+import type { DemoActivityEntry, DemoBin, DemoMember } from './demoSeedData.js';
 import {
   CUSTOM_FIELD_DEFINITIONS,
   CUSTOM_FIELD_VALUES,
   DEMO_ACTIVITY_ENTRIES,
   DEMO_BINS,
-  DEMO_USERNAMES,
   DEMO_USERS,
   HOME_AREAS,
   NESTED_AREAS,
@@ -27,6 +27,56 @@ import { pushLog } from './logBuffer.js';
 import { createLogger } from './logger.js';
 import { generateShortCode } from './shortCode.js';
 
+interface ExternalDemoData {
+  users: Record<string, string>;
+  locations: { home: string; storage: string };
+  homeAreas: string[];
+  nestedAreas: Record<string, string[]>;
+  storageAreas: string[];
+  bins: DemoBin[];
+  trashedBins: DemoBin[];
+  tagColors: Record<string, string>;
+  pinnedBinNames: string[];
+  pinnedBinNamesPat: string[];
+  scannedBinNames: Record<string, string[]>;
+  customFieldDefinitions: Array<{ name: string; position: number }>;
+  customFieldValues: Record<string, Record<string, string>>;
+  activityEntries: Array<{
+    user: DemoMember;
+    location: 'home' | 'storage';
+    action: string;
+    entityType: string;
+    entityName?: string;
+    binName?: string;
+    changes?: Record<string, { old: unknown; new: unknown }>;
+    daysAgo: number;
+  }>;
+}
+
+const REQUIRED_KEYS: (keyof ExternalDemoData)[] = [
+  'users', 'locations', 'homeAreas', 'storageAreas', 'bins',
+];
+
+function loadExternalDemoData(): ExternalDemoData | null {
+  const filePath = config.demoSeedPath;
+  if (!filePath) return null;
+
+  const log = createLogger('demoSeed');
+  try {
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    for (const key of REQUIRED_KEYS) {
+      if (!(key in raw)) {
+        log.error(`Demo seed file missing required key: "${key}"`);
+        return null;
+      }
+    }
+    return raw as unknown as ExternalDemoData;
+  } catch (err) {
+    log.error(`Failed to load demo seed file "${filePath}":`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
 async function createLocation(tx: TxQueryFn, userId: string, name: string): Promise<string> {
   const locationId = generateUuid();
   const inviteCode = crypto.randomBytes(16).toString('hex');
@@ -43,8 +93,8 @@ async function createLocation(tx: TxQueryFn, userId: string, name: string): Prom
   return locationId;
 }
 
-async function cleanupExistingDemoUsers(tx: TxQueryFn): Promise<void> {
-  for (const username of DEMO_USERNAMES) {
+async function cleanupExistingDemoUsers(tx: TxQueryFn, usernames: string[]): Promise<void> {
+  for (const username of usernames) {
     const existing = await tx<{ id: string }>(
       'SELECT id FROM users WHERE username = $1',
       [username],
@@ -56,9 +106,9 @@ async function cleanupExistingDemoUsers(tx: TxQueryFn): Promise<void> {
   }
 }
 
-async function createDemoUsers(tx: TxQueryFn, passwordHash: string): Promise<Map<DemoMember, string>> {
+async function createDemoUsers(tx: TxQueryFn, passwordHash: string, users: Record<string, string>): Promise<Map<DemoMember, string>> {
   const userIdMap = new Map<DemoMember, string>();
-  for (const [username, displayName] of Object.entries(DEMO_USERS)) {
+  for (const [username, displayName] of Object.entries(users)) {
     const id = generateUuid();
     userIdMap.set(username as DemoMember, id);
     await tx(
@@ -69,10 +119,10 @@ async function createDemoUsers(tx: TxQueryFn, passwordHash: string): Promise<Map
   return userIdMap;
 }
 
-async function setupLocations(tx: TxQueryFn, userId: string): Promise<{ homeLocationId: string; storageLocationId: string }> {
+async function setupLocations(tx: TxQueryFn, userId: string, locationNames: { home: string; storage: string }): Promise<{ homeLocationId: string; storageLocationId: string }> {
   return {
-    homeLocationId: await createLocation(tx, userId, 'Our House'),
-    storageLocationId: await createLocation(tx, userId, 'Self Storage Unit'),
+    homeLocationId: await createLocation(tx, userId, locationNames.home),
+    storageLocationId: await createLocation(tx, userId, locationNames.storage),
   };
 }
 
@@ -118,11 +168,14 @@ async function createAreas(
   homeLocationId: string,
   storageLocationId: string,
   userId: string,
+  homeAreas: string[],
+  nestedAreas: Record<string, string[]>,
+  storageAreas: string[],
 ): Promise<Map<string, string>> {
   const areaMap = new Map<string, string>();
 
   // Home parent areas
-  for (const areaName of HOME_AREAS) {
+  for (const areaName of homeAreas) {
     const areaId = generateUuid();
     areaMap.set(areaName, areaId);
     await tx(
@@ -132,7 +185,7 @@ async function createAreas(
   }
 
   // Nested child areas under home areas
-  for (const [parentName, children] of Object.entries(NESTED_AREAS)) {
+  for (const [parentName, children] of Object.entries(nestedAreas)) {
     const parentId = areaMap.get(parentName);
     if (!parentId) continue;
     for (const childName of children) {
@@ -146,7 +199,7 @@ async function createAreas(
   }
 
   // Storage location areas
-  for (const areaName of STORAGE_AREAS) {
+  for (const areaName of storageAreas) {
     const areaId = generateUuid();
     areaMap.set(areaName, areaId);
     await tx(
@@ -164,10 +217,11 @@ async function createBins(
   storageLocationId: string,
   areaMap: Map<string, string>,
   userIdMap: Map<DemoMember, string>,
+  binList: DemoBin[],
 ): Promise<Map<string, string>> {
   const binIdMap = new Map<string, string>();
 
-  for (const bin of DEMO_BINS) {
+  for (const bin of binList) {
     const binId = generateShortCode(bin.name);
     binIdMap.set(bin.name, binId);
     const locationId = bin.location === 'home' ? homeLocationId : storageLocationId;
@@ -202,9 +256,10 @@ async function createTrashedBins(
   areaMap: Map<string, string>,
   userIdMap: Map<DemoMember, string>,
   binIdMap: Map<string, string>,
+  trashedBinList: DemoBin[],
 ): Promise<void> {
-  for (let i = 0; i < TRASHED_BINS.length; i++) {
-    const bin = TRASHED_BINS[i];
+  for (let i = 0; i < trashedBinList.length; i++) {
+    const bin = trashedBinList[i];
     const binId = generateShortCode(bin.name);
     binIdMap.set(bin.name, binId);
     const locationId = bin.location === 'home' ? homeLocationId : storageLocationId;
@@ -230,9 +285,9 @@ async function createTrashedBins(
   }
 }
 
-async function seedTagColors(tx: TxQueryFn, homeLocationId: string, storageLocationId: string): Promise<void> {
+async function seedTagColors(tx: TxQueryFn, homeLocationId: string, storageLocationId: string, tagColors: Record<string, string>): Promise<void> {
   for (const locId of [homeLocationId, storageLocationId]) {
-    for (const [tag, color] of Object.entries(TAG_COLORS)) {
+    for (const [tag, color] of Object.entries(tagColors)) {
       await tx(
         'INSERT INTO tag_colors (id, location_id, tag, color) VALUES ($1, $2, $3, $4)',
         [generateUuid(), locId, tag, color],
@@ -241,9 +296,9 @@ async function seedTagColors(tx: TxQueryFn, homeLocationId: string, storageLocat
   }
 }
 
-async function seedPins(tx: TxQueryFn, userId: string, patUserId: string, binIdMap: Map<string, string>): Promise<void> {
-  for (let i = 0; i < PINNED_BIN_NAMES.length; i++) {
-    const binId = binIdMap.get(PINNED_BIN_NAMES[i]);
+async function seedPins(tx: TxQueryFn, userId: string, patUserId: string, binIdMap: Map<string, string>, pinnedNames: string[], pinnedNamesPat: string[]): Promise<void> {
+  for (let i = 0; i < pinnedNames.length; i++) {
+    const binId = binIdMap.get(pinnedNames[i]);
     if (binId) {
       await tx(
         'INSERT INTO pinned_bins (user_id, bin_id, position) VALUES ($1, $2, $3)',
@@ -251,8 +306,8 @@ async function seedPins(tx: TxQueryFn, userId: string, patUserId: string, binIdM
       );
     }
   }
-  for (let i = 0; i < PINNED_BIN_NAMES_PAT.length; i++) {
-    const binId = binIdMap.get(PINNED_BIN_NAMES_PAT[i]);
+  for (let i = 0; i < pinnedNamesPat.length; i++) {
+    const binId = binIdMap.get(pinnedNamesPat[i]);
     if (binId) {
       await tx(
         'INSERT INTO pinned_bins (user_id, bin_id, position) VALUES ($1, $2, $3)',
@@ -289,16 +344,9 @@ async function seedSavedViews(tx: TxQueryFn, userId: string, sarahUserId: string
   }
 }
 
-async function seedScanHistory(tx: TxQueryFn, userIdMap: Map<DemoMember, string>, binIdMap: Map<string, string>): Promise<void> {
-  const scanEntries: [DemoMember, string[]][] = [
-    ['demo', SCANNED_BIN_NAMES],
-    ['sarah', SCANNED_BIN_NAMES_SARAH],
-    ['alex', SCANNED_BIN_NAMES_ALEX],
-    ['pat', SCANNED_BIN_NAMES_PAT],
-  ];
-
-  for (const [member, binNames] of scanEntries) {
-    const userId = userIdMap.get(member)!;
+async function seedScanHistory(tx: TxQueryFn, userIdMap: Map<DemoMember, string>, binIdMap: Map<string, string>, scannedNames: Record<string, string[]>): Promise<void> {
+  for (const [member, binNames] of Object.entries(scannedNames)) {
+    const userId = userIdMap.get(member as DemoMember)!;
     for (const name of binNames) {
       const binId = binIdMap.get(name);
       if (binId) {
@@ -323,10 +371,16 @@ async function seedOnboardingPrefs(tx: TxQueryFn, userIdMap: Map<DemoMember, str
   }
 }
 
-async function seedCustomFields(tx: TxQueryFn, homeLocationId: string, binIdMap: Map<string, string>): Promise<void> {
+async function seedCustomFields(
+  tx: TxQueryFn,
+  homeLocationId: string,
+  binIdMap: Map<string, string>,
+  defs: Array<{ name: string; position: number }>,
+  values: Record<string, Record<string, string>>,
+): Promise<void> {
   const fieldIdMap = new Map<string, string>();
 
-  for (const field of CUSTOM_FIELD_DEFINITIONS) {
+  for (const field of defs) {
     const fieldId = generateUuid();
     fieldIdMap.set(field.name, fieldId);
     await tx(
@@ -335,7 +389,7 @@ async function seedCustomFields(tx: TxQueryFn, homeLocationId: string, binIdMap:
     );
   }
 
-  for (const [binName, fields] of Object.entries(CUSTOM_FIELD_VALUES)) {
+  for (const [binName, fields] of Object.entries(values)) {
     const binId = binIdMap.get(binName);
     if (!binId) continue;
     for (const [fieldName, value] of Object.entries(fields)) {
@@ -355,8 +409,9 @@ async function seedActivityLog(
   storageLocationId: string,
   userIdMap: Map<DemoMember, string>,
   binIdMap: Map<string, string>,
+  entries: DemoActivityEntry[],
 ): Promise<void> {
-  for (const entry of DEMO_ACTIVITY_ENTRIES) {
+  for (const entry of entries) {
     const locationId = entry.location === 'home' ? homeLocationId : storageLocationId;
     const userId = userIdMap.get(entry.user)!;
     const entityId = entry.binName ? (binIdMap.get(entry.binName) ?? null) : null;
@@ -374,37 +429,59 @@ async function seedActivityLog(
 export async function seedDemoData(): Promise<void> {
   if (!config.demoMode) return;
 
+  const external = loadExternalDemoData();
+  const users = external?.users ?? DEMO_USERS;
+  const usernames = Object.keys(users);
+  const locationNames = external?.locations ?? { home: 'Our House', storage: 'Self Storage Unit' };
+  const homeAreaNames = external?.homeAreas ?? HOME_AREAS;
+  const nestedAreaDefs = external?.nestedAreas ?? NESTED_AREAS;
+  const storageAreaNames = external?.storageAreas ?? STORAGE_AREAS;
+  const bins = external?.bins ?? DEMO_BINS;
+  const trashedBinsList = external?.trashedBins ?? TRASHED_BINS;
+  const tagColorDefs = external?.tagColors ?? TAG_COLORS;
+  const pinnedNames = external?.pinnedBinNames ?? PINNED_BIN_NAMES;
+  const pinnedNamesPat = external?.pinnedBinNamesPat ?? PINNED_BIN_NAMES_PAT;
+  const scannedNames = external?.scannedBinNames ?? {
+    demo: SCANNED_BIN_NAMES,
+    sarah: SCANNED_BIN_NAMES_SARAH,
+    alex: SCANNED_BIN_NAMES_ALEX,
+    pat: SCANNED_BIN_NAMES_PAT,
+  };
+  const cfDefs = external?.customFieldDefinitions ?? CUSTOM_FIELD_DEFINITIONS;
+  const cfValues = external?.customFieldValues ?? CUSTOM_FIELD_VALUES;
+  const activityEntries = external?.activityEntries ?? DEMO_ACTIVITY_ENTRIES;
+
   const startTime = Date.now();
 
   try {
     await withTransaction(async (tx) => {
-      await cleanupExistingDemoUsers(tx);
+      await cleanupExistingDemoUsers(tx, usernames);
 
       const randomPassword = crypto.randomBytes(32).toString('hex');
       const passwordHash = bcrypt.hashSync(randomPassword, 10);
-      const userIdMap = await createDemoUsers(tx, passwordHash);
+      const userIdMap = await createDemoUsers(tx, passwordHash, users);
       const userId = userIdMap.get('demo')!;
 
-      const { homeLocationId, storageLocationId } = await setupLocations(tx, userId);
+      const { homeLocationId, storageLocationId } = await setupLocations(tx, userId, locationNames);
       await assignMemberships(tx, homeLocationId, storageLocationId, userIdMap);
-      const areaMap = await createAreas(tx, homeLocationId, storageLocationId, userId);
-      const binIdMap = await createBins(tx, homeLocationId, storageLocationId, areaMap, userIdMap);
-      await createTrashedBins(tx, homeLocationId, storageLocationId, areaMap, userIdMap, binIdMap);
+      const areaMap = await createAreas(tx, homeLocationId, storageLocationId, userId, homeAreaNames, nestedAreaDefs, storageAreaNames);
+      const binIdMap = await createBins(tx, homeLocationId, storageLocationId, areaMap, userIdMap, bins);
+      await createTrashedBins(tx, homeLocationId, storageLocationId, areaMap, userIdMap, binIdMap, trashedBinsList);
 
-      await seedTagColors(tx, homeLocationId, storageLocationId);
-      await seedPins(tx, userId, userIdMap.get('pat')!, binIdMap);
+      await seedTagColors(tx, homeLocationId, storageLocationId, tagColorDefs);
+      await seedPins(tx, userId, userIdMap.get('pat')!, binIdMap, pinnedNames, pinnedNamesPat);
       await seedSavedViews(tx, userId, userIdMap.get('sarah')!, areaMap);
-      await seedScanHistory(tx, userIdMap, binIdMap);
+      await seedScanHistory(tx, userIdMap, binIdMap, scannedNames);
       await seedOnboardingPrefs(tx, userIdMap);
-      await seedCustomFields(tx, homeLocationId, binIdMap);
-      await seedActivityLog(tx, homeLocationId, storageLocationId, userIdMap, binIdMap);
+      await seedCustomFields(tx, homeLocationId, binIdMap, cfDefs, cfValues);
+      await seedActivityLog(tx, homeLocationId, storageLocationId, userIdMap, binIdMap, activityEntries);
     });
 
     const elapsed = Date.now() - startTime;
-    const homeBins = DEMO_BINS.filter((b) => b.location === 'home').length;
-    const storageBins = DEMO_BINS.filter((b) => b.location === 'storage').length;
-    const totalAreas = HOME_AREAS.length + Object.values(NESTED_AREAS).flat().length + STORAGE_AREAS.length;
-    const message = `Demo data seeded in ${elapsed}ms (${DEMO_USERNAMES.length} users, ${homeBins} + ${storageBins} bins, ${TRASHED_BINS.length} trashed, ${totalAreas} areas, ${CUSTOM_FIELD_DEFINITIONS.length} custom fields, ${DEMO_ACTIVITY_ENTRIES.length} activity log entries across 2 locations)`;
+    const homeBins = bins.filter((b) => b.location === 'home').length;
+    const storageBins = bins.filter((b) => b.location === 'storage').length;
+    const totalAreas = homeAreaNames.length + Object.values(nestedAreaDefs).flat().length + storageAreaNames.length;
+    const message = `Demo data seeded in ${elapsed}ms (${usernames.length} users, ${homeBins} + ${storageBins} bins, ${trashedBinsList.length} trashed, ${totalAreas} areas, ${cfDefs.length} custom fields, ${activityEntries.length} activity log entries across 2 locations)`;
     const log = createLogger('demoSeed');
     log.info(message);
     pushLog({ level: 'info', message });

--- a/server/src/lib/emailSender.ts
+++ b/server/src/lib/emailSender.ts
@@ -1,6 +1,7 @@
 import { generateUuid, isUniqueViolation, query } from '../db.js';
 import { config } from './config.js';
 import { sendEmail } from './email.js';
+import { getTemplateOverride } from './emailTemplateLoader.js';
 import {
   type DowngradeImpact,
   downgradeImpactEmail,
@@ -55,60 +56,100 @@ async function safeSend(userId: string, emailType: EmailType, to: string, templa
   }
 }
 
+function resolveTemplate(
+  type: string,
+  vars: Record<string, string>,
+  builtIn: { subject: string; html: string; text: string },
+): { subject: string; html: string; text: string } {
+  return getTemplateOverride(type, vars) ?? builtIn;
+}
+
 export function fireWelcomeEmail(userId: string, email: string, displayName: string): void {
   if (config.selfHosted && !config.emailEnabled) return;
   const loginUrl = config.baseUrl ? `${config.baseUrl}/login` : '';
-  safeSend(userId, 'welcome', email, welcomeEmail({ displayName, loginUrl }));
+  const vars = { displayName, loginUrl };
+  const template = resolveTemplate('welcome', vars, welcomeEmail({ displayName, loginUrl }));
+  safeSend(userId, 'welcome', email, template);
 }
 
 export function fireSubscriptionConfirmedEmail(userId: string, email: string, displayName: string, plan: PlanTier, activeUntil: string | null): void {
-  safeSend(userId, 'subscription_confirmed', email, subscriptionConfirmedEmail({
-    displayName,
-    plan: planLabel(plan),
-    activeUntil,
-  }));
+  const vars = { displayName, plan: planLabel(plan), activeUntil: activeUntil ?? '' };
+  const template = resolveTemplate('subscription_confirmed', vars, subscriptionConfirmedEmail({ displayName, plan: planLabel(plan), activeUntil }));
+  safeSend(userId, 'subscription_confirmed', email, template);
 }
 
 export async function fireSubscriptionExpiredEmail(userId: string, email: string, displayName: string): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'subscription_expired', email, subscriptionExpiredEmail({ displayName, upgradeUrl }));
+  const vars = { displayName, upgradeUrl };
+  const template = resolveTemplate('subscription_expired', vars, subscriptionExpiredEmail({ displayName, upgradeUrl }));
+  safeSend(userId, 'subscription_expired', email, template);
 }
 
 export async function fireTrialExpiringEmail(userId: string, email: string, displayName: string, expiryDate: string): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'trial_expiring', email, trialExpiringEmail({ displayName, expiryDate, upgradeUrl }));
+  const vars = { displayName, expiryDate, upgradeUrl };
+  const template = resolveTemplate('trial_expiring', vars, trialExpiringEmail({ displayName, expiryDate, upgradeUrl }));
+  safeSend(userId, 'trial_expiring', email, template);
 }
 
 export async function fireTrialExpiredEmail(userId: string, email: string, displayName: string): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'trial_expired', email, trialExpiredEmail({ displayName, upgradeUrl }));
+  const vars = { displayName, upgradeUrl };
+  const template = resolveTemplate('trial_expired', vars, trialExpiredEmail({ displayName, upgradeUrl }));
+  safeSend(userId, 'trial_expired', email, template);
 }
 
 export function fireExploreFeaturesEmail(userId: string, email: string, displayName: string): void {
   const dashboardUrl = config.baseUrl ? `${config.baseUrl}/dashboard` : '';
-  safeSend(userId, 'explore_features', email, exploreFeaturesEmail({ displayName, dashboardUrl }));
+  const vars = { displayName, dashboardUrl };
+  const template = resolveTemplate('explore_features', vars, exploreFeaturesEmail({ displayName, dashboardUrl }));
+  safeSend(userId, 'explore_features', email, template);
 }
 
 export async function firePostTrialEarlyEmail(userId: string, email: string, displayName: string): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'post_trial_early', email, postTrialEarlyEmail({ displayName, upgradeUrl }));
+  const vars = { displayName, upgradeUrl };
+  const template = resolveTemplate('post_trial_early', vars, postTrialEarlyEmail({ displayName, upgradeUrl }));
+  safeSend(userId, 'post_trial_early', email, template);
 }
 
 export async function firePostTrialLateEmail(userId: string, email: string, displayName: string): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'post_trial_late', email, postTrialLateEmail({ displayName, upgradeUrl }));
+  const vars = { displayName, upgradeUrl };
+  const template = resolveTemplate('post_trial_late', vars, postTrialLateEmail({ displayName, upgradeUrl }));
+  safeSend(userId, 'post_trial_late', email, template);
 }
 
 export function firePasswordResetEmail(userId: string, email: string, displayName: string, resetUrl: string): void {
-  safeSend(userId, 'password_reset', email, passwordResetEmail({ displayName, resetUrl }));
+  const vars = { displayName, resetUrl };
+  const template = resolveTemplate('password_reset', vars, passwordResetEmail({ displayName, resetUrl }));
+  safeSend(userId, 'password_reset', email, template);
 }
 
 export async function fireSubscriptionExpiringEmail(userId: string, email: string, displayName: string, expiryDate: string): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'subscription_expiring', email, subscriptionExpiringEmail({ displayName, expiryDate, upgradeUrl }));
+  const vars = { displayName, expiryDate, upgradeUrl };
+  const template = resolveTemplate('subscription_expiring', vars, subscriptionExpiringEmail({ displayName, expiryDate, upgradeUrl }));
+  safeSend(userId, 'subscription_expiring', email, template);
 }
 
 export async function fireDowngradeImpactEmail(userId: string, email: string, displayName: string, impact: DowngradeImpact): Promise<void> {
   const upgradeUrl = await generateUpgradeUrl(userId, email) || '';
-  safeSend(userId, 'downgrade_impact', email, downgradeImpactEmail({ displayName, impact, upgradeUrl }));
+  const impactLines: string[] = [];
+  if (impact.locationCount > impact.maxLocations) {
+    impactLines.push(`You have ${impact.locationCount} locations (Lite allows ${impact.maxLocations}).`);
+  }
+  for (const loc of impact.overLimitMembers) {
+    impactLines.push(`${loc.locationName} has ${loc.memberCount} members (Lite allows ${impact.maxMembersPerLocation}).`);
+  }
+  if (impact.photoStorageMb > impact.maxPhotoStorageMb) {
+    impactLines.push(`Using ${impact.photoStorageMb.toFixed(1)} MB storage (Lite allows ${impact.maxPhotoStorageMb} MB).`);
+  }
+  const impactHtml = impactLines.length > 0
+    ? `<ul>${impactLines.map(l => `<li>${l}</li>`).join('')}</ul>`
+    : '';
+  const impactText = impactLines.map(l => `- ${l}`).join('\n');
+  const vars = { displayName, upgradeUrl, impactHtml, impactText };
+  const template = resolveTemplate('downgrade_impact', vars, downgradeImpactEmail({ displayName, impact, upgradeUrl }));
+  safeSend(userId, 'downgrade_impact', email, template);
 }

--- a/server/src/lib/emailSender.ts
+++ b/server/src/lib/emailSender.ts
@@ -1,7 +1,7 @@
 import { generateUuid, isUniqueViolation, query } from '../db.js';
 import { config } from './config.js';
 import { sendEmail } from './email.js';
-import { getTemplateOverride } from './emailTemplateLoader.js';
+import { type EmailType, getTemplateOverride } from './emailTemplateLoader.js';
 import {
   type DowngradeImpact,
   downgradeImpactEmail,
@@ -18,8 +18,6 @@ import {
 } from './emailTemplates.js';
 import { createLogger } from './logger.js';
 import { generateUpgradeUrl, type PlanTier, planLabel } from './planGate.js';
-
-type EmailType = 'welcome' | 'trial_expiring' | 'trial_expired' | 'subscription_confirmed' | 'subscription_expired' | 'subscription_expiring' | 'downgrade_impact' | 'explore_features' | 'post_trial_early' | 'post_trial_late' | 'password_reset';
 
 const log = createLogger('email');
 const SKIP_DEDUP: ReadonlySet<EmailType> = new Set(['welcome', 'password_reset']);

--- a/server/src/lib/emailTemplateLoader.ts
+++ b/server/src/lib/emailTemplateLoader.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { config } from './config.js';
 import { createLogger } from './logger.js';
+import { safePath } from './pathSafety.js';
 
 const log = createLogger('emailTemplateLoader');
 
@@ -13,12 +14,16 @@ interface RawTemplate {
 
 const overrides = new Map<string, RawTemplate>();
 
-const VALID_TYPES = new Set([
+export const EMAIL_TYPES = [
   'welcome', 'trial_expiring', 'trial_expired',
   'subscription_confirmed', 'subscription_expired', 'subscription_expiring',
   'explore_features', 'post_trial_early', 'post_trial_late',
   'password_reset', 'downgrade_impact',
-]);
+] as const;
+
+export type EmailType = (typeof EMAIL_TYPES)[number];
+
+const VALID_TYPES: ReadonlySet<string> = new Set(EMAIL_TYPES);
 
 export function loadEmailTemplates(): void {
   overrides.clear();
@@ -39,8 +44,13 @@ export function loadEmailTemplates(): void {
       log.warn(`Skipping unknown email template type: ${file}`);
       continue;
     }
+    const filePath = safePath(dir, file);
+    if (!filePath) {
+      log.warn(`Skipping email template with unsafe path: ${file}`);
+      continue;
+    }
     try {
-      const raw = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8')) as Record<string, unknown>;
+      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
       if (typeof raw.subject !== 'string' || typeof raw.html !== 'string' || typeof raw.text !== 'string') {
         log.warn(`Email template "${file}" missing required fields (subject, html, text), skipping`);
         continue;

--- a/server/src/lib/emailTemplateLoader.ts
+++ b/server/src/lib/emailTemplateLoader.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { config } from './config.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('emailTemplateLoader');
+
+interface RawTemplate {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const overrides = new Map<string, RawTemplate>();
+
+const VALID_TYPES = new Set([
+  'welcome', 'trial_expiring', 'trial_expired',
+  'subscription_confirmed', 'subscription_expired', 'subscription_expiring',
+  'explore_features', 'post_trial_early', 'post_trial_late',
+  'password_reset', 'downgrade_impact',
+]);
+
+export function loadEmailTemplates(): void {
+  overrides.clear();
+  const dir = config.emailTemplateDir;
+  if (!dir) return;
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+  } catch (err) {
+    log.warn(`Failed to read email template directory "${dir}":`, err instanceof Error ? err.message : err);
+    return;
+  }
+
+  for (const file of files) {
+    const type = path.basename(file, '.json');
+    if (!VALID_TYPES.has(type)) {
+      log.warn(`Skipping unknown email template type: ${file}`);
+      continue;
+    }
+    try {
+      const raw = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8')) as Record<string, unknown>;
+      if (typeof raw.subject !== 'string' || typeof raw.html !== 'string' || typeof raw.text !== 'string') {
+        log.warn(`Email template "${file}" missing required fields (subject, html, text), skipping`);
+        continue;
+      }
+      overrides.set(type, { subject: raw.subject, html: raw.html, text: raw.text });
+    } catch (err) {
+      log.warn(`Failed to parse email template "${file}":`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  if (overrides.size > 0) {
+    log.info(`Loaded ${overrides.size} email template override(s): ${[...overrides.keys()].join(', ')}`);
+  }
+}
+
+function substituteVars(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
+    return key in vars ? vars[key] : match;
+  });
+}
+
+export function getTemplateOverride(
+  type: string,
+  vars: Record<string, string>,
+): { subject: string; html: string; text: string } | null {
+  const tpl = overrides.get(type);
+  if (!tpl) return null;
+  return {
+    subject: substituteVars(tpl.subject, vars),
+    html: substituteVars(tpl.html, vars),
+    text: substituteVars(tpl.text, vars),
+  };
+}
+
+/** Visible for testing. */
+export function _clearOverrides(): void {
+  overrides.clear();
+}

--- a/server/src/lib/planGate.ts
+++ b/server/src/lib/planGate.ts
@@ -100,20 +100,21 @@ const UNRESTRICTED: PlanFeatures = {
 
 export function getFeatureMap(plan: PlanTier): PlanFeatures {
   if (config.selfHosted) return UNRESTRICTED;
+  const pl = config.planLimits;
   if (plan === Plan.PRO) {
-    return { ...UNRESTRICTED, maxPhotoStorageMb: 5000, activityRetentionDays: 90 };
+    return { ...UNRESTRICTED, maxPhotoStorageMb: pl.proMaxStorageMb, activityRetentionDays: pl.proActivityRetentionDays };
   }
   return {
-    ai: false,
-    apiKeys: false,
-    customFields: false,
-    fullExport: false,
-    reorganize: false,
-    binSharing: false,
-    maxLocations: 1,
-    maxPhotoStorageMb: 100,
-    maxMembersPerLocation: 1,
-    activityRetentionDays: 30,
+    ai: pl.liteAi,
+    apiKeys: pl.liteApiKeys,
+    customFields: pl.liteCustomFields,
+    fullExport: pl.liteFullExport,
+    reorganize: pl.liteReorganize,
+    binSharing: pl.liteBinSharing,
+    maxLocations: pl.liteMaxLocations,
+    maxPhotoStorageMb: pl.liteMaxStorageMb,
+    maxMembersPerLocation: pl.liteMaxMembers,
+    activityRetentionDays: pl.liteActivityRetentionDays,
   };
 }
 

--- a/server/src/start.ts
+++ b/server/src/start.ts
@@ -4,6 +4,7 @@ import { createApp } from './index.js';
 import { startBackupScheduler, stopBackupScheduler } from './lib/backup.js';
 import { config } from './lib/config.js';
 import { seedDemoData } from './lib/demoSeed.js';
+import { loadEmailTemplates } from './lib/emailTemplateLoader.js';
 import { pushLog } from './lib/logBuffer.js';
 import { createLogger } from './lib/logger.js';
 import { cleanupOrphanPhotos } from './lib/photoCleanup.js';
@@ -16,6 +17,7 @@ const log = createLogger('startup');
 
 // Initialize the database engine before anything touches the DB
 await initialize();
+loadEmailTemplates();
 
 const app = createApp();
 


### PR DESCRIPTION
## Summary

- **Plan limits via env vars**: 12 new env vars (`PLAN_LITE_*`, `PLAN_PRO_*`) replace hardcoded values in `getFeatureMap()`, allowing pricing/packaging to be configured from a private deploy repo
- **Email template overrides**: `EMAIL_TEMPLATE_DIR` env var loads JSON template files that override built-in lifecycle emails (trial expiring, upgrade nudges, etc.) with `{{variable}}` substitution
- **Demo seed data from external JSON**: `DEMO_SEED_PATH` env var loads demo data from a JSON file instead of inline constants, plus an export script to generate the initial file

All changes are backwards compatible — existing self-hosted deployments need zero configuration changes. Self-hosted mode continues to bypass all plan limits.

## Test plan

- [ ] Verify `cd server && npx vitest run` passes (885 tests)
- [ ] Verify `npx vitest run` passes (668 frontend tests)
- [ ] Verify `npx biome check .` reports no issues
- [ ] Verify `cd server && npx tsc --noEmit` has no errors
- [ ] Verify `npx tsx server/scripts/export-demo-data.ts` outputs valid JSON