### PR TITLE
feat: two-column layout for bin detail page on desktop

### DIFF
--- a/src/features/bins/BinDetailPage.tsx
+++ b/src/features/bins/BinDetailPage.tsx
@@ -167,7 +167,7 @@ export function BinDetailPage() {
   );
 
   return (
-    <div className="page-content">
+    <div className="page-content max-w-5xl">
       <BinDetailToolbar
         bin={bin}
         editing={edit.editing}

--- a/src/features/bins/BinDetailSkeleton.tsx
+++ b/src/features/bins/BinDetailSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export function BinDetailSkeleton() {
   return (
-    <div className="page-content">
+    <div className="page-content max-w-5xl">
       {/* Toolbar */}
       <div className="flex items-center gap-2">
         <Skeleton className="hidden lg:block h-5 w-5 rounded shrink-0" />

--- a/src/features/bins/BinDetailSkeleton.tsx
+++ b/src/features/bins/BinDetailSkeleton.tsx
@@ -12,48 +12,56 @@ export function BinDetailSkeleton() {
         <Skeleton className="h-9 w-9 rounded-[var(--radius-md)]" />
       </div>
 
-      {/* Items card */}
-      <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-2.5">
-        <Skeleton className="h-4 w-16" />
-        <div className="rounded-[var(--radius-md)] bg-[var(--bg-input)] p-3.5 space-y-2">
-          <Skeleton className="h-4 w-3/4" />
-          <Skeleton className="h-4 w-1/2" />
-          <Skeleton className="h-4 w-2/3" />
-        </div>
-        <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
-      </div>
+      <div className="flex flex-col lg:grid lg:grid-cols-[3fr_2fr] lg:items-start gap-4">
+        {/* Left column */}
+        <div className="flex flex-col gap-4">
+          {/* Items card */}
+          <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-2.5">
+            <Skeleton className="h-4 w-16" />
+            <div className="rounded-[var(--radius-md)] bg-[var(--bg-input)] p-3.5 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+            <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
+          </div>
 
-      {/* Notes card */}
-      <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-2.5">
-        <Skeleton className="h-4 w-12" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-2/3" />
-      </div>
+          {/* Notes card */}
+          <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-2.5">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
 
-      {/* Area & Tags card */}
-      <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-4">
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-12" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-10" />
-          <div className="flex gap-2">
-            <Skeleton className="h-6 w-16 rounded-full" />
-            <Skeleton className="h-6 w-20 rounded-full" />
-            <Skeleton className="h-6 w-14 rounded-full" />
+          {/* Photos disclosure (collapsed) */}
+          <div className="flat-card rounded-[var(--radius-lg)] px-4 py-4">
+            <Skeleton className="h-4 w-20" />
           </div>
         </div>
-      </div>
 
-      {/* Photos disclosure (collapsed) */}
-      <div className="flat-card rounded-[var(--radius-lg)] px-4 py-4">
-        <Skeleton className="h-4 w-20" />
-      </div>
+        {/* Right column */}
+        <div className="flex flex-col gap-4">
+          {/* Area & Tags card */}
+          <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-4">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-10" />
+              <div className="flex gap-2">
+                <Skeleton className="h-6 w-16 rounded-full" />
+                <Skeleton className="h-6 w-20 rounded-full" />
+                <Skeleton className="h-6 w-14 rounded-full" />
+              </div>
+            </div>
+          </div>
 
-      {/* QR Code disclosure (collapsed) */}
-      <div className="flat-card rounded-[var(--radius-lg)] px-4 py-4">
-        <Skeleton className="h-4 w-28" />
+          {/* QR Code disclosure (collapsed) */}
+          <div className="flat-card rounded-[var(--radius-lg)] px-4 py-4">
+            <Skeleton className="h-4 w-28" />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/features/bins/BinDetailSkeleton.tsx
+++ b/src/features/bins/BinDetailSkeleton.tsx
@@ -26,13 +26,6 @@ export function BinDetailSkeleton() {
             <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
           </div>
 
-          {/* Notes card */}
-          <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-2.5">
-            <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-2/3" />
-          </div>
-
           {/* Photos disclosure (collapsed) */}
           <div className="flat-card rounded-[var(--radius-lg)] px-4 py-4">
             <Skeleton className="h-4 w-20" />
@@ -41,6 +34,13 @@ export function BinDetailSkeleton() {
 
         {/* Right column */}
         <div className="flex flex-col gap-4">
+          {/* Notes card */}
+          <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-2.5">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+
           {/* Area & Tags card */}
           <div className="flat-card rounded-[var(--radius-lg)] p-4 space-y-4">
             <div className="space-y-2">

--- a/src/features/bins/BinEditContent.tsx
+++ b/src/features/bins/BinEditContent.tsx
@@ -58,98 +58,104 @@ export function BinEditContent({
   });
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* Items */}
-      <Card>
-        <CardContent className="pt-3 pb-4">
-          <ItemList items={edit.items} onItemsChange={edit.setItems} collapsible />
-          <QuickAddWidget quickAdd={quickAdd} aiEnabled={aiEnabled} />
-        </CardContent>
-      </Card>
-
-      {/* Notes */}
-      <Card>
-        <CardContent className="space-y-2 pt-3 pb-4">
-          <Label htmlFor="edit-notes">Notes</Label>
-          <Textarea
-            id="edit-notes"
-            value={edit.notes}
-            onChange={(e) => edit.setNotes(e.target.value)}
-            maxLength={10000}
-            rows={3}
-            className="[field-sizing:content] min-h-[5rem]"
-          />
-        </CardContent>
-      </Card>
-
-      {/* Organization: Area + Tags */}
-      <Card>
-        <CardContent className="space-y-5 pt-3 pb-4">
-          <div className="space-y-2">
-            <Label>{t.Area}</Label>
-            <AreaPicker locationId={activeLocationId} value={edit.areaId} onChange={edit.setAreaId} />
-          </div>
-          <div className="space-y-2">
-            <Label>Tags</Label>
-            <TagInput tags={edit.tags} onChange={edit.setTags} suggestions={allTags} />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Custom Fields */}
-      <CustomFieldsEditCard
-        fields={customFields}
-        values={edit.customFields}
-        onChange={edit.setCustomFields}
-      />
-
-      {photosSection}
-
-      {/* Appearance — icon, color, style */}
-      <Card>
-        <CardContent className="space-y-5 pt-3 pb-4">
-          <div className="space-y-3">
-            <Label>Preview</Label>
-            <BinPreviewCard
-              name={edit.name}
-              color={edit.color}
-              items={edit.items.map((i) => i.name)}
-              tags={edit.tags}
-              icon={edit.icon}
-              cardStyle={edit.cardStyle}
-              areaName={editAreaName}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Icon</Label>
-            <IconPicker value={edit.icon} onChange={edit.setIcon} />
-          </div>
-          <div className="space-y-2">
-            <Label>Color</Label>
-            <ColorPicker
-              value={edit.color}
-              onChange={edit.setColor}
-              secondaryLabel={secondaryInfo?.label}
-              secondaryValue={secondaryInfo?.value}
-              onSecondaryChange={secondaryInfo ? (c) => edit.setCardStyle(setSecondaryColor(edit.cardStyle, c)) : undefined}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Style</Label>
-            <StylePicker value={edit.cardStyle} color={edit.color} onChange={edit.setCardStyle} photos={photos} />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Visibility */}
-      {canChangeVisibility && (
+    <div className="flex flex-col lg:grid lg:grid-cols-[3fr_2fr] lg:items-start gap-4">
+      {/* Left column */}
+      <div className="flex flex-col gap-4">
+        {/* Items */}
         <Card>
-          <CardContent className="space-y-2 pt-3 pb-4">
-            <Label>Visibility</Label>
-            <VisibilityPicker value={edit.visibility} onChange={edit.setVisibility} />
+          <CardContent className="pt-3 pb-4">
+            <ItemList items={edit.items} onItemsChange={edit.setItems} collapsible />
+            <QuickAddWidget quickAdd={quickAdd} aiEnabled={aiEnabled} />
           </CardContent>
         </Card>
-      )}
+
+        {/* Notes */}
+        <Card>
+          <CardContent className="space-y-2 pt-3 pb-4">
+            <Label htmlFor="edit-notes">Notes</Label>
+            <Textarea
+              id="edit-notes"
+              value={edit.notes}
+              onChange={(e) => edit.setNotes(e.target.value)}
+              maxLength={10000}
+              rows={3}
+              className="[field-sizing:content] min-h-[5rem]"
+            />
+          </CardContent>
+        </Card>
+
+        {photosSection}
+
+        {/* Appearance — icon, color, style */}
+        <Card>
+          <CardContent className="space-y-5 pt-3 pb-4">
+            <div className="space-y-3">
+              <Label>Preview</Label>
+              <BinPreviewCard
+                name={edit.name}
+                color={edit.color}
+                items={edit.items.map((i) => i.name)}
+                tags={edit.tags}
+                icon={edit.icon}
+                cardStyle={edit.cardStyle}
+                areaName={editAreaName}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Icon</Label>
+              <IconPicker value={edit.icon} onChange={edit.setIcon} />
+            </div>
+            <div className="space-y-2">
+              <Label>Color</Label>
+              <ColorPicker
+                value={edit.color}
+                onChange={edit.setColor}
+                secondaryLabel={secondaryInfo?.label}
+                secondaryValue={secondaryInfo?.value}
+                onSecondaryChange={secondaryInfo ? (c) => edit.setCardStyle(setSecondaryColor(edit.cardStyle, c)) : undefined}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Style</Label>
+              <StylePicker value={edit.cardStyle} color={edit.color} onChange={edit.setCardStyle} photos={photos} />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Right column */}
+      <div className="lg:sticky lg:top-6 flex flex-col gap-4">
+        {/* Organization: Area + Tags */}
+        <Card>
+          <CardContent className="space-y-5 pt-3 pb-4">
+            <div className="space-y-2">
+              <Label>{t.Area}</Label>
+              <AreaPicker locationId={activeLocationId} value={edit.areaId} onChange={edit.setAreaId} />
+            </div>
+            <div className="space-y-2">
+              <Label>Tags</Label>
+              <TagInput tags={edit.tags} onChange={edit.setTags} suggestions={allTags} />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Custom Fields */}
+        <CustomFieldsEditCard
+          fields={customFields}
+          values={edit.customFields}
+          onChange={edit.setCustomFields}
+        />
+
+        {/* Visibility */}
+        {canChangeVisibility && (
+          <Card>
+            <CardContent className="space-y-2 pt-3 pb-4">
+              <Label>Visibility</Label>
+              <VisibilityPicker value={edit.visibility} onChange={edit.setVisibility} />
+            </CardContent>
+          </Card>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/bins/BinEditContent.tsx
+++ b/src/features/bins/BinEditContent.tsx
@@ -69,21 +69,6 @@ export function BinEditContent({
           </CardContent>
         </Card>
 
-        {/* Notes */}
-        <Card>
-          <CardContent className="space-y-2 pt-3 pb-4">
-            <Label htmlFor="edit-notes">Notes</Label>
-            <Textarea
-              id="edit-notes"
-              value={edit.notes}
-              onChange={(e) => edit.setNotes(e.target.value)}
-              maxLength={10000}
-              rows={3}
-              className="[field-sizing:content] min-h-[5rem]"
-            />
-          </CardContent>
-        </Card>
-
         {photosSection}
 
         {/* Appearance — icon, color, style */}
@@ -125,6 +110,21 @@ export function BinEditContent({
 
       {/* Right column */}
       <div className="lg:sticky lg:top-6 flex flex-col gap-4">
+        {/* Notes */}
+        <Card>
+          <CardContent className="space-y-2 pt-3 pb-4">
+            <Label htmlFor="edit-notes">Notes</Label>
+            <Textarea
+              id="edit-notes"
+              value={edit.notes}
+              onChange={(e) => edit.setNotes(e.target.value)}
+              maxLength={10000}
+              rows={3}
+              className="[field-sizing:content] min-h-[5rem]"
+            />
+          </CardContent>
+        </Card>
+
         {/* Organization: Area + Tags */}
         <Card>
           <CardContent className="space-y-5 pt-3 pb-4">

--- a/src/features/bins/BinViewContent.tsx
+++ b/src/features/bins/BinViewContent.tsx
@@ -60,140 +60,146 @@ export function BinViewContent({
   const t = useTerminology();
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* AI error */}
-      {aiError && (
-        <Card className="border-t-2 border-t-[var(--destructive)]">
-          <CardContent>
-            <p className="text-[14px] text-[var(--destructive)]">{aiError}</p>
-            <Button variant="ghost" size="sm" onClick={onClearSuggestions} className="mt-2">
-              Dismiss
-            </Button>
-          </CardContent>
-        </Card>
-      )}
+    <div className="flex flex-col lg:grid lg:grid-cols-[3fr_2fr] lg:items-start gap-4">
+      {/* Left column */}
+      <div className="flex flex-col gap-4">
+        {/* AI error */}
+        {aiError && (
+          <Card className="border-t-2 border-t-[var(--destructive)]">
+            <CardContent>
+              <p className="text-[14px] text-[var(--destructive)]">{aiError}</p>
+              <Button variant="ghost" size="sm" onClick={onClearSuggestions} className="mt-2">
+                Dismiss
+              </Button>
+            </CardContent>
+          </Card>
+        )}
 
-      {/* AI suggestions */}
-      {suggestions && (
-        <AiSuggestionsPanel
-          suggestions={suggestions}
-          previousResult={previousResult}
-          currentName={bin.name}
-          currentItems={bin.items}
-          currentTags={bin.tags}
-          currentNotes={bin.notes}
-          customFieldDefs={customFields}
-          currentCustomFields={bin.custom_fields}
-          onApply={onApplySuggestions}
-          onDismiss={onClearSuggestions}
-        />
-      )}
+        {/* AI suggestions */}
+        {suggestions && (
+          <AiSuggestionsPanel
+            suggestions={suggestions}
+            previousResult={previousResult}
+            currentName={bin.name}
+            currentItems={bin.items}
+            currentTags={bin.tags}
+            currentNotes={bin.notes}
+            customFieldDefs={customFields}
+            currentCustomFields={bin.custom_fields}
+            onApply={onApplySuggestions}
+            onDismiss={onClearSuggestions}
+          />
+        )}
 
-      {/* Items card */}
-      <Card>
-        <CardContent className="pt-3 pb-4">
-          <ItemList items={bin.items} binId={bin.id} readOnly={!canEdit} collapsible />
-          {canEdit && <QuickAddWidget quickAdd={quickAdd} aiEnabled={aiEnabled} aiGated={aiGated} onUpgrade={onUpgrade} />}
-        </CardContent>
-      </Card>
-
-      {/* Notes card */}
-      {hasNotes && (
+        {/* Items card */}
         <Card>
           <CardContent className="pt-3 pb-4">
-            <Label>Notes</Label>
-            <p className="mt-2 text-[15px] text-[var(--text-primary)] whitespace-pre-wrap leading-relaxed">
-              {bin.notes}
-            </p>
+            <ItemList items={bin.items} binId={bin.id} readOnly={!canEdit} collapsible />
+            {canEdit && <QuickAddWidget quickAdd={quickAdd} aiEnabled={aiEnabled} aiGated={aiGated} onUpgrade={onUpgrade} />}
           </CardContent>
         </Card>
-      )}
 
-      {/* Area & Tags card */}
-      {(bin.area_name || hasTags) && (
-        <Card>
-          <CardContent className="space-y-4 pt-3 pb-4">
-            {bin.area_name && (
-              <div>
-                <Label>{t.Area}</Label>
-                <p className="mt-1.5 text-[15px] text-[var(--text-primary)]">
-                  {bin.area_name}
-                </p>
-              </div>
-            )}
-            {hasTags && (
-              <div>
-                <Label>Tags</Label>
-                <div className="flex flex-wrap gap-2 mt-2.5">
-                  {bin.tags.map((tag) => (
-                    <Badge
-                      key={tag}
-                      variant="secondary"
-                      style={getTagStyle(tag)}
-                      onClick={() => navigate(`/bins?tags=${encodeURIComponent(tag)}`)}
-                    >
-                      {tag}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
+        {/* Notes card */}
+        {hasNotes && (
+          <Card>
+            <CardContent className="pt-3 pb-4">
+              <Label>Notes</Label>
+              <p className="mt-2 text-[15px] text-[var(--text-primary)] whitespace-pre-wrap leading-relaxed">
+                {bin.notes}
+              </p>
+            </CardContent>
+          </Card>
+        )}
 
-      {/* Custom Fields */}
-      <CustomFieldsViewCard fields={customFields} values={bin.custom_fields} />
+        {photosSection}
+      </div>
 
-      {photosSection}
-
-      {/* QR Code & Info */}
-      <Card data-tour="qr-section">
-        <CardContent className="!py-0">
-          <Disclosure
-            label="QR Code & Info"
-            labelClassName={disclosureSectionLabel}
-            defaultOpen={localStorage.getItem('openbin-qr-expanded') === 'true'}
-            onOpenChange={(v) => localStorage.setItem('openbin-qr-expanded', String(v))}
-          >
-            <div className="pb-4 space-y-4">
-              <div className="flex flex-col items-center">
-                <QRCodeDisplay binId={bin.id} size={160} />
-              </div>
-              <div className="border-t border-[var(--border-subtle)] pt-4">
-                <div className="mb-4">
-                  <Label>Code</Label>
-                  <p className="mt-1.5 text-[15px] font-mono tracking-widest text-[var(--text-primary)]">
-                    {bin.short_code}
+      {/* Right column */}
+      <div className="lg:sticky lg:top-6 flex flex-col gap-4">
+        {/* Area & Tags card */}
+        {(bin.area_name || hasTags) && (
+          <Card>
+            <CardContent className="space-y-4 pt-3 pb-4">
+              {bin.area_name && (
+                <div>
+                  <Label>{t.Area}</Label>
+                  <p className="mt-1.5 text-[15px] text-[var(--text-primary)]">
+                    {bin.area_name}
                   </p>
                 </div>
-                {bin.created_by_name && (
+              )}
+              {hasTags && (
+                <div>
+                  <Label>Tags</Label>
+                  <div className="flex flex-wrap gap-2 mt-2.5">
+                    {bin.tags.map((tag) => (
+                      <Badge
+                        key={tag}
+                        variant="secondary"
+                        style={getTagStyle(tag)}
+                        onClick={() => navigate(`/bins?tags=${encodeURIComponent(tag)}`)}
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Custom Fields */}
+        <CustomFieldsViewCard fields={customFields} values={bin.custom_fields} />
+
+        {/* QR Code & Info */}
+        <Card data-tour="qr-section">
+          <CardContent className="!py-0">
+            <Disclosure
+              label="QR Code & Info"
+              labelClassName={disclosureSectionLabel}
+              defaultOpen={localStorage.getItem('openbin-qr-expanded') === 'true'}
+              onOpenChange={(v) => localStorage.setItem('openbin-qr-expanded', String(v))}
+            >
+              <div className="pb-4 space-y-4">
+                <div className="flex flex-col items-center">
+                  <QRCodeDisplay binId={bin.id} size={160} />
+                </div>
+                <div className="border-t border-[var(--border-subtle)] pt-4">
                   <div className="mb-4">
-                    <Label>Created by</Label>
-                    <p className="mt-1.5 text-[13px] text-[var(--text-secondary)]">
-                      {bin.created_by_name}
+                    <Label>Code</Label>
+                    <p className="mt-1.5 text-[15px] font-mono tracking-widest text-[var(--text-primary)]">
+                      {bin.short_code}
                     </p>
                   </div>
-                )}
-                <div className="grid grid-cols-2 gap-6">
-                  <div>
-                    <Label>Created</Label>
-                    <p className="mt-1.5 text-[13px] text-[var(--text-secondary)]">
-                      {formatDate(bin.created_at)}
-                    </p>
-                  </div>
-                  <div>
-                    <Label>Updated</Label>
-                    <p className="mt-1.5 text-[13px] text-[var(--text-secondary)]">
-                      {formatDate(bin.updated_at)}
-                    </p>
+                  {bin.created_by_name && (
+                    <div className="mb-4">
+                      <Label>Created by</Label>
+                      <p className="mt-1.5 text-[13px] text-[var(--text-secondary)]">
+                        {bin.created_by_name}
+                      </p>
+                    </div>
+                  )}
+                  <div className="grid grid-cols-2 gap-6">
+                    <div>
+                      <Label>Created</Label>
+                      <p className="mt-1.5 text-[13px] text-[var(--text-secondary)]">
+                        {formatDate(bin.created_at)}
+                      </p>
+                    </div>
+                    <div>
+                      <Label>Updated</Label>
+                      <p className="mt-1.5 text-[13px] text-[var(--text-secondary)]">
+                        {formatDate(bin.updated_at)}
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </Disclosure>
-        </CardContent>
-      </Card>
+            </Disclosure>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/features/bins/BinViewContent.tsx
+++ b/src/features/bins/BinViewContent.tsx
@@ -99,6 +99,11 @@ export function BinViewContent({
           </CardContent>
         </Card>
 
+        {photosSection}
+      </div>
+
+      {/* Right column */}
+      <div className="lg:sticky lg:top-6 flex flex-col gap-4">
         {/* Notes card */}
         {hasNotes && (
           <Card>
@@ -111,11 +116,6 @@ export function BinViewContent({
           </Card>
         )}
 
-        {photosSection}
-      </div>
-
-      {/* Right column */}
-      <div className="lg:sticky lg:top-6 flex flex-col gap-4">
         {/* Area & Tags card */}
         {(bin.area_name || hasTags) && (
           <Card>


### PR DESCRIPTION
## Summary
- Adds a responsive two-column grid layout for both view and edit modes on desktop (lg breakpoint)
- Widens bin detail container from max-w-3xl to max-w-5xl to accommodate the layout
- Updates skeleton loading state to match the new two-column structure
- Moves notes card to the right column for better content balance

## Test plan
- [ ] Verify two-column layout appears at lg (1024px+) breakpoint in both view and edit modes
- [ ] Confirm single-column layout on mobile/tablet is unchanged
- [ ] Check skeleton loading state matches the two-column structure
- [ ] Test notes card positioning in right column (view and edit)