### PR TITLE
feat: admin usage metrics and per-plan breakdown

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "@vitejs/plugin-react": "^5.1.4",
         "concurrently": "^9.2.1",
         "happy-dom": "^20.8.9",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "vite": "^6.4.1",
@@ -3647,6 +3649,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4038,6 +4056,85 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4064,6 +4161,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4619,6 +4723,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
@@ -4830,6 +4947,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -5063,6 +5187,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5391,6 +5528,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -6364,6 +6517,58 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -6384,6 +6589,101 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6455,6 +6755,19 @@
       "license": "CC0-1.0",
       "optional": true,
       "peer": true
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -6602,6 +6915,22 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -7086,6 +7415,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rgbcolor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
@@ -7449,6 +7802,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -7545,6 +7944,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -7845,9 +8254,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8944,6 +9353,91 @@
         "workbox-core": "7.4.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -8993,6 +9487,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "npx biome check src/",
-    "check": "tsc --noEmit && cd server && npx tsc --noEmit"
+    "check": "tsc --noEmit && cd server && npx tsc --noEmit",
+    "prepare": "husky"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -42,10 +43,16 @@
     "@vitejs/plugin-react": "^5.1.4",
     "concurrently": "^9.2.1",
     "happy-dom": "^20.8.9",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vite": "^6.4.1",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.0.18"
+  },
+  "lint-staged": {
+    "src/**/*.{ts,tsx}": "npx biome check --no-errors-on-unmatched",
+    "server/src/**/*.{ts,tsx}": "npx biome check --no-errors-on-unmatched"
   }
 }

--- a/server/schema.pg.sql
+++ b/server/schema.pg.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
   previous_sub_status INTEGER,
   ai_credits_used    INTEGER NOT NULL DEFAULT 0,
   ai_credits_reset_at TEXT,
+  last_active_at TEXT,
   is_admin           BOOLEAN NOT NULL DEFAULT FALSE,
   deleted_at         TEXT,
   created_at         TEXT NOT NULL DEFAULT (NOW()),

--- a/server/schema.sqlite.sql
+++ b/server/schema.sqlite.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
   previous_sub_status INTEGER,
   ai_credits_used    INTEGER NOT NULL DEFAULT 0,
   ai_credits_reset_at TEXT,
+  last_active_at TEXT,
   is_admin           INTEGER NOT NULL DEFAULT 0,
   deleted_at         TEXT,
   created_at         TEXT NOT NULL DEFAULT (datetime('now')),

--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -387,6 +387,8 @@ async function runSqliteInit(): Promise<DatabaseEngine> {
 
   // Tag hierarchy: add parent_tag column to tag_colors
   addColumnIfNotExists('ALTER TABLE tag_colors ADD COLUMN parent_tag TEXT DEFAULT NULL');
+  // Admin usage metrics: last_active_at on users
+  addColumnIfNotExists('ALTER TABLE users ADD COLUMN last_active_at TEXT');
 
   } catch (e) {
     log.error('Migration failed — exiting to prevent corrupt state:', e instanceof Error ? e.message : e);

--- a/server/src/lib/metrics.ts
+++ b/server/src/lib/metrics.ts
@@ -216,6 +216,137 @@ function computeWarnings(metrics: Omit<CloudMetrics, 'warnings'>): string[] {
   return warnings;
 }
 
+export interface PlanBreakdownTier {
+  userCount: number;
+  avgBins: number;
+  avgItems: number;
+  avgPhotos: number;
+  avgStorageMb: number;
+  avgLocations: number;
+  avgMembersPerLocation: number;
+  avgAiCreditsUsed: number;
+  aiCreditsLimit: number | null;
+  avgApiKeys: number;
+  avgApiRequests7d: number;
+  avgScans30d: number;
+  atBinLimitPct: number;
+  atStorageLimitPct: number;
+}
+
+export interface PlanBreakdownResponse {
+  free: PlanBreakdownTier;
+  plus: PlanBreakdownTier;
+  pro: PlanBreakdownTier;
+}
+
+const BREAKDOWN_CACHE_TTL_MS = 5 * 60 * 1000;
+let breakdownCache: { data: PlanBreakdownResponse; fetchedAt: number } | null = null;
+
+function emptyTier(): PlanBreakdownTier {
+  return {
+    userCount: 0, avgBins: 0, avgItems: 0, avgPhotos: 0, avgStorageMb: 0,
+    avgLocations: 0, avgMembersPerLocation: 0, avgAiCreditsUsed: 0,
+    aiCreditsLimit: null, avgApiKeys: 0, avgApiRequests7d: 0, avgScans30d: 0,
+    atBinLimitPct: 0, atStorageLimitPct: 0,
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export async function getPlanBreakdown(): Promise<PlanBreakdownResponse> {
+  if (breakdownCache && Date.now() - breakdownCache.fetchedAt < BREAKDOWN_CACHE_TTL_MS) {
+    return breakdownCache.data;
+  }
+
+  const demo = demoExclusion();
+
+  const result = await query<{
+    user_id: string; plan: number; sub_status: number;
+    bin_count: number; item_count: number; photo_count: number;
+    storage_bytes: number; location_count: number; ai_credits_used: number;
+    api_key_count: number; api_requests_7d: number; scans_30d: number;
+  }>(
+    `SELECT u.id as user_id, u.plan, u.sub_status,
+       (SELECT COUNT(*) FROM bins WHERE created_by = u.id AND deleted_at IS NULL) AS bin_count,
+       (SELECT COUNT(*) FROM bin_items bi JOIN bins b ON b.id = bi.bin_id WHERE b.created_by = u.id AND b.deleted_at IS NULL) AS item_count,
+       (SELECT COUNT(*) FROM photos WHERE created_by = u.id) AS photo_count,
+       (SELECT COALESCE(SUM(size), 0) FROM photos WHERE created_by = u.id) AS storage_bytes,
+       (SELECT COUNT(DISTINCT lm.location_id) FROM location_members lm WHERE lm.user_id = u.id) AS location_count,
+       u.ai_credits_used,
+       (SELECT COUNT(*) FROM api_keys WHERE user_id = u.id AND revoked_at IS NULL) AS api_key_count,
+       (SELECT COALESCE(SUM(request_count), 0) FROM api_key_daily_usage WHERE api_key_id IN (SELECT id FROM api_keys WHERE user_id = u.id) AND date >= ${d.dateOf(d.daysAgo(7))}) AS api_requests_7d,
+       (SELECT COUNT(*) FROM scan_history WHERE user_id = u.id AND scanned_at >= ${d.daysAgo(30)}) AS scans_30d
+     FROM users u
+     WHERE u.sub_status != ${SubStatus.INACTIVE} AND u.deleted_at IS NULL ${demo.clause}`,
+    demo.params,
+  );
+
+  const memberAvgResult = await query<{ plan: number; avg_members: number }>(
+    `SELECT u.plan, AVG(cnt) as avg_members
+     FROM (SELECT l.created_by, lm.location_id, COUNT(*) as cnt FROM location_members lm JOIN locations l ON l.id = lm.location_id GROUP BY l.created_by, lm.location_id) sub
+     JOIN users u ON u.id = sub.created_by
+     WHERE u.sub_status != ${SubStatus.INACTIVE} AND u.deleted_at IS NULL
+     GROUP BY u.plan`,
+  );
+  const memberAvgByPlan = new Map<number, number>();
+  for (const row of memberAvgResult.rows) memberAvgByPlan.set(row.plan, row.avg_members);
+
+  const tiers = new Map<number, typeof result.rows>([
+    [Plan.FREE, []], [Plan.PLUS, []], [Plan.PRO, []],
+  ]);
+  for (const row of result.rows) {
+    tiers.get(row.plan)?.push(row);
+  }
+
+  function buildTier(planId: number, users: typeof result.rows): PlanBreakdownTier {
+    const n = users.length;
+    if (n === 0) return emptyTier();
+    const features = getFeatureMap(planId as import('./planGate.js').PlanTier);
+    const sum = { bins: 0, items: 0, photos: 0, storageMb: 0, locations: 0, aiCredits: 0, apiKeys: 0, apiReqs: 0, scans: 0 };
+    let atBinLimit = 0;
+    let atStorageLimit = 0;
+    for (const u of users) {
+      sum.bins += u.bin_count;
+      sum.items += u.item_count;
+      sum.photos += u.photo_count;
+      sum.storageMb += u.storage_bytes / (1024 * 1024);
+      sum.locations += u.location_count;
+      sum.aiCredits += u.ai_credits_used;
+      sum.apiKeys += u.api_key_count;
+      sum.apiReqs += u.api_requests_7d;
+      sum.scans += u.scans_30d;
+      if (features.maxBins !== null && u.bin_count >= features.maxBins * 0.9) atBinLimit++;
+      if (features.maxPhotoStorageMb !== null && u.storage_bytes / (1024 * 1024) >= features.maxPhotoStorageMb * 0.9) atStorageLimit++;
+    }
+    return {
+      userCount: n,
+      avgBins: round2(sum.bins / n),
+      avgItems: round2(sum.items / n),
+      avgPhotos: round2(sum.photos / n),
+      avgStorageMb: round2(sum.storageMb / n),
+      avgLocations: round2(sum.locations / n),
+      avgMembersPerLocation: round2(memberAvgByPlan.get(planId) ?? 0),
+      avgAiCreditsUsed: round2(sum.aiCredits / n),
+      aiCreditsLimit: features.aiCreditsPerMonth,
+      avgApiKeys: round2(sum.apiKeys / n),
+      avgApiRequests7d: round2(sum.apiReqs / n),
+      avgScans30d: round2(sum.scans / n),
+      atBinLimitPct: Math.round(atBinLimit / n * 100),
+      atStorageLimitPct: Math.round(atStorageLimit / n * 100),
+    };
+  }
+
+  const data: PlanBreakdownResponse = {
+    free: buildTier(Plan.FREE, tiers.get(Plan.FREE)!),
+    plus: buildTier(Plan.PLUS, tiers.get(Plan.PLUS)!),
+    pro: buildTier(Plan.PRO, tiers.get(Plan.PRO)!),
+  };
+  breakdownCache = { data, fetchedAt: Date.now() };
+  return data;
+}
+
 export async function getCloudMetrics(): Promise<CloudMetrics> {
   if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
     return cache.data;

--- a/server/src/lib/metrics.ts
+++ b/server/src/lib/metrics.ts
@@ -262,34 +262,36 @@ export async function getPlanBreakdown(): Promise<PlanBreakdownResponse> {
 
   const demo = demoExclusion();
 
-  const result = await query<{
-    user_id: string; plan: number; sub_status: number;
-    bin_count: number; item_count: number; photo_count: number;
-    storage_bytes: number; location_count: number; ai_credits_used: number;
-    api_key_count: number; api_requests_7d: number; scans_30d: number;
-  }>(
-    `SELECT u.id as user_id, u.plan, u.sub_status,
-       (SELECT COUNT(*) FROM bins WHERE created_by = u.id AND deleted_at IS NULL) AS bin_count,
-       (SELECT COUNT(*) FROM bin_items bi JOIN bins b ON b.id = bi.bin_id WHERE b.created_by = u.id AND b.deleted_at IS NULL) AS item_count,
-       (SELECT COUNT(*) FROM photos WHERE created_by = u.id) AS photo_count,
-       (SELECT COALESCE(SUM(size), 0) FROM photos WHERE created_by = u.id) AS storage_bytes,
-       (SELECT COUNT(DISTINCT lm.location_id) FROM location_members lm WHERE lm.user_id = u.id) AS location_count,
-       u.ai_credits_used,
-       (SELECT COUNT(*) FROM api_keys WHERE user_id = u.id AND revoked_at IS NULL) AS api_key_count,
-       (SELECT COALESCE(SUM(request_count), 0) FROM api_key_daily_usage WHERE api_key_id IN (SELECT id FROM api_keys WHERE user_id = u.id) AND date >= ${d.dateOf(d.daysAgo(7))}) AS api_requests_7d,
-       (SELECT COUNT(*) FROM scan_history WHERE user_id = u.id AND scanned_at >= ${d.daysAgo(30)}) AS scans_30d
-     FROM users u
-     WHERE u.sub_status != ${SubStatus.INACTIVE} AND u.deleted_at IS NULL ${demo.clause}`,
-    demo.params,
-  );
+  const [result, memberAvgResult] = await Promise.all([
+    query<{
+      user_id: string; plan: number; sub_status: number;
+      bin_count: number; item_count: number; photo_count: number;
+      storage_bytes: number; location_count: number; ai_credits_used: number;
+      api_key_count: number; api_requests_7d: number; scans_30d: number;
+    }>(
+      `SELECT u.id as user_id, u.plan, u.sub_status,
+         (SELECT COUNT(*) FROM bins WHERE created_by = u.id AND deleted_at IS NULL) AS bin_count,
+         (SELECT COUNT(*) FROM bin_items bi JOIN bins b ON b.id = bi.bin_id WHERE b.created_by = u.id AND b.deleted_at IS NULL) AS item_count,
+         (SELECT COUNT(*) FROM photos WHERE created_by = u.id) AS photo_count,
+         (SELECT COALESCE(SUM(size), 0) FROM photos WHERE created_by = u.id) AS storage_bytes,
+         (SELECT COUNT(DISTINCT lm.location_id) FROM location_members lm WHERE lm.user_id = u.id) AS location_count,
+         u.ai_credits_used,
+         (SELECT COUNT(*) FROM api_keys WHERE user_id = u.id AND revoked_at IS NULL) AS api_key_count,
+         (SELECT COALESCE(SUM(request_count), 0) FROM api_key_daily_usage WHERE api_key_id IN (SELECT id FROM api_keys WHERE user_id = u.id) AND date >= ${d.dateOf(d.daysAgo(7))}) AS api_requests_7d,
+         (SELECT COUNT(*) FROM scan_history WHERE user_id = u.id AND scanned_at >= ${d.daysAgo(30)}) AS scans_30d
+       FROM users u
+       WHERE u.sub_status != ${SubStatus.INACTIVE} AND u.deleted_at IS NULL ${demo.clause}`,
+      demo.params,
+    ),
+    query<{ plan: number; avg_members: number }>(
+      `SELECT u.plan, AVG(cnt) as avg_members
+       FROM (SELECT l.created_by, lm.location_id, COUNT(*) as cnt FROM location_members lm JOIN locations l ON l.id = lm.location_id GROUP BY l.created_by, lm.location_id) sub
+       JOIN users u ON u.id = sub.created_by
+       WHERE u.sub_status != ${SubStatus.INACTIVE} AND u.deleted_at IS NULL
+       GROUP BY u.plan`,
+    ),
+  ]);
 
-  const memberAvgResult = await query<{ plan: number; avg_members: number }>(
-    `SELECT u.plan, AVG(cnt) as avg_members
-     FROM (SELECT l.created_by, lm.location_id, COUNT(*) as cnt FROM location_members lm JOIN locations l ON l.id = lm.location_id GROUP BY l.created_by, lm.location_id) sub
-     JOIN users u ON u.id = sub.created_by
-     WHERE u.sub_status != ${SubStatus.INACTIVE} AND u.deleted_at IS NULL
-     GROUP BY u.plan`,
-  );
   const memberAvgByPlan = new Map<number, number>();
   for (const row of memberAvgResult.rows) memberAvgByPlan.set(row.plan, row.avg_members);
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -46,6 +46,7 @@ export function tryAuthenticate(req: Request, _res: Response, next: NextFunction
         if (user) {
           req.user = user;
           req.authMethod = 'jwt';
+          maybeUpdateLastActive(user.id);
         }
         next();
       }).catch(() => next());
@@ -59,6 +60,18 @@ export function tryAuthenticate(req: Request, _res: Response, next: NextFunction
 // Soft-deletes are rare admin actions; 60 s staleness is acceptable.
 const deletedCache = new Map<string, { deleted: boolean; expires: number }>();
 const DELETED_CACHE_TTL = 60_000;
+
+// Debounce last_active_at writes to once per 5 minutes per user
+const LAST_ACTIVE_DEBOUNCE_MS = 5 * 60 * 1000;
+const lastActiveCache = new Map<string, number>();
+
+function maybeUpdateLastActive(userId: string): void {
+  const now = Date.now();
+  const lastWrite = lastActiveCache.get(userId);
+  if (lastWrite && now - lastWrite < LAST_ACTIVE_DEBOUNCE_MS) return;
+  lastActiveCache.set(userId, now);
+  query(`UPDATE users SET last_active_at = ${d.now()} WHERE id = $1`, [userId]).catch(() => {});
+}
 
 function checkSoftDeleted(userId: string): Promise<boolean> {
   const cached = deletedCache.get(userId);
@@ -81,13 +94,15 @@ export function invalidateDeletedCache(userId: string): void {
 
 export function authenticate(req: Request, res: Response, next: NextFunction): void {
   if (req.user) {
-    checkSoftDeleted(req.user.id).then((deleted) => {
+    const userId = req.user.id;
+    checkSoftDeleted(userId).then((deleted) => {
       if (deleted) {
         req.user = undefined;
         req.authMethod = undefined;
         res.status(401).json({ error: 'ACCOUNT_DELETED', message: 'This account has been deleted' });
         return;
       }
+      maybeUpdateLastActive(userId);
       next();
     }).catch(next);
     return;
@@ -125,6 +140,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
       req.user = { id: row.id, username: row.username };
       req.authMethod = 'api_key';
       req.apiKeyId = row.key_id;
+      maybeUpdateLastActive(row.id);
       // Fire-and-forget: update last_used_at + daily usage counter
       query(`UPDATE api_keys SET last_used_at = ${d.now()} WHERE id = $1`, [row.key_id]).catch(() => {});
       query(`INSERT INTO api_key_daily_usage (api_key_id, date) VALUES ($1, ${d.today()}) ON CONFLICT(api_key_id, date) DO UPDATE SET request_count = request_count + 1`, [row.key_id]).catch(() => {});
@@ -145,6 +161,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
         }
         req.user = user;
         req.authMethod = 'jwt';
+        maybeUpdateLastActive(user.id);
         next();
       }).catch(next);
     } else {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -63,12 +63,14 @@ const DELETED_CACHE_TTL = 60_000;
 
 // Debounce last_active_at writes to once per 5 minutes per user
 const LAST_ACTIVE_DEBOUNCE_MS = 5 * 60 * 1000;
+const LAST_ACTIVE_CACHE_MAX = 10_000;
 const lastActiveCache = new Map<string, number>();
 
 function maybeUpdateLastActive(userId: string): void {
   const now = Date.now();
   const lastWrite = lastActiveCache.get(userId);
   if (lastWrite && now - lastWrite < LAST_ACTIVE_DEBOUNCE_MS) return;
+  if (lastActiveCache.size >= LAST_ACTIVE_CACHE_MAX) lastActiveCache.clear();
   lastActiveCache.set(userId, now);
   query(`UPDATE users SET last_active_at = ${d.now()} WHERE id = $1`, [userId]).catch(() => {});
 }

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -12,7 +12,7 @@ import { firePasswordResetEmail } from '../lib/emailSender.js';
 import { ConflictError, ForbiddenError, HttpError, NotFoundError, ValidationError } from '../lib/httpErrors.js';
 import { createLogger } from '../lib/logger.js';
 import { notifyManagerUserUpdate } from '../lib/managerWebhook.js';
-import { getCloudMetrics } from '../lib/metrics.js';
+import { getCloudMetrics, getPlanBreakdown } from '../lib/metrics.js';
 import { createPasswordResetToken } from '../lib/passwordReset.js';
 import { getFeatureMap, invalidateOverLimitCache, isSelfHosted, Plan, type PlanTier, planLabel, SubStatus, type SubStatusType, subStatusLabel, validatePlanTransition } from '../lib/planGate.js';
 import { metricsLimiter } from '../lib/rateLimiters.js';
@@ -123,6 +123,8 @@ router.get('/users', asyncHandler(async (req, res) => {
       apiKeyCount: u.api_key_count ?? 0,
       apiRequests7d: u.api_requests_7d ?? 0,
       binsCreated7d: u.bins_created_7d ?? 0,
+      binLimit: features.maxBins,
+      storageLimit: features.maxPhotoStorageMb,
     };
   });
 
@@ -508,7 +510,6 @@ router.get('/metrics/plan-breakdown', metricsLimiter, asyncHandler(async (_req, 
   if (config.selfHosted) {
     throw new NotFoundError('Metrics not available in self-hosted mode');
   }
-  const { getPlanBreakdown } = await import('../lib/metrics.js');
   const breakdown = await getPlanBreakdown();
   res.json(breakdown);
 }));

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -14,7 +14,7 @@ import { createLogger } from '../lib/logger.js';
 import { notifyManagerUserUpdate } from '../lib/managerWebhook.js';
 import { getCloudMetrics } from '../lib/metrics.js';
 import { createPasswordResetToken } from '../lib/passwordReset.js';
-import { invalidateOverLimitCache, isSelfHosted, Plan, type PlanTier, planLabel, SubStatus, type SubStatusType, subStatusLabel, validatePlanTransition } from '../lib/planGate.js';
+import { getFeatureMap, invalidateOverLimitCache, isSelfHosted, Plan, type PlanTier, planLabel, SubStatus, type SubStatusType, subStatusLabel, validatePlanTransition } from '../lib/planGate.js';
 import { metricsLimiter } from '../lib/rateLimiters.js';
 import { restoreBackup } from '../lib/restore.js';
 import { validateDisplayName, validateEmail, validatePassword, validateUsername } from '../lib/validation.js';
@@ -64,36 +64,67 @@ router.get('/users', asyncHandler(async (req, res) => {
     bins: 'bin_count',
     locations: 'location_count',
     storage: 'photo_storage_bytes',
+    lastActive: 'u.last_active_at',
+    items: 'item_count',
+    photos: 'photo_count',
+    scans30d: 'scans_30d',
+    aiCredits: 'u.ai_credits_used',
+    apiKeys: 'api_key_count',
+    apiRequests7d: 'api_requests_7d',
+    binPct: 'bin_count',
+    storagePct: 'photo_storage_bytes',
+    binsCreated7d: 'bins_created_7d',
+    accountAge: 'u.created_at',
   };
   const orderCol = Object.hasOwn(sortMap, field) ? sortMap[field] : sortMap.created;
   const orderDir = desc ? 'DESC' : 'ASC';
 
   const usersResult = await query(
-    `SELECT u.id, u.username, u.display_name, u.email, u.is_admin, u.plan, u.sub_status, u.active_until, u.deleted_at, u.created_at,
+    `SELECT u.id, u.username, u.display_name, u.email, u.is_admin, u.plan, u.sub_status,
+       u.active_until, u.deleted_at, u.created_at, u.last_active_at,
+       u.ai_credits_used, u.ai_credits_reset_at,
        (SELECT COUNT(*) FROM bins b JOIN location_members lm ON b.location_id = lm.location_id WHERE lm.user_id = u.id AND b.deleted_at IS NULL) AS bin_count,
        (SELECT COUNT(DISTINCT lm.location_id) FROM location_members lm WHERE lm.user_id = u.id) AS location_count,
-       (SELECT COALESCE(SUM(p.size), 0) FROM photos p WHERE p.created_by = u.id) AS photo_storage_bytes
+       (SELECT COALESCE(SUM(p.size), 0) FROM photos p WHERE p.created_by = u.id) AS photo_storage_bytes,
+       (SELECT COUNT(*) FROM bin_items bi JOIN bins b ON b.id = bi.bin_id WHERE b.created_by = u.id AND b.deleted_at IS NULL) AS item_count,
+       (SELECT COUNT(*) FROM photos WHERE created_by = u.id) AS photo_count,
+       (SELECT COUNT(*) FROM scan_history WHERE user_id = u.id AND scanned_at >= ${d.daysAgo(30)}) AS scans_30d,
+       (SELECT COUNT(*) FROM api_keys WHERE user_id = u.id AND revoked_at IS NULL) AS api_key_count,
+       (SELECT COALESCE(SUM(request_count), 0) FROM api_key_daily_usage WHERE api_key_id IN (SELECT id FROM api_keys WHERE user_id = u.id) AND date >= ${d.dateOf(d.daysAgo(7))}) AS api_requests_7d,
+       (SELECT COUNT(*) FROM bins WHERE created_by = u.id AND deleted_at IS NULL AND created_at >= ${d.daysAgo(7)}) AS bins_created_7d
      FROM users u ${whereClause}
      ORDER BY ${orderCol} ${orderDir}
      LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
     [...params, limit, offset],
   );
 
-  const results = usersResult.rows.map((u: any) => ({
-    id: u.id,
-    username: u.username,
-    displayName: u.display_name,
-    email: u.email || null,
-    isAdmin: !!u.is_admin,
-    plan: planLabel(u.plan),
-    status: subStatusLabel(u.sub_status),
-    activeUntil: u.active_until || null,
-    deletedAt: u.deleted_at || null,
-    createdAt: u.created_at,
-    binCount: u.bin_count ?? 0,
-    locationCount: u.location_count ?? 0,
-    photoStorageMb: Math.round((u.photo_storage_bytes ?? 0) / 1024 / 1024 * 10) / 10,
-  }));
+  const results = usersResult.rows.map((u: any) => {
+    const features = getFeatureMap(u.plan as PlanTier);
+    return {
+      id: u.id,
+      username: u.username,
+      displayName: u.display_name,
+      email: u.email || null,
+      isAdmin: !!u.is_admin,
+      plan: planLabel(u.plan),
+      status: subStatusLabel(u.sub_status),
+      activeUntil: u.active_until || null,
+      deletedAt: u.deleted_at || null,
+      createdAt: u.created_at,
+      binCount: u.bin_count ?? 0,
+      locationCount: u.location_count ?? 0,
+      photoStorageMb: Math.round((u.photo_storage_bytes ?? 0) / 1024 / 1024 * 10) / 10,
+      lastActiveAt: u.last_active_at || null,
+      itemCount: u.item_count ?? 0,
+      photoCount: u.photo_count ?? 0,
+      scans30d: u.scans_30d ?? 0,
+      aiCreditsUsed: u.ai_credits_used ?? 0,
+      aiCreditsLimit: features.aiCreditsPerMonth ?? 0,
+      apiKeyCount: u.api_key_count ?? 0,
+      apiRequests7d: u.api_requests_7d ?? 0,
+      binsCreated7d: u.bins_created_7d ?? 0,
+    };
+  });
 
   res.json({ results, count: countResult.rows[0].cnt, adminCount: await getAdminCount() });
 }));
@@ -163,22 +194,29 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
     id: string; username: string; display_name: string; email: string | null;
     is_admin: number; plan: PlanTier; sub_status: SubStatusType;
     active_until: string | null; deleted_at: string | null; created_at: string; updated_at: string;
+    last_active_at: string | null; ai_credits_used: number | null; ai_credits_reset_at: string | null;
   }>(
-    'SELECT id, username, display_name, email, is_admin, plan, sub_status, active_until, deleted_at, created_at, updated_at FROM users WHERE id = $1',
+    'SELECT id, username, display_name, email, is_admin, plan, sub_status, active_until, deleted_at, created_at, updated_at, last_active_at, ai_credits_used, ai_credits_reset_at FROM users WHERE id = $1',
     [userId],
   );
 
   const row = userResult.rows[0];
   if (!row) throw new NotFoundError('User not found');
 
-  const [locationRes, binRes, photoRes, storageRes, apiKeyRes, shareRes] = await Promise.all([
+  const [locationRes, binRes, photoRes, storageRes, apiKeyRes, shareRes, itemRes, scanRes, apiReqRes, binsCreated7dRes] = await Promise.all([
     query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM locations WHERE created_by = $1', [userId]),
     query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM bins WHERE created_by = $1 AND deleted_at IS NULL', [userId]),
     query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM photos WHERE created_by = $1', [userId]),
     query<{ total: number }>('SELECT COALESCE(SUM(size), 0) as total FROM photos WHERE created_by = $1', [userId]),
     query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL', [userId]),
     query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM bin_shares WHERE created_by = $1 AND revoked_at IS NULL', [userId]),
+    query<{ cnt: number }>(`SELECT COUNT(*) as cnt FROM bin_items bi JOIN bins b ON b.id = bi.bin_id WHERE b.created_by = $1 AND b.deleted_at IS NULL`, [userId]),
+    query<{ cnt: number }>(`SELECT COUNT(*) as cnt FROM scan_history WHERE user_id = $1 AND scanned_at >= ${d.daysAgo(30)}`, [userId]),
+    query<{ total: number }>(`SELECT COALESCE(SUM(request_count), 0) as total FROM api_key_daily_usage WHERE api_key_id IN (SELECT id FROM api_keys WHERE user_id = $1) AND date >= ${d.dateOf(d.daysAgo(7))}`, [userId]),
+    query<{ cnt: number }>(`SELECT COUNT(*) as cnt FROM bins WHERE created_by = $1 AND deleted_at IS NULL AND created_at >= ${d.daysAgo(7)}`, [userId]),
   ]);
+
+  const features = getFeatureMap(row.plan);
 
   res.json({
     id: row.id,
@@ -192,6 +230,7 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
     deletedAt: row.deleted_at || null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    lastActiveAt: row.last_active_at || null,
     stats: {
       locationCount: locationRes.rows[0].cnt,
       binCount: binRes.rows[0].cnt,
@@ -199,6 +238,15 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
       photoStorageMb: Math.round((storageRes.rows[0].total / (1024 * 1024)) * 100) / 100,
       apiKeyCount: apiKeyRes.rows[0].cnt,
       shareCount: shareRes.rows[0].cnt,
+      itemCount: itemRes.rows[0].cnt,
+      scans30d: scanRes.rows[0].cnt,
+      aiCreditsUsed: row.ai_credits_used ?? 0,
+      aiCreditsLimit: features.aiCreditsPerMonth ?? 0,
+      aiCreditsResetAt: row.ai_credits_reset_at || null,
+      apiRequests7d: apiReqRes.rows[0].total,
+      binsCreated7d: binsCreated7dRes.rows[0].cnt,
+      binLimit: features.maxBins,
+      storageLimit: features.maxPhotoStorageMb,
     },
   });
 }));

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -503,6 +503,16 @@ router.get('/metrics', metricsLimiter, asyncHandler(async (_req, res) => {
   res.json(metrics);
 }));
 
+// GET /api/admin/metrics/plan-breakdown — per-plan usage averages
+router.get('/metrics/plan-breakdown', metricsLimiter, asyncHandler(async (_req, res) => {
+  if (config.selfHosted) {
+    throw new NotFoundError('Metrics not available in self-hosted mode');
+  }
+  const { getPlanBreakdown } = await import('../lib/metrics.js');
+  const breakdown = await getPlanBreakdown();
+  res.json(breakdown);
+}));
+
 // PATCH /api/admin/registration — toggle registration mode
 // Runtime override stored in settings table; env var takes precedence
 router.patch('/registration', asyncHandler(async (req, res) => {

--- a/src/features/admin/AdminColumnVisibilityMenu.tsx
+++ b/src/features/admin/AdminColumnVisibilityMenu.tsx
@@ -1,0 +1,60 @@
+import { Columns3 } from 'lucide-react';
+import { useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip } from '@/components/ui/tooltip';
+import { useClickOutside } from '@/lib/useClickOutside';
+import { usePopover } from '@/lib/usePopover';
+import { cn } from '@/lib/utils';
+import { ADMIN_FIELD_LABELS, type AdminFieldKey, TOGGLEABLE_FIELDS } from './useAdminColumnVisibility';
+
+interface AdminColumnVisibilityMenuProps {
+  visibility: Record<AdminFieldKey, boolean>;
+  onToggle: (field: AdminFieldKey) => void;
+}
+
+export function AdminColumnVisibilityMenu({ visibility, onToggle }: AdminColumnVisibilityMenuProps) {
+  const { visible, animating, close, toggle } = usePopover();
+  const menuRef = useRef<HTMLDivElement>(null);
+  useClickOutside(menuRef, close);
+
+  return (
+    <div ref={menuRef} className="relative">
+      <Tooltip content="Columns" side="bottom">
+        <Button
+          variant="secondary"
+          size="icon"
+          onClick={toggle}
+          className="shrink-0 rounded-[var(--radius-sm)]"
+          aria-label="Toggle column visibility"
+        >
+          <Columns3 className="h-4 w-4" />
+        </Button>
+      </Tooltip>
+      {visible && (
+        <div className={cn(
+          animating === 'exit' ? 'animate-popover-exit' : 'animate-popover-enter',
+          'absolute right-0 mt-1 w-52 max-h-80 overflow-y-auto rounded-[var(--radius-md)] flat-popover z-20',
+        )}>
+          <div className="px-3.5 py-2 text-[11px] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
+            Visible Columns
+          </div>
+          {TOGGLEABLE_FIELDS.map((field) => (
+            <label
+              key={field}
+              htmlFor={`admin-col-${field}`}
+              className="w-full row-spread px-3.5 py-2 text-[15px] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
+            >
+              {ADMIN_FIELD_LABELS[field]}
+              <Switch
+                id={`admin-col-${field}`}
+                checked={visibility[field]}
+                onCheckedChange={() => onToggle(field)}
+              />
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/admin/AdminMetricsSection.tsx
+++ b/src/features/admin/AdminMetricsSection.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+import { PlanBreakdownCard } from './PlanBreakdownCard';
 import { useAdminMetrics } from './useAdminMetrics';
 
 function MetricCard({ label, value, sub, large }: { label: string; value: string | number; sub?: string; large?: boolean }) {
@@ -110,6 +111,8 @@ export function AdminMetricsSection() {
           </div>
         </CardContent>
       </Card>
+
+      <PlanBreakdownCard />
     </>
   );
 }

--- a/src/features/admin/AdminUserDetailPage.tsx
+++ b/src/features/admin/AdminUserDetailPage.tsx
@@ -26,7 +26,7 @@ import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/toast';
 import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
-import { cn, getErrorMessage } from '@/lib/utils';
+import { cn, getErrorMessage, relativeTime } from '@/lib/utils';
 import { capitalize, deleteUser, regenerateApiKey, sendPasswordReset, statusVariant, updateUser, useAdminCount, useAdminUserDetail } from './useAdminUsers';
 
 function StatItem({ label, value }: { label: string; value: string | number }) {
@@ -53,18 +53,6 @@ function LimitStatItem({ label, used, limit, unit }: { label: string; used: numb
       </div>
     </div>
   );
-}
-
-function relativeTime(iso: string | null): string {
-  if (!iso) return '—';
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'Just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 export function AdminUserDetailPage() {

--- a/src/features/admin/AdminUserDetailPage.tsx
+++ b/src/features/admin/AdminUserDetailPage.tsx
@@ -38,6 +38,35 @@ function StatItem({ label, value }: { label: string; value: string | number }) {
   );
 }
 
+function LimitStatItem({ label, used, limit, unit }: { label: string; used: number; limit: number | null; unit?: string }) {
+  if (limit === null || limit === 0) return <StatItem label={label} value="—" />;
+  const pct = Math.round(used / limit * 100);
+  const color = pct >= 90 ? 'bg-[var(--destructive)]' : pct >= 75 ? 'bg-[var(--color-warning)]' : 'bg-[var(--accent)]';
+  return (
+    <div className="flex flex-col gap-1.5 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-input)]">
+      <span className="text-[12px] text-[var(--text-tertiary)] uppercase tracking-wide">{label}</span>
+      <span className="text-[20px] font-bold text-[var(--text-primary)] leading-tight tabular-nums">
+        {used}{unit ? ` ${unit}` : ''} <span className="text-[14px] font-normal text-[var(--text-tertiary)]">/ {limit}{unit ? ` ${unit}` : ''}</span>
+      </span>
+      <div className="h-1.5 rounded-[var(--radius-full)] bg-[var(--bg-hover)] overflow-hidden">
+        <div className={cn('h-full rounded-[var(--radius-full)] transition-all', color)} style={{ width: `${Math.min(pct, 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
 export function AdminUserDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -294,14 +323,31 @@ export function AdminUserDetailPage() {
           <CardTitle>Stats</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            <StatItem label="Last Active" value={relativeTime(detail.lastActiveAt)} />
             <StatItem label="Locations" value={detail.stats.locationCount} />
             <StatItem label="Bins" value={detail.stats.binCount} />
+            <StatItem label="Items" value={detail.stats.itemCount} />
             <StatItem label="Photos" value={detail.stats.photoCount} />
             <StatItem label="Storage (MB)" value={detail.stats.photoStorageMb} />
+            <StatItem label="Scans (30d)" value={detail.stats.scans30d} />
             <StatItem label="API Keys" value={detail.stats.apiKeyCount} />
+            <StatItem label="API Reqs (7d)" value={detail.stats.apiRequests7d} />
             <StatItem label="Shares" value={detail.stats.shareCount} />
+            <StatItem label="New Bins (7d)" value={detail.stats.binsCreated7d} />
+            <StatItem label="Account Age" value={`${Math.floor((Date.now() - new Date(detail.createdAt).getTime()) / 86400000)}d`} />
           </div>
+
+          {/* Limit bars */}
+          {(detail.stats.binLimit !== null || detail.stats.storageLimit !== null || detail.stats.aiCreditsLimit > 0) && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mt-3">
+              <LimitStatItem label="Bin Usage" used={detail.stats.binCount} limit={detail.stats.binLimit} />
+              <LimitStatItem label="Storage Usage" used={detail.stats.photoStorageMb} limit={detail.stats.storageLimit} unit="MB" />
+              {detail.stats.aiCreditsLimit > 0 && (
+                <LimitStatItem label="AI Credits" used={detail.stats.aiCreditsUsed} limit={detail.stats.aiCreditsLimit} />
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/src/features/admin/AdminUsersPage.tsx
+++ b/src/features/admin/AdminUsersPage.tsx
@@ -21,8 +21,10 @@ import { useToast } from '@/components/ui/toast';
 import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
 import { getErrorMessage } from '@/lib/utils';
+import { AdminColumnVisibilityMenu } from './AdminColumnVisibilityMenu';
 import { AdminMetricsSection } from './AdminMetricsSection';
 import { AdminUsersTable } from './AdminUsersTable';
+import { useAdminColumnVisibility } from './useAdminColumnVisibility';
 import { type AdminUser, useAdminUsers } from './useAdminUsers';
 
 const PAGE_SIZE = 25;
@@ -41,8 +43,9 @@ export function AdminUsersPage() {
   const [tab, setTab] = useState<'users' | 'metrics'>('users');
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
-  const [sortColumn, setSortColumn] = useState<'username' | 'email' | 'plan' | 'status' | 'bins' | 'locations' | 'storage' | 'created'>('created');
+  const [sortColumn, setSortColumn] = useState<string>('created');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const { visibility, toggleField, isVisible } = useAdminColumnVisibility();
   const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [createForm, setCreateForm] = useState({ username: '', password: '', displayName: '', email: '', isAdmin: false });
@@ -52,7 +55,7 @@ export function AdminUsersPage() {
   const { users, count, isLoading, registration, deleteUser, updateRegistrationMode, createUser } = useAdminUsers(search, page, sortParam);
   const totalPages = Math.ceil(count / PAGE_SIZE);
 
-  const handleSort = useCallback((column: typeof sortColumn, direction: SortDirection) => {
+  const handleSort = useCallback((column: string, direction: SortDirection) => {
     setSortColumn(column);
     setSortDirection(direction);
     setPage(1);
@@ -167,12 +170,16 @@ export function AdminUsersPage() {
             <Badge variant="secondary" className="text-[11px]">{count}</Badge>
           </div>
 
-          <SearchInput
-            placeholder="Search users..."
-            value={search}
-            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-            onClear={search ? () => { setSearch(''); setPage(1); } : undefined}
-          />
+          <div className="flex items-center gap-2">
+            <SearchInput
+              placeholder="Search users..."
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              onClear={search ? () => { setSearch(''); setPage(1); } : undefined}
+              className="flex-1"
+            />
+            <AdminColumnVisibilityMenu visibility={visibility} onToggle={toggleField} />
+          </div>
 
           {/* Users table */}
           {isLoading ? (
@@ -224,6 +231,7 @@ export function AdminUsersPage() {
               onSort={handleSort}
               onDelete={setDeleteTarget}
               onClickUser={(id) => navigate(`/admin/users/${id}`)}
+              isVisible={isVisible}
             />
           )}
 

--- a/src/features/admin/AdminUsersTable.tsx
+++ b/src/features/admin/AdminUsersTable.tsx
@@ -4,18 +4,46 @@ import { Button } from '@/components/ui/button';
 import { type SortDirection, SortHeader } from '@/components/ui/sort-header';
 import { Table, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
+import type { AdminFieldKey } from './useAdminColumnVisibility';
 import { type AdminUser, capitalize, statusVariant } from './useAdminUsers';
 
-type SortField = 'username' | 'email' | 'plan' | 'status' | 'bins' | 'locations' | 'storage' | 'created';
+
+const PLAN_LIMITS: Record<string, { maxBins: number | null; maxStorageMb: number | null }> = {
+  free:  { maxBins: 50,   maxStorageMb: 0    },
+  plus:  { maxBins: 500,  maxStorageMb: 100  },
+  pro:   { maxBins: 5000, maxStorageMb: 1000 },
+};
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+function pctColor(pct: number): string {
+  if (pct > 90) return 'text-[var(--destructive)]';
+  if (pct >= 75) return 'text-[var(--color-warning)]';
+  return '';
+}
 
 interface AdminUsersTableProps {
   users: AdminUser[];
   currentUserId: string;
-  sortColumn: SortField;
+  sortColumn: string;
   sortDirection: SortDirection;
-  onSort: (column: SortField, direction: SortDirection) => void;
+  onSort: (column: string, direction: SortDirection) => void;
   onDelete: (user: AdminUser) => void;
   onClickUser: (id: string) => void;
+  isVisible: (field: AdminFieldKey) => boolean;
 }
 
 export function AdminUsersTable({
@@ -26,6 +54,7 @@ export function AdminUsersTable({
   onSort,
   onDelete,
   onClickUser,
+  isVisible,
 }: AdminUsersTableProps) {
   return (
     <Table>
@@ -33,35 +62,111 @@ export function AdminUsersTable({
         <div className="flex-1 min-w-0">
           <SortHeader label="User" column="username" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
         </div>
-        <div className="hidden lg:block w-40">
-          <SortHeader label="Email" column="email" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
-        </div>
-        <div className="w-16">
-          <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Role</span>
-        </div>
+        {isVisible('email') && (
+          <div className="hidden lg:block w-40">
+            <SortHeader label="Email" column="email" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
+          </div>
+        )}
+        {isVisible('role') && (
+          <div className="w-16">
+            <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Role</span>
+          </div>
+        )}
         <div className="w-16">
           <SortHeader label="Plan" column="plan" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
         </div>
         <div className="w-24">
           <SortHeader label="Status" column="status" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
         </div>
-        <div className="hidden lg:block w-14 text-right">
-          <SortHeader label="Bins" column="bins" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
-        </div>
-        <div className="hidden lg:block w-14 text-right">
-          <SortHeader label="Locs" column="locations" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
-        </div>
-        <div className="hidden lg:block w-20 text-right">
-          <SortHeader label="Storage" column="storage" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
-        </div>
-        <div className="hidden sm:block w-24">
-          <SortHeader label="Created" column="created" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
-        </div>
+        {isVisible('bins') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Bins" column="bins" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('locations') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Locs" column="locations" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('storage') && (
+          <div className="hidden lg:block w-20 text-right">
+            <SortHeader label="Storage" column="storage" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('lastActive') && (
+          <div className="hidden sm:block w-24">
+            <SortHeader label="Last Active" column="lastActive" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
+          </div>
+        )}
+        {isVisible('items') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Items" column="items" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('photos') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Photos" column="photos" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('scans30d') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Scans" column="scans30d" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('aiCredits') && (
+          <div className="hidden lg:block w-20 text-right">
+            <SortHeader label="AI Credits" column="aiCredits" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('apiKeys') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Keys" column="apiKeys" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('apiRequests7d') && (
+          <div className="hidden lg:block w-20 text-right">
+            <SortHeader label="Reqs (7d)" column="apiRequests7d" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('binPct') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Bin %" column="binPct" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('storagePct') && (
+          <div className="hidden lg:block w-20 text-right">
+            <SortHeader label="Stor %" column="storagePct" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('binsCreated7d') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="New (7d)" column="binsCreated7d" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('accountAge') && (
+          <div className="hidden lg:block w-14 text-right">
+            <SortHeader label="Age" column="accountAge" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} defaultDirection="desc" className="justify-end" />
+          </div>
+        )}
+        {isVisible('created') && (
+          <div className="hidden sm:block w-24">
+            <SortHeader label="Created" column="created" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
+          </div>
+        )}
         <div className="w-9" />
       </TableHeader>
 
       {users.map((u) => {
         const isSelf = u.id === currentUserId;
+        const limits = PLAN_LIMITS[u.plan] ?? PLAN_LIMITS.free;
+        const binPct = limits.maxBins !== null && limits.maxBins > 0
+          ? Math.round((u.binCount / limits.maxBins) * 100)
+          : null;
+        const storagePct = limits.maxStorageMb !== null && limits.maxStorageMb > 0
+          ? Math.round((u.photoStorageMb / limits.maxStorageMb) * 100)
+          : null;
+        const accountAge = Math.floor((Date.now() - new Date(u.createdAt).getTime()) / 86400000);
+
         return (
           <TableRow
             key={u.id}
@@ -74,10 +179,14 @@ export function AdminUsersTable({
               <div className="font-medium text-[14px] text-[var(--text-primary)] truncate">{u.displayName || u.username}</div>
               <div className="text-[12px] text-[var(--text-tertiary)] truncate">@{u.username}</div>
             </div>
-            <div className="hidden lg:block w-40 text-[14px] text-[var(--text-secondary)] truncate">{u.email || '—'}</div>
-            <div className="w-16 text-[14px]">
-              {u.isAdmin ? <Badge variant="default" className="text-[11px]">Admin</Badge> : <span className="text-[var(--text-tertiary)]">—</span>}
-            </div>
+            {isVisible('email') && (
+              <div className="hidden lg:block w-40 text-[14px] text-[var(--text-secondary)] truncate">{u.email || '—'}</div>
+            )}
+            {isVisible('role') && (
+              <div className="w-16 text-[14px]">
+                {u.isAdmin ? <Badge variant="default" className="text-[11px]">Admin</Badge> : <span className="text-[var(--text-tertiary)]">—</span>}
+              </div>
+            )}
             <div className="w-16 text-[14px]">
               <Badge variant="secondary" className="text-[11px]">{capitalize(u.plan)}</Badge>
             </div>
@@ -87,12 +196,63 @@ export function AdminUsersTable({
                 <Badge variant={statusVariant(u.status)} className="text-[11px]">{capitalize(u.status)}</Badge>
               </span>
             </div>
-            <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.binCount}</div>
-            <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.locationCount}</div>
-            <div className="hidden lg:block w-20 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : `${u.photoStorageMb} MB`}</div>
-            <div className="hidden sm:block w-24">
-              <span className="text-[12px] text-[var(--text-tertiary)] whitespace-nowrap">{new Date(u.createdAt).toLocaleDateString()}</span>
-            </div>
+            {isVisible('bins') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.binCount}</div>
+            )}
+            {isVisible('locations') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.locationCount}</div>
+            )}
+            {isVisible('storage') && (
+              <div className="hidden lg:block w-20 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : `${u.photoStorageMb} MB`}</div>
+            )}
+            {isVisible('lastActive') && (
+              <div className="hidden sm:block w-24">
+                <span className="text-[12px] text-[var(--text-tertiary)] whitespace-nowrap">
+                  {u.deletedAt ? '—' : relativeTime(u.lastActiveAt)}
+                </span>
+              </div>
+            )}
+            {isVisible('items') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.itemCount}</div>
+            )}
+            {isVisible('photos') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.photoCount}</div>
+            )}
+            {isVisible('scans30d') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.scans30d}</div>
+            )}
+            {isVisible('aiCredits') && (
+              <div className="hidden lg:block w-20 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">
+                {u.deletedAt || u.aiCreditsLimit === 0 ? '—' : `${u.aiCreditsUsed}/${u.aiCreditsLimit}`}
+              </div>
+            )}
+            {isVisible('apiKeys') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.apiKeyCount}</div>
+            )}
+            {isVisible('apiRequests7d') && (
+              <div className="hidden lg:block w-20 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.apiRequests7d}</div>
+            )}
+            {isVisible('binPct') && (
+              <div className={cn('hidden lg:block w-14 text-[14px] text-right tabular-nums', binPct !== null ? pctColor(binPct) : 'text-[var(--text-secondary)]')}>
+                {u.deletedAt || binPct === null ? '—' : `${binPct}%`}
+              </div>
+            )}
+            {isVisible('storagePct') && (
+              <div className={cn('hidden lg:block w-20 text-[14px] text-right tabular-nums', storagePct !== null ? pctColor(storagePct) : 'text-[var(--text-secondary)]')}>
+                {u.deletedAt || storagePct === null ? '—' : `${storagePct}%`}
+              </div>
+            )}
+            {isVisible('binsCreated7d') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : u.binsCreated7d}</div>
+            )}
+            {isVisible('accountAge') && (
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] text-right tabular-nums">{u.deletedAt ? '—' : `${accountAge}d`}</div>
+            )}
+            {isVisible('created') && (
+              <div className="hidden sm:block w-24">
+                <span className="text-[12px] text-[var(--text-tertiary)] whitespace-nowrap">{new Date(u.createdAt).toLocaleDateString()}</span>
+              </div>
+            )}
             <div className="w-9 flex justify-center">
               <Button
                 variant="ghost"

--- a/src/features/admin/AdminUsersTable.tsx
+++ b/src/features/admin/AdminUsersTable.tsx
@@ -3,31 +3,9 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { type SortDirection, SortHeader } from '@/components/ui/sort-header';
 import { Table, TableHeader, TableRow } from '@/components/ui/table';
-import { cn } from '@/lib/utils';
+import { cn, relativeTime } from '@/lib/utils';
 import type { AdminFieldKey } from './useAdminColumnVisibility';
 import { type AdminUser, capitalize, statusVariant } from './useAdminUsers';
-
-
-const PLAN_LIMITS: Record<string, { maxBins: number | null; maxStorageMb: number | null }> = {
-  free:  { maxBins: 50,   maxStorageMb: 0    },
-  plus:  { maxBins: 500,  maxStorageMb: 100  },
-  pro:   { maxBins: 5000, maxStorageMb: 1000 },
-};
-
-function relativeTime(iso: string | null): string {
-  if (!iso) return '—';
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  const months = Math.floor(days / 30);
-  if (months < 12) return `${months}mo ago`;
-  return `${Math.floor(months / 12)}y ago`;
-}
 
 function pctColor(pct: number): string {
   if (pct > 90) return 'text-[var(--destructive)]';
@@ -158,12 +136,11 @@ export function AdminUsersTable({
 
       {users.map((u) => {
         const isSelf = u.id === currentUserId;
-        const limits = PLAN_LIMITS[u.plan] ?? PLAN_LIMITS.free;
-        const binPct = limits.maxBins !== null && limits.maxBins > 0
-          ? Math.round((u.binCount / limits.maxBins) * 100)
+        const binPct = u.binLimit !== null && u.binLimit > 0
+          ? Math.round((u.binCount / u.binLimit) * 100)
           : null;
-        const storagePct = limits.maxStorageMb !== null && limits.maxStorageMb > 0
-          ? Math.round((u.photoStorageMb / limits.maxStorageMb) * 100)
+        const storagePct = u.storageLimit !== null && u.storageLimit > 0
+          ? Math.round((u.photoStorageMb / u.storageLimit) * 100)
           : null;
         const accountAge = Math.floor((Date.now() - new Date(u.createdAt).getTime()) / 86400000);
 

--- a/src/features/admin/PlanBreakdownCard.tsx
+++ b/src/features/admin/PlanBreakdownCard.tsx
@@ -1,0 +1,132 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import { type PlanBreakdownResponse, useAdminPlanBreakdown } from './useAdminPlanBreakdown';
+
+interface MetricRow {
+  label: string;
+  key: keyof PlanBreakdownResponse['free'];
+  format?: 'number' | 'mb' | 'pct' | 'credits';
+  gatedPlans?: string[];
+}
+
+const ROWS: MetricRow[] = [
+  { label: 'Users', key: 'userCount' },
+  { label: 'Avg Bins', key: 'avgBins' },
+  { label: 'Avg Items', key: 'avgItems' },
+  { label: 'Avg Photos', key: 'avgPhotos' },
+  { label: 'Avg Storage', key: 'avgStorageMb', format: 'mb' },
+  { label: 'Avg Locations', key: 'avgLocations' },
+  { label: 'Avg Members/Loc', key: 'avgMembersPerLocation' },
+  { label: 'Avg AI Credits', key: 'avgAiCreditsUsed', format: 'credits', gatedPlans: ['free'] },
+  { label: 'Avg API Keys', key: 'avgApiKeys', gatedPlans: ['free', 'plus'] },
+  { label: 'Avg API Reqs (7d)', key: 'avgApiRequests7d', gatedPlans: ['free', 'plus'] },
+  { label: 'Avg Scans (30d)', key: 'avgScans30d' },
+  { label: 'At Bin Limit', key: 'atBinLimitPct', format: 'pct' },
+  { label: 'At Storage Limit', key: 'atStorageLimitPct', format: 'pct' },
+];
+
+const PLANS = ['free', 'plus', 'pro'] as const;
+const PLAN_LABELS: Record<string, string> = { free: 'Free', plus: 'Plus', pro: 'Pro' };
+
+function formatValue(value: number, format: MetricRow['format'], tier?: PlanBreakdownResponse[(typeof PLANS)[number]]): string {
+  switch (format) {
+    case 'mb': return `${value} MB`;
+    case 'pct': return `${value}%`;
+    case 'credits': return tier?.aiCreditsLimit ? `${value} / ${tier.aiCreditsLimit}` : `${value}`;
+    default: return String(value);
+  }
+}
+
+export function PlanBreakdownCard() {
+  const { breakdown, isLoading, error } = useAdminPlanBreakdown();
+
+  if (error) return null;
+
+  if (isLoading || !breakdown) {
+    return (
+      <Card>
+        <CardHeader><Skeleton className="h-5 w-36" /></CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {Array.from({ length: 8 }, (_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+              <div key={i} className="flex gap-3">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage by Plan</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {/* Desktop: horizontal table */}
+        <div className="hidden sm:block overflow-x-auto">
+          <table className="w-full text-[14px]">
+            <thead>
+              <tr className="border-b border-[var(--border-subtle)]">
+                <th className="text-left py-2 pr-4 text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Metric</th>
+                {PLANS.map((p) => (
+                  <th key={p} className="text-right py-2 px-3 text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">{PLAN_LABELS[p]}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map((row) => (
+                <tr key={row.key} className="border-b border-[var(--border-subtle)] last:border-0">
+                  <td className="py-2 pr-4 text-[var(--text-secondary)]">{row.label}</td>
+                  {PLANS.map((plan) => {
+                    const tier = breakdown[plan];
+                    const isGated = row.gatedPlans?.includes(plan);
+                    const val = tier[row.key] as number;
+                    return (
+                      <td key={plan} className={cn('text-right py-2 px-3 tabular-nums', isGated ? 'text-[var(--text-tertiary)]' : 'text-[var(--text-primary)]')}>
+                        {isGated ? '—' : formatValue(val, row.format, tier)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile: vertical cards */}
+        <div className="sm:hidden flex flex-col gap-3">
+          {PLANS.map((plan) => {
+            const tier = breakdown[plan];
+            return (
+              <div key={plan} className="rounded-[var(--radius-sm)] bg-[var(--bg-input)] p-3">
+                <div className="text-[13px] font-semibold text-[var(--text-primary)] mb-2">{PLAN_LABELS[plan]} ({tier.userCount} users)</div>
+                <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                  {ROWS.filter((r) => r.key !== 'userCount').map((row) => {
+                    const isGated = row.gatedPlans?.includes(plan);
+                    const val = tier[row.key] as number;
+                    return (
+                      <div key={row.key} className="flex justify-between text-[13px]">
+                        <span className="text-[var(--text-tertiary)]">{row.label}</span>
+                        <span className={cn('tabular-nums', isGated ? 'text-[var(--text-tertiary)]' : 'text-[var(--text-primary)]')}>
+                          {isGated ? '—' : formatValue(val, row.format, tier)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/admin/useAdminColumnVisibility.ts
+++ b/src/features/admin/useAdminColumnVisibility.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo, useState } from 'react';
+import { STORAGE_KEYS } from '@/lib/storageKeys';
+
+export type AdminFieldKey =
+  | 'username' | 'email' | 'role' | 'plan' | 'status'
+  | 'bins' | 'locations' | 'storage' | 'created'
+  | 'lastActive' | 'items' | 'photos' | 'scans30d'
+  | 'aiCredits' | 'apiKeys' | 'apiRequests7d'
+  | 'binPct' | 'storagePct' | 'binsCreated7d' | 'accountAge';
+
+const DEFAULT_VISIBILITY: Record<AdminFieldKey, boolean> = {
+  username: true, email: true, role: true, plan: true, status: true,
+  bins: true, locations: true, storage: true, created: true,
+  lastActive: false, items: false, photos: false, scans30d: false,
+  aiCredits: false, apiKeys: false, apiRequests7d: false,
+  binPct: false, storagePct: false, binsCreated7d: false, accountAge: false,
+};
+
+export const ADMIN_FIELD_LABELS: Record<AdminFieldKey, string> = {
+  username: 'User', email: 'Email', role: 'Role', plan: 'Plan', status: 'Status',
+  bins: 'Bins', locations: 'Locations', storage: 'Storage', created: 'Created',
+  lastActive: 'Last Active', items: 'Items', photos: 'Photos', scans30d: 'Scans (30d)',
+  aiCredits: 'AI Credits', apiKeys: 'API Keys', apiRequests7d: 'API Reqs (7d)',
+  binPct: 'Bin %', storagePct: 'Storage %', binsCreated7d: 'New Bins (7d)', accountAge: 'Age',
+};
+
+export const TOGGLEABLE_FIELDS: AdminFieldKey[] = [
+  'email', 'role', 'bins', 'locations', 'storage', 'created',
+  'lastActive', 'items', 'photos', 'scans30d',
+  'aiCredits', 'apiKeys', 'apiRequests7d',
+  'binPct', 'storagePct', 'binsCreated7d', 'accountAge',
+];
+
+function readStored(): Record<AdminFieldKey, boolean> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.ADMIN_COLUMN_VISIBILITY);
+    if (!raw) return { ...DEFAULT_VISIBILITY };
+    return { ...DEFAULT_VISIBILITY, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT_VISIBILITY };
+  }
+}
+
+export function useAdminColumnVisibility() {
+  const [visibility, setVisibility] = useState<Record<AdminFieldKey, boolean>>(readStored);
+
+  const toggleField = useCallback((field: AdminFieldKey) => {
+    setVisibility((prev) => {
+      const next = { ...prev, [field]: !prev[field] };
+      localStorage.setItem(STORAGE_KEYS.ADMIN_COLUMN_VISIBILITY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const isVisible = useCallback(
+    (field: AdminFieldKey): boolean => visibility[field],
+    [visibility],
+  );
+
+  const visibleCount = useMemo(
+    () => TOGGLEABLE_FIELDS.filter((f) => visibility[f]).length,
+    [visibility],
+  );
+
+  return { visibility, toggleField, isVisible, visibleCount };
+}

--- a/src/features/admin/useAdminPlanBreakdown.ts
+++ b/src/features/admin/useAdminPlanBreakdown.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/api';
+
+export interface PlanBreakdownTier {
+  userCount: number;
+  avgBins: number;
+  avgItems: number;
+  avgPhotos: number;
+  avgStorageMb: number;
+  avgLocations: number;
+  avgMembersPerLocation: number;
+  avgAiCreditsUsed: number;
+  aiCreditsLimit: number | null;
+  avgApiKeys: number;
+  avgApiRequests7d: number;
+  avgScans30d: number;
+  atBinLimitPct: number;
+  atStorageLimitPct: number;
+}
+
+export interface PlanBreakdownResponse {
+  free: PlanBreakdownTier;
+  plus: PlanBreakdownTier;
+  pro: PlanBreakdownTier;
+}
+
+export function useAdminPlanBreakdown() {
+  const [breakdown, setBreakdown] = useState<PlanBreakdownResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiFetch<PlanBreakdownResponse>('/api/admin/metrics/plan-breakdown')
+      .then(setBreakdown)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  return { breakdown, isLoading, error };
+}

--- a/src/features/admin/useAdminUsers.ts
+++ b/src/features/admin/useAdminUsers.ts
@@ -24,6 +24,8 @@ export interface AdminUser {
   apiKeyCount: number;
   apiRequests7d: number;
   binsCreated7d: number;
+  binLimit: number | null;
+  storageLimit: number | null;
 }
 
 interface RegistrationInfo {

--- a/src/features/admin/useAdminUsers.ts
+++ b/src/features/admin/useAdminUsers.ts
@@ -15,6 +15,15 @@ export interface AdminUser {
   binCount: number;
   locationCount: number;
   photoStorageMb: number;
+  lastActiveAt: string | null;
+  itemCount: number;
+  photoCount: number;
+  scans30d: number;
+  aiCreditsUsed: number;
+  aiCreditsLimit: number;
+  apiKeyCount: number;
+  apiRequests7d: number;
+  binsCreated7d: number;
 }
 
 interface RegistrationInfo {
@@ -97,6 +106,7 @@ export interface AdminUserDetail {
   deletedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  lastActiveAt: string | null;
   stats: {
     locationCount: number;
     binCount: number;
@@ -104,6 +114,15 @@ export interface AdminUserDetail {
     photoStorageMb: number;
     apiKeyCount: number;
     shareCount: number;
+    itemCount: number;
+    scans30d: number;
+    aiCreditsUsed: number;
+    aiCreditsLimit: number;
+    aiCreditsResetAt: string | null;
+    apiRequests7d: number;
+    binsCreated7d: number;
+    binLimit: number | null;
+    storageLimit: number | null;
   };
 }
 

--- a/src/lib/storageKeys.ts
+++ b/src/lib/storageKeys.ts
@@ -6,4 +6,5 @@ export const STORAGE_KEYS = {
   BIN_PAGE_SIZE: 'openbin-bin-page-size',
   COLUMN_VISIBILITY: 'openbin-column-visibility',
   SIDEBAR_COLLAPSED: 'openbin-sidebar-collapsed',
+  ADMIN_COLUMN_VISIBILITY: 'openbin-admin-column-visibility',
 } as const;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -73,3 +73,19 @@ export const rowAction =
 /** Disclosure label for collapsible card sections (Photos, QR Code). */
 export const disclosureSectionLabel =
   'py-4 text-[var(--text-tertiary)] uppercase tracking-wider';
+
+/** Human-readable relative time string from an ISO timestamp (e.g. "5m ago", "3d ago"). */
+export function relativeTime(iso: string | null): string {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}


### PR DESCRIPTION
## Summary
- **11 new toggleable columns** on the admin user list (last active, items, photos, scans, AI credits, API keys/reqs, bin/storage %, new bins, account age) — hidden by default, toggled via column visibility menu
- **Per-plan breakdown card** in admin metrics showing averaged usage by Free/Plus/Pro tier (bins, items, storage, AI, API, scans, limit proximity)
- **Enhanced user detail page** with expanded stats grid and progress bars for bin/storage/AI credit limits
- **`last_active_at` tracking** with debounced (5-min) update in auth middleware

## Test plan
- [ ] Admin user list loads with existing columns visible
- [ ] Column visibility menu toggles new columns on/off, persists across page loads
- [ ] Sorting works for all new columns
- [ ] Admin user detail page shows all new stat tiles and limit bars
- [ ] Metrics tab shows "Usage by Plan" breakdown card with correct per-tier averages
- [ ] `last_active_at` updates after login (verify via user detail page)
- [ ] Self-hosted mode: metrics endpoints return 404, user list still works
- [ ] `npx tsc --noEmit` and `cd server && npx tsc --noEmit` pass
- [ ] `npx vitest run` and `cd server && npx vitest run` pass