### PR TITLE
feat: add task routing, intent classification, and global admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,15 @@
 # AI_MODEL=                          # e.g. gpt-5-mini, claude-sonnet-4-6, gemini-3-flash-preview
 # AI_ENDPOINT_URL=                   # Only for openai-compatible (e.g. http://localhost:11434/v1)
 
+# Per-task-group AI overrides (omit to inherit from default AI_* values)
+# AI_VISION_PROVIDER=               # Override provider for photo analysis
+# AI_VISION_API_KEY=                 # Override API key for photo analysis
+# AI_VISION_MODEL=                   # Override model for photo analysis (e.g. gemini-2.0-flash)
+# AI_QUICK_TEXT_PROVIDER=            # Override provider for commands + text extraction
+# AI_QUICK_TEXT_MODEL=               # Override model for commands + text extraction (e.g. gpt-4o-mini)
+# AI_DEEP_TEXT_PROVIDER=             # Override provider for queries + reorganize
+# AI_DEEP_TEXT_MODEL=                # Override model for queries + reorganize
+
 # ── Backups ───────────────────────────────────
 # BACKUP_ENABLED=false
 # BACKUP_INTERVAL=daily              # hourly | daily | weekly | cron expression

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Publish Docker Image
 on:
   push:
     tags: ['v*']
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -32,9 +33,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=sha,prefix=,format=short
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
 
       - uses: docker/build-push-action@v6
         with:
@@ -48,6 +51,7 @@ jobs:
 
   deploy:
     needs: build-and-push
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH

--- a/docs/superpowers/plans/2026-04-05-task-routing.md
+++ b/docs/superpowers/plans/2026-04-05-task-routing.md
@@ -1,0 +1,1205 @@
+# Per-Task-Group AI Model Routing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users route different AI task groups (Vision, Quick Text, Deep Text) to different provider+model combos, with env var and DB cascade.
+
+**Architecture:** New `taskRouting.ts` module handles group definitions, config resolution with a 4-layer cascade (env group -> DB override -> env default -> DB default). New `user_ai_task_overrides` table stores per-user per-group overrides. Existing `getConfigForTask()` is replaced. UI adds a Disclosure section with three group rows.
+
+**Tech Stack:** Express 4, SQLite/PostgreSQL (dialect abstraction), React 18, TypeScript 5, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-05-task-routing-design.md` (committed at `2f5b34d`)
+
+---
+
+## File Map
+
+**Create:**
+- `server/src/lib/taskRouting.ts` — Task group types, task-to-group map, env var config, `resolveTaskConfig()`, DB queries for overrides
+- `server/src/__tests__/taskRouting.test.ts` — Unit tests for resolution logic
+- `src/features/ai/TaskRoutingSection.tsx` — Task Routing Disclosure UI component
+
+**Modify:**
+- `server/schema.sqlite.sql` — Add `user_ai_task_overrides` table
+- `server/schema.pg.sql` — Same for PostgreSQL
+- `server/src/db/init.ts` — Add migration for new table (SQLite `CREATE TABLE IF NOT EXISTS`)
+- `server/src/lib/config.ts` — Add per-group env var parsing
+- `server/src/routes/ai.ts` — Extend GET settings response, add PUT/DELETE task-override routes, update non-streaming handlers
+- `server/src/routes/aiStream.ts` — Update `resolveUserModel()` to use `resolveTaskConfig()`
+- `src/types.ts` — Add `AiTaskGroup`, `AiTaskOverride` types to `AiSettings`
+- `src/features/ai/useAiSettings.ts` — Add `saveTaskOverride()`, `deleteTaskOverride()` functions
+- `src/features/ai/AiSettingsSection.tsx` — Add Task Routing Disclosure, remove per-tab model override UI
+- `.env.example` — Add per-group env var documentation
+
+---
+
+### Task 1: Database Schema
+
+**Files:**
+- Modify: `server/schema.sqlite.sql`
+- Modify: `server/schema.pg.sql`
+- Modify: `server/src/db/init.ts`
+
+- [ ] **Step 1: Add table to SQLite schema**
+
+In `server/schema.sqlite.sql`, add after the `user_ai_settings` index (after line 134):
+
+```sql
+CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+  id              TEXT PRIMARY KEY,
+  user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+  provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+  api_key         TEXT,
+  model           TEXT,
+  endpoint_url    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(user_id, task_group)
+);
+CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id);
+```
+
+- [ ] **Step 2: Add table to PostgreSQL schema**
+
+In `server/schema.pg.sql`, add after the `user_ai_settings` index:
+
+```sql
+CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+  id              TEXT PRIMARY KEY,
+  user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+  provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+  api_key         TEXT,
+  model           TEXT,
+  endpoint_url    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (now()),
+  updated_at      TEXT NOT NULL DEFAULT (now()),
+  UNIQUE(user_id, task_group)
+);
+CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id);
+```
+
+- [ ] **Step 3: Add migration in init.ts**
+
+In `server/src/db/init.ts`, add alongside the existing AI settings migrations (around line 146, after the `task_model_overrides` migration). Follow the existing pattern -- the SQLite init runs `CREATE TABLE IF NOT EXISTS` directly. For PostgreSQL, add a similar block in the `initPostgres()` function.
+
+SQLite (inside the existing `try` block that handles migrations):
+```ts
+  // Task routing overrides table
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+      id              TEXT PRIMARY KEY,
+      user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+      provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+      api_key         TEXT,
+      model           TEXT,
+      endpoint_url    TEXT,
+      created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(user_id, task_group)
+    )
+  `);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id)');
+```
+
+Add the equivalent PostgreSQL migration in the Postgres init section (using `now()` instead of `datetime('now')`).
+
+- [ ] **Step 4: Verify schema loads**
+
+Start the dev server briefly:
+```bash
+npm run dev:server
+```
+Expected: Server starts without schema errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/schema.sqlite.sql server/schema.pg.sql server/src/db/init.ts
+git commit -m "feat: add user_ai_task_overrides table for per-group model routing"
+```
+
+---
+
+### Task 2: Config -- Per-Group Env Vars
+
+**Files:**
+- Modify: `server/src/lib/config.ts`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add per-group env var parsing to config.ts**
+
+In `server/src/lib/config.ts`, add after the existing `aiEndpointUrl` line (line 146):
+
+```ts
+  // Per-task-group AI overrides (each field cascades independently to the default AI_* values)
+  aiVisionProvider: (process.env.AI_VISION_PROVIDER as AiProviderType) || null,
+  aiVisionApiKey: process.env.AI_VISION_API_KEY || null,
+  aiVisionModel: process.env.AI_VISION_MODEL || null,
+  aiVisionEndpointUrl: process.env.AI_VISION_ENDPOINT_URL || null,
+
+  aiQuickTextProvider: (process.env.AI_QUICK_TEXT_PROVIDER as AiProviderType) || null,
+  aiQuickTextApiKey: process.env.AI_QUICK_TEXT_API_KEY || null,
+  aiQuickTextModel: process.env.AI_QUICK_TEXT_MODEL || null,
+  aiQuickTextEndpointUrl: process.env.AI_QUICK_TEXT_ENDPOINT_URL || null,
+
+  aiDeepTextProvider: (process.env.AI_DEEP_TEXT_PROVIDER as AiProviderType) || null,
+  aiDeepTextApiKey: process.env.AI_DEEP_TEXT_API_KEY || null,
+  aiDeepTextModel: process.env.AI_DEEP_TEXT_MODEL || null,
+  aiDeepTextEndpointUrl: process.env.AI_DEEP_TEXT_ENDPOINT_URL || null,
+```
+
+- [ ] **Step 2: Add helper to check if a group has env overrides**
+
+Add after the existing `getEnvAiConfig()` function:
+
+```ts
+export type AiTaskGroup = 'vision' | 'quickText' | 'deepText';
+export const AI_TASK_GROUPS: AiTaskGroup[] = ['vision', 'quickText', 'deepText'];
+
+/** Per-group env var config. Each field is nullable -- null means "inherit from default". */
+interface EnvGroupOverride {
+  provider: AiProviderType | null;
+  apiKey: string | null;
+  model: string | null;
+  endpointUrl: string | null;
+}
+
+const ENV_GROUP_MAP: Record<AiTaskGroup, EnvGroupOverride> = {
+  vision: {
+    provider: config.aiVisionProvider,
+    apiKey: config.aiVisionApiKey,
+    model: config.aiVisionModel,
+    endpointUrl: config.aiVisionEndpointUrl,
+  },
+  quickText: {
+    provider: config.aiQuickTextProvider,
+    apiKey: config.aiQuickTextApiKey,
+    model: config.aiQuickTextModel,
+    endpointUrl: config.aiQuickTextEndpointUrl,
+  },
+  deepText: {
+    provider: config.aiDeepTextProvider,
+    apiKey: config.aiDeepTextApiKey,
+    model: config.aiDeepTextModel,
+    endpointUrl: config.aiDeepTextEndpointUrl,
+  },
+};
+
+/** Get env-based overrides for a task group. Returns the group override object (all-null if nothing set). */
+export function getEnvGroupOverride(group: AiTaskGroup): EnvGroupOverride {
+  return ENV_GROUP_MAP[group];
+}
+
+/** Check if any env var is set for a task group (makes it env-locked). */
+export function isGroupEnvLocked(group: AiTaskGroup): boolean {
+  const o = ENV_GROUP_MAP[group];
+  return !!(o.provider || o.apiKey || o.model || o.endpointUrl);
+}
+```
+
+- [ ] **Step 3: Document env vars in .env.example**
+
+Add after the existing `AI_ENDPOINT_URL` line:
+
+```env
+# Per-task-group AI overrides (omit to inherit from default AI_* values)
+# AI_VISION_PROVIDER=               # Override provider for photo analysis
+# AI_VISION_API_KEY=                 # Override API key for photo analysis
+# AI_VISION_MODEL=                   # Override model for photo analysis (e.g. gemini-2.0-flash)
+# AI_QUICK_TEXT_PROVIDER=            # Override provider for commands + text extraction
+# AI_QUICK_TEXT_MODEL=               # Override model for commands + text extraction (e.g. gpt-4o-mini)
+# AI_DEEP_TEXT_PROVIDER=             # Override provider for queries + reorganize
+# AI_DEEP_TEXT_MODEL=                # Override model for queries + reorganize
+```
+
+- [ ] **Step 4: Verify type check**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/lib/config.ts .env.example
+git commit -m "feat: add per-task-group AI env var parsing with cascade support"
+```
+
+---
+
+### Task 3: Server -- Task Routing Resolution Logic
+
+**Files:**
+- Create: `server/src/lib/taskRouting.ts`
+- Create: `server/src/__tests__/taskRouting.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `server/src/__tests__/taskRouting.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before imports
+vi.mock('../db.js', () => ({
+  query: vi.fn(),
+  generateUuid: () => 'test-uuid',
+  d: { now: () => "datetime('now')" },
+}));
+
+vi.mock('../lib/crypto.js', () => ({
+  decryptApiKey: (k: string) => k.startsWith('enc:') ? k.slice(4) : k,
+  encryptApiKey: (k: string) => `enc:${k}`,
+}));
+
+vi.mock('../lib/config.js', () => ({
+  config: {
+    aiProvider: 'openai',
+    aiApiKey: 'sk-default',
+    aiModel: 'gpt-4o',
+    aiEndpointUrl: null,
+    aiVisionProvider: null,
+    aiVisionApiKey: null,
+    aiVisionModel: null,
+    aiVisionEndpointUrl: null,
+    aiQuickTextProvider: null,
+    aiQuickTextApiKey: null,
+    aiQuickTextModel: null,
+    aiQuickTextEndpointUrl: null,
+    aiDeepTextProvider: null,
+    aiDeepTextApiKey: null,
+    aiDeepTextModel: null,
+    aiDeepTextEndpointUrl: null,
+  },
+  hasEnvAiConfig: () => true,
+  getEnvAiConfig: () => ({
+    provider: 'openai',
+    apiKey: 'sk-default',
+    model: 'gpt-4o',
+    endpointUrl: null,
+  }),
+  getEnvGroupOverride: vi.fn(),
+  isGroupEnvLocked: vi.fn(),
+}));
+
+import { query } from '../db.js';
+import { getEnvGroupOverride } from '../lib/config.js';
+import { resolveTaskConfig, TASK_GROUP_MAP } from '../lib/taskRouting.js';
+
+const mockQuery = vi.mocked(query);
+const mockGetEnvGroupOverride = vi.mocked(getEnvGroupOverride);
+
+describe('TASK_GROUP_MAP', () => {
+  it('maps all AI tasks to groups', () => {
+    expect(TASK_GROUP_MAP.analysis).toBe('vision');
+    expect(TASK_GROUP_MAP['analyze-image']).toBe('vision');
+    expect(TASK_GROUP_MAP.command).toBe('quickText');
+    expect(TASK_GROUP_MAP.execute).toBe('quickText');
+    expect(TASK_GROUP_MAP['structure-text']).toBe('quickText');
+    expect(TASK_GROUP_MAP.query).toBe('deepText');
+    expect(TASK_GROUP_MAP.reorganization).toBe('deepText');
+  });
+});
+
+describe('resolveTaskConfig', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockGetEnvGroupOverride.mockReturnValue({
+      provider: null, apiKey: null, model: null, endpointUrl: null,
+    });
+  });
+
+  it('returns default config when no overrides exist', async () => {
+    // No DB override row
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    // Default user settings
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ provider: 'openai', api_key: 'sk-user', model: 'gpt-4o', endpoint_url: null }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user1', 'vision');
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-user',
+      model: 'gpt-4o',
+      endpointUrl: null,
+    });
+  });
+
+  it('returns full DB override when all fields set', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ provider: 'gemini', api_key: 'enc:AIza-vision', model: 'gemini-2.0-flash', endpoint_url: null }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user1', 'vision');
+    expect(result).toEqual({
+      provider: 'gemini',
+      apiKey: 'AIza-vision',
+      model: 'gemini-2.0-flash',
+      endpointUrl: null,
+    });
+  });
+
+  it('cascades: model-only DB override inherits provider+key from default', async () => {
+    // DB override with only model set
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ provider: null, api_key: null, model: 'gpt-4o-mini', endpoint_url: null }],
+      rowCount: 1,
+    });
+    // Default user settings for provider+key
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ provider: 'openai', api_key: 'sk-user', model: 'gpt-4o', endpoint_url: null }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user1', 'quickText');
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-user',
+      model: 'gpt-4o-mini',
+      endpointUrl: null,
+    });
+  });
+
+  it('env group override takes precedence over DB override', async () => {
+    mockGetEnvGroupOverride.mockReturnValue({
+      provider: 'gemini' as any, apiKey: 'AIza-env', model: 'gemini-flash', endpointUrl: null,
+    });
+
+    // DB override exists but should be ignored for env-overridden fields
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ provider: 'anthropic', api_key: 'enc:sk-db', model: 'claude-haiku', endpoint_url: null }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user1', 'vision');
+    expect(result).toEqual({
+      provider: 'gemini',
+      apiKey: 'AIza-env',
+      model: 'gemini-flash',
+      endpointUrl: null,
+    });
+  });
+
+  it('env group model-only cascades other fields from env default', async () => {
+    mockGetEnvGroupOverride.mockReturnValue({
+      provider: null, apiKey: null, model: 'gpt-4o-mini', endpointUrl: null,
+    });
+
+    // No DB override
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await resolveTaskConfig('user1', 'quickText');
+    // provider and apiKey from env default (openai, sk-default), model from env group override
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-default',
+      model: 'gpt-4o-mini',
+      endpointUrl: null,
+    });
+  });
+
+  it('falls back to env default when no user DB settings exist', async () => {
+    // No DB override
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    // No DB default settings either
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await resolveTaskConfig('user1', 'deepText');
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-default',
+      model: 'gpt-4o',
+      endpointUrl: null,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/__tests__/taskRouting.test.ts`
+Expected: FAIL -- module `../lib/taskRouting.js` not found.
+
+- [ ] **Step 3: Write taskRouting.ts**
+
+Create `server/src/lib/taskRouting.ts`:
+
+```ts
+import { query } from '../db.js';
+import type { AiProviderConfig, AiProviderType } from './aiCaller.js';
+import { getEnvAiConfig, getEnvGroupOverride, type AiTaskGroup } from './config.js';
+import { decryptApiKey } from './crypto.js';
+
+export type { AiTaskGroup } from './config.js';
+
+/** Maps each AI route task key to its task group. */
+export const TASK_GROUP_MAP: Record<string, AiTaskGroup> = {
+  'analysis': 'vision',
+  'analyze-image': 'vision',
+  'command': 'quickText',
+  'execute': 'quickText',
+  'structure-text': 'quickText',
+  'query': 'deepText',
+  'reorganization': 'deepText',
+};
+
+/**
+ * Resolve the AI provider config for a specific task group.
+ *
+ * Resolution order per field (first non-null wins):
+ * 1. Env group override (AI_VISION_MODEL, etc.)
+ * 2. DB task override (user_ai_task_overrides row)
+ * 3. Env default (AI_MODEL, etc.)
+ * 4. DB user default (user_ai_settings active row)
+ */
+export async function resolveTaskConfig(
+  userId: string,
+  group: AiTaskGroup,
+): Promise<AiProviderConfig> {
+  // Layer 1: env group override
+  const envGroup = getEnvGroupOverride(group);
+
+  // Layer 2: DB task override
+  const dbOverride = await query(
+    'SELECT provider, api_key, model, endpoint_url FROM user_ai_task_overrides WHERE user_id = $1 AND task_group = $2',
+    [userId, group],
+  );
+  const dbRow = dbOverride.rows[0] ?? null;
+
+  // Layer 3: env default
+  const envDefault = getEnvAiConfig();
+
+  // Layer 4: DB user default (only fetch if needed)
+  let dbDefault: { provider: string; api_key: string; model: string; endpoint_url: string | null } | null = null;
+
+  const needsDbDefault =
+    !(envGroup.provider && envGroup.apiKey && envGroup.model) &&
+    !(dbRow?.provider && dbRow?.api_key && dbRow?.model) &&
+    !envDefault;
+
+  if (needsDbDefault) {
+    const dbDefaultResult = await query(
+      'SELECT provider, api_key, model, endpoint_url FROM user_ai_settings WHERE user_id = $1 AND is_active = TRUE',
+      [userId],
+    );
+    dbDefault = dbDefaultResult.rows[0] ?? null;
+  }
+
+  // Resolve each field through the cascade
+  const provider =
+    envGroup.provider ??
+    dbRow?.provider ??
+    envDefault?.provider ??
+    dbDefault?.provider ??
+    null;
+
+  const apiKey =
+    envGroup.apiKey ??
+    (dbRow?.api_key ? decryptApiKey(dbRow.api_key) : null) ??
+    envDefault?.apiKey ??
+    (dbDefault?.api_key ? decryptApiKey(dbDefault.api_key) : null) ??
+    null;
+
+  const model =
+    envGroup.model ??
+    dbRow?.model ??
+    envDefault?.model ??
+    dbDefault?.model ??
+    null;
+
+  const endpointUrl =
+    envGroup.endpointUrl ??
+    dbRow?.endpoint_url ??
+    envDefault?.endpointUrl ??
+    dbDefault?.endpoint_url ??
+    null;
+
+  if (!provider || !apiKey || !model) {
+    const { NoAiSettingsError } = await import('./aiSettings.js');
+    throw new NoAiSettingsError();
+  }
+
+  return {
+    provider: provider as AiProviderType,
+    apiKey,
+    model,
+    endpointUrl: endpointUrl ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/__tests__/taskRouting.test.ts`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Type check**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/lib/taskRouting.ts server/src/__tests__/taskRouting.test.ts
+git commit -m "feat: add task routing resolution logic with 4-layer cascade"
+```
+
+---
+
+### Task 4: API Endpoints -- Task Override CRUD
+
+**Files:**
+- Modify: `server/src/routes/ai.ts`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `server/src/routes/ai.ts`, add to the existing imports:
+
+```ts
+import { AI_TASK_GROUPS, isGroupEnvLocked, type AiTaskGroup } from '../lib/config.js';
+```
+
+- [ ] **Step 2: Extend GET /api/ai/settings to include taskOverrides**
+
+In the GET `/settings` handler (around line 87, after `const activeRow = ...`), add a query for task overrides and build the response:
+
+```ts
+  // Fetch task overrides for this user
+  const overridesResult = await query(
+    'SELECT task_group, provider, model, endpoint_url FROM user_ai_task_overrides WHERE user_id = $1',
+    [req.user!.id],
+  );
+
+  const taskOverrides: Record<string, { provider: string | null; model: string | null; endpointUrl: string | null; source: 'user' } | null> = {};
+  for (const row of overridesResult.rows) {
+    taskOverrides[row.task_group] = {
+      provider: row.provider || null,
+      model: row.model || null,
+      endpointUrl: row.endpoint_url || null,
+      source: 'user',
+    };
+  }
+
+  // Env-locked groups: any group with env vars set
+  const taskOverridesEnvLocked: string[] = AI_TASK_GROUPS.filter(isGroupEnvLocked);
+```
+
+Then add `taskOverrides` and `taskOverridesEnvLocked` to the JSON response object (both the env-config path and the DB-config path).
+
+For the env-config response (around line 61), add:
+```ts
+        taskOverrides: {},
+        taskOverridesEnvLocked: AI_TASK_GROUPS.filter(isGroupEnvLocked),
+```
+
+For the DB-config response (around line 101), add to `res.json({...})`:
+```ts
+    taskOverrides,
+    taskOverridesEnvLocked,
+```
+
+- [ ] **Step 3: Add PUT /api/ai/task-overrides/:taskGroup**
+
+Add before the `export default router` line:
+
+```ts
+// PUT /api/ai/task-overrides/:taskGroup -- set override for a task group
+router.put('/task-overrides/:taskGroup', requireAiAccess(), aiRouteHandler('save task override', async (req, res) => {
+  const group = req.params.taskGroup as AiTaskGroup;
+  if (!(AI_TASK_GROUPS as readonly string[]).includes(group)) {
+    throw new ValidationError(`Invalid task group: ${group}. Valid: ${AI_TASK_GROUPS.join(', ')}`);
+  }
+
+  if (isGroupEnvLocked(group)) {
+    throw new HttpError(409, 'ENV_LOCKED', `Task routing for ${group} is configured by server environment`);
+  }
+
+  if (isDemoUser(req)) {
+    throw new HttpError(403, 'DEMO_RESTRICTION', 'Demo accounts cannot configure task routing');
+  }
+
+  const { provider, model, endpointUrl } = req.body;
+
+  if (provider && !['openai', 'anthropic', 'gemini', 'openai-compatible'].includes(provider)) {
+    throw new ValidationError('Invalid provider');
+  }
+
+  const id = generateUuid();
+  await query(
+    `INSERT INTO user_ai_task_overrides (id, user_id, task_group, provider, model, endpoint_url)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (user_id, task_group) DO UPDATE SET
+       provider = $4, model = $5, endpoint_url = $6, updated_at = ${d.now()}`,
+    [id, req.user!.id, group, provider || null, model || null, endpointUrl || null],
+  );
+
+  res.json({ taskGroup: group, provider: provider || null, model: model || null, endpointUrl: endpointUrl || null });
+}));
+
+// DELETE /api/ai/task-overrides/:taskGroup -- clear override
+router.delete('/task-overrides/:taskGroup', requireAiAccess(), aiRouteHandler('delete task override', async (req, res) => {
+  const group = req.params.taskGroup as AiTaskGroup;
+  if (!(AI_TASK_GROUPS as readonly string[]).includes(group)) {
+    throw new ValidationError(`Invalid task group: ${group}`);
+  }
+
+  if (isGroupEnvLocked(group)) {
+    throw new HttpError(409, 'ENV_LOCKED', `Task routing for ${group} is configured by server environment`);
+  }
+
+  await query(
+    'DELETE FROM user_ai_task_overrides WHERE user_id = $1 AND task_group = $2',
+    [req.user!.id, group],
+  );
+
+  res.json({ deleted: true });
+}));
+```
+
+- [ ] **Step 4: Also clear task overrides in DELETE /api/ai/settings**
+
+In the existing DELETE `/settings` handler (line 264), add a line to also clear task overrides:
+
+```ts
+  await query('DELETE FROM user_ai_task_overrides WHERE user_id = $1', [req.user!.id]);
+  await query('DELETE FROM user_ai_settings WHERE user_id = $1', [req.user!.id]);
+```
+
+- [ ] **Step 5: Type check + existing tests**
+
+Run:
+```bash
+cd server && npx tsc --noEmit && npx vitest run
+```
+Expected: No type errors, existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/ai.ts
+git commit -m "feat: add task override CRUD endpoints and extend settings response"
+```
+
+---
+
+### Task 5: Update Route Handlers to Use resolveTaskConfig
+
+**Files:**
+- Modify: `server/src/routes/aiStream.ts`
+- Modify: `server/src/routes/ai.ts`
+
+- [ ] **Step 1: Update resolveUserModel in aiStream.ts**
+
+In `server/src/routes/aiStream.ts`, add import:
+```ts
+import { resolveTaskConfig, TASK_GROUP_MAP } from '../lib/taskRouting.js';
+```
+
+Replace the `resolveUserModel` function (lines 53-62) with:
+
+```ts
+/** Resolve a user's AI model (task routing + SSRF check + SDK model). */
+async function resolveUserModel(userId: string, task: TaskType, isDemoUser = false) {
+  const settings = await getUserAiSettings(userId);
+  const group = TASK_GROUP_MAP[task];
+  const taskConfig = group
+    ? await resolveTaskConfig(userId, group)
+    : getConfigForTask(settings, task);
+  const resolvedIps = taskConfig.endpointUrl
+    ? await validateEndpointUrl(taskConfig.endpointUrl, isDemoUser)
+    : undefined;
+  const pinnedFetch = resolvedIps ? createPinnedFetch(resolvedIps) : undefined;
+  const model = createSdkModel(taskConfig, pinnedFetch);
+  return { settings, model };
+}
+```
+
+- [ ] **Step 2: Update non-streaming handlers in ai.ts**
+
+In `server/src/routes/ai.ts`, add import:
+```ts
+import { resolveTaskConfig } from '../lib/taskRouting.js';
+```
+
+For each non-streaming route that calls `getConfigForTask()`, update to use `resolveTaskConfig()`:
+
+In `POST /analyze-image` (around line 291): replace
+```ts
+  const taskConfig = getConfigForTask(settings, 'analysis');
+```
+with:
+```ts
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
+```
+
+In `POST /analyze` (around line 331): same change.
+
+In `POST /reanalyze` (around line 380): same change.
+
+In `POST /structure-text` (around line 409): replace
+```ts
+  const taskConfig = getConfigForTask(settings, 'structure');
+```
+with:
+```ts
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'quickText');
+```
+
+Note: `getUserAiSettings()` is still called in each handler because prompts and advanced params come from it. Only the config resolution changes.
+
+- [ ] **Step 3: Type check and run tests**
+
+Run:
+```bash
+cd server && npx tsc --noEmit && npx vitest run
+```
+Expected: No type errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/routes/aiStream.ts server/src/routes/ai.ts
+git commit -m "feat: route AI handlers through per-group task config resolution"
+```
+
+---
+
+### Task 6: Client Types
+
+**Files:**
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: Add task routing types**
+
+In `src/types.ts`, add after the `AiProvider` type (line 166):
+
+```ts
+export type AiTaskGroup = 'vision' | 'quickText' | 'deepText';
+
+export interface AiTaskOverride {
+  provider: AiProvider | null;
+  model: string | null;
+  endpointUrl: string | null;
+  source: 'env' | 'user';
+}
+```
+
+- [ ] **Step 2: Extend AiSettings interface**
+
+Add to the `AiSettings` interface (around line 183, before the closing `}`):
+
+```ts
+  taskOverrides?: Partial<Record<AiTaskGroup, AiTaskOverride | null>>;
+  taskOverridesEnvLocked?: AiTaskGroup[];
+```
+
+- [ ] **Step 3: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat: add AiTaskGroup and AiTaskOverride types"
+```
+
+---
+
+### Task 7: Client Hooks
+
+**Files:**
+- Modify: `src/features/ai/useAiSettings.ts`
+
+- [ ] **Step 1: Add saveTaskOverride function**
+
+Add after the existing `testAiConnection` function:
+
+```ts
+export async function saveTaskOverride(
+  taskGroup: string,
+  override: { provider?: string | null; model?: string | null; endpointUrl?: string | null },
+): Promise<void> {
+  await apiFetch(`/api/ai/task-overrides/${taskGroup}`, {
+    method: 'PUT',
+    body: override,
+  });
+  notifyAiSettingsChanged();
+}
+
+export async function deleteTaskOverride(taskGroup: string): Promise<void> {
+  await apiFetch(`/api/ai/task-overrides/${taskGroup}`, { method: 'DELETE' });
+  notifyAiSettingsChanged();
+}
+```
+
+- [ ] **Step 2: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/ai/useAiSettings.ts
+git commit -m "feat: add saveTaskOverride and deleteTaskOverride client functions"
+```
+
+---
+
+### Task 8: UI -- Task Routing Section
+
+**Files:**
+- Create: `src/features/ai/TaskRoutingSection.tsx`
+- Modify: `src/features/ai/AiSettingsSection.tsx`
+- Modify: `src/features/ai/aiConstants.ts`
+
+- [ ] **Step 1: Add TASK_GROUP_META to aiConstants.ts**
+
+Add to `src/features/ai/aiConstants.ts`:
+
+```ts
+import type { AiTaskGroup } from '@/types';
+
+export const TASK_GROUP_META: { key: AiTaskGroup; label: string; description: string }[] = [
+  { key: 'vision', label: 'Vision', description: 'Photo Scan' },
+  { key: 'quickText', label: 'Quick Text', description: 'Commands, Text Extraction' },
+  { key: 'deepText', label: 'Deep Text', description: 'Queries, Reorganize' },
+];
+```
+
+- [ ] **Step 2: Create TaskRoutingSection.tsx**
+
+Create `src/features/ai/TaskRoutingSection.tsx`:
+
+```tsx
+import { RotateCcw } from 'lucide-react';
+import { Disclosure } from '@/components/ui/disclosure';
+import { Input } from '@/components/ui/input';
+import type { AiProvider, AiSettings, AiTaskGroup } from '@/types';
+import { cn, inputBase } from '@/lib/utils';
+import { AI_PROVIDERS, MODEL_HINTS, TASK_GROUP_META } from './aiConstants';
+
+interface TaskRoutingSectionProps {
+  settings: AiSettings;
+  overrides: Partial<Record<AiTaskGroup, { provider: string | null; model: string | null; endpointUrl: string | null }>>;
+  onChange: (group: AiTaskGroup, override: { provider: string | null; model: string | null; endpointUrl: string | null } | null) => void;
+  disabled?: boolean;
+}
+
+export function TaskRoutingSection({ settings, overrides, onChange, disabled }: TaskRoutingSectionProps) {
+  const envLocked = settings.taskOverridesEnvLocked ?? [];
+  const hasAnyOverride = Object.values(overrides).some((o) => o && (o.provider || o.model));
+
+  // Build list of configured providers from providerConfigs
+  const configuredProviders = settings.providerConfigs
+    ? Object.keys(settings.providerConfigs) as AiProvider[]
+    : [settings.provider];
+
+  return (
+    <Disclosure
+      label="Task Routing"
+      indicator={hasAnyOverride}
+    >
+      <div className="flex flex-col">
+        {TASK_GROUP_META.map((group, i) => {
+          const isLocked = envLocked.includes(group.key);
+          const envOverride = settings.taskOverrides?.[group.key];
+          const override = isLocked ? envOverride : overrides[group.key];
+          const hasOverride = !!(override?.provider || override?.model);
+          const selectedProvider = override?.provider || '';
+          const selectedModel = override?.model || '';
+          const selectedEndpoint = override?.endpointUrl || '';
+
+          return (
+            <div key={group.key}>
+              {i > 0 && <div className="border-t border-[var(--border-subtle)] my-3" />}
+
+              <div className="space-y-2">
+                <div>
+                  <span className="text-[13px] font-medium text-[var(--text-primary)]">{group.label}</span>
+                  <span className="text-[11px] text-[var(--text-tertiary)] ml-1.5">{group.description}</span>
+                </div>
+
+                {isLocked && (
+                  <div className="px-3 py-2 rounded-[var(--radius-sm)] bg-[var(--accent)]/10 border border-[var(--accent)]/20">
+                    <p className="text-[12px] text-[var(--text-secondary)]">
+                      Configured by server
+                      {envOverride?.provider && ` \u2014 ${envOverride.provider}`}
+                      {envOverride?.model && ` / ${envOverride.model}`}
+                    </p>
+                  </div>
+                )}
+
+                {!isLocked && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <label className="text-[12px] text-[var(--text-tertiary)]">Provider</label>
+                      <select
+                        value={selectedProvider}
+                        onChange={(e) => {
+                          const provider = e.target.value || null;
+                          onChange(group.key, {
+                            provider,
+                            model: provider ? selectedModel : null,
+                            endpointUrl: provider === 'openai-compatible' ? selectedEndpoint : null,
+                          });
+                        }}
+                        disabled={disabled}
+                        className={cn(inputBase, 'text-[13px]')}
+                      >
+                        <option value="">Default ({AI_PROVIDERS.find((p) => p.key === settings.provider)?.label ?? settings.provider})</option>
+                        {configuredProviders.map((p) => (
+                          <option key={p} value={p}>
+                            {AI_PROVIDERS.find((ap) => ap.key === p)?.label ?? p}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <label className="text-[12px] text-[var(--text-tertiary)]">Model</label>
+                      <Input
+                        value={selectedModel}
+                        onChange={(e) => {
+                          onChange(group.key, {
+                            provider: selectedProvider || null,
+                            model: e.target.value || null,
+                            endpointUrl: selectedEndpoint || null,
+                          });
+                        }}
+                        placeholder={
+                          selectedProvider
+                            ? (MODEL_HINTS[selectedProvider as AiProvider] ?? '')
+                            : settings.model
+                        }
+                        disabled={disabled}
+                        className="text-[13px]"
+                      />
+                    </div>
+
+                    {hasOverride && !disabled && (
+                      <button
+                        type="button"
+                        onClick={() => onChange(group.key, null)}
+                        className="self-end sm:self-center p-1.5 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+                        title="Reset to default"
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {!isLocked && selectedProvider === 'openai-compatible' && (
+                  <div className="space-y-1">
+                    <label className="text-[12px] text-[var(--text-tertiary)]">Endpoint URL</label>
+                    <Input
+                      value={selectedEndpoint}
+                      onChange={(e) => {
+                        onChange(group.key, {
+                          provider: selectedProvider,
+                          model: selectedModel || null,
+                          endpointUrl: e.target.value || null,
+                        });
+                      }}
+                      placeholder="http://localhost:11434/v1"
+                      disabled={disabled}
+                      className="text-[13px]"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Disclosure>
+  );
+}
+```
+
+- [ ] **Step 3: Integrate into AiSettingsSection.tsx**
+
+Add import at the top:
+```ts
+import { TaskRoutingSection } from './TaskRoutingSection';
+import { deleteTaskOverride, saveTaskOverride } from './useAiSettings';
+import type { AiTaskGroup } from '@/types';
+```
+
+Replace the existing `taskModelOverrides` state (line 49) with:
+```ts
+  const [taskOverrides, setTaskOverrides] = useState<Partial<Record<AiTaskGroup, { provider: string | null; model: string | null; endpointUrl: string | null } | null>>>({});
+```
+
+In the `useEffect` that populates form from settings (around line 58), replace the `setTaskModelOverrides` line (line 69) with:
+```ts
+      setTaskOverrides(settings.taskOverrides
+        ? Object.fromEntries(
+            Object.entries(settings.taskOverrides)
+              .filter(([, v]) => v)
+              .map(([k, v]) => [k, { provider: v!.provider, model: v!.model, endpointUrl: v!.endpointUrl }])
+          )
+        : {});
+```
+
+- [ ] **Step 4: Update handleSave to save task overrides**
+
+In `handleSave()`, after the existing `saveAiSettings()` call (around line 113), add task override saves:
+
+```ts
+    // Save task overrides
+    const groups: AiTaskGroup[] = ['vision', 'quickText', 'deepText'];
+    for (const group of groups) {
+      const override = taskOverrides[group];
+      const original = settings?.taskOverrides?.[group];
+      const isEnvLocked = settings?.taskOverridesEnvLocked?.includes(group);
+      if (isEnvLocked) continue;
+
+      if (override && (override.provider || override.model)) {
+        await saveTaskOverride(group, override);
+      } else if (original) {
+        await deleteTaskOverride(group);
+      }
+    }
+```
+
+Also remove `taskModelOverrides` from the `saveAiSettings()` call payload.
+
+- [ ] **Step 5: Add TaskRoutingSection to JSX**
+
+In the JSX, add between the endpoint URL conditional and the "Custom Prompts" Disclosure:
+
+```tsx
+                {/* Task Routing */}
+                {settings && (
+                  <TaskRoutingSection
+                    settings={settings}
+                    overrides={taskOverrides}
+                    onChange={(group, override) => {
+                      setTaskOverrides((prev) => {
+                        if (!override) {
+                          const { [group]: _, ...rest } = prev;
+                          return rest;
+                        }
+                        return { ...prev, [group]: override };
+                      });
+                    }}
+                    disabled={demoMode}
+                  />
+                )}
+```
+
+- [ ] **Step 6: Remove old per-tab model override UI**
+
+In `AiSettingsSection.tsx`, remove the per-tab "Model override" input section (the `<div className="space-y-1.5 pt-1">` block at lines 318-349 that contains the `model-override-${activePromptTab}` input).
+
+In `handleRemove()`, replace `setTaskModelOverrides({})` with `setTaskOverrides({})`.
+
+- [ ] **Step 7: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/ai/TaskRoutingSection.tsx src/features/ai/AiSettingsSection.tsx src/features/ai/aiConstants.ts
+git commit -m "feat: add Task Routing UI section with per-group provider+model selection"
+```
+
+---
+
+### Task 9: Cleanup -- Remove Legacy taskModelOverrides
+
+**Files:**
+- Modify: `server/src/routes/ai.ts`
+- Modify: `src/types.ts`
+- Modify: `src/features/ai/useAiSettings.ts`
+
+- [ ] **Step 1: Remove taskModelOverrides from server response**
+
+In `server/src/routes/ai.ts`, in both the GET and PUT settings responses, remove the `taskModelOverrides` field from `res.json()`. Keep the DB column (backward compat for rollback) but stop sending it.
+
+In the PUT handler, remove the `rawOverrides` validation block (lines 186-199) and the `finalOverrides` variable from the INSERT query. Set the `task_model_overrides` parameter to `null` in the query to clear any existing values.
+
+- [ ] **Step 2: Remove from client types**
+
+In `src/types.ts`, remove from the `AiSettings` interface:
+```ts
+  taskModelOverrides?: Partial<Record<string, string>> | null;  // REMOVE THIS LINE
+```
+
+- [ ] **Step 3: Remove from saveAiSettings**
+
+In `src/features/ai/useAiSettings.ts`, remove the `taskModelOverrides` field from the `saveAiSettings` options type.
+
+- [ ] **Step 4: Remove getConfigForTask usage from import statements**
+
+In `server/src/routes/ai.ts` and `server/src/routes/aiStream.ts`, remove `getConfigForTask` from the import if no longer used. In `server/src/routes/aiStream.ts`, `getConfigForTask` is used as a fallback for tasks not in `TASK_GROUP_MAP` -- if all tasks are now mapped, it can be removed.
+
+- [ ] **Step 5: Full type check + tests**
+
+Run:
+```bash
+npx tsc --noEmit && cd server && npx tsc --noEmit && npx vitest run
+```
+Expected: No errors, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/ai.ts server/src/routes/aiStream.ts src/types.ts src/features/ai/useAiSettings.ts
+git commit -m "refactor: remove legacy taskModelOverrides in favor of task routing"
+```
+
+---
+
+### Task 10: Biome Check + Final Verification
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run biome check**
+
+Run: `npx biome check .`
+Expected: No lint/format errors. If any, fix with `npx biome check --write .`
+
+- [ ] **Step 2: Run full type checks**
+
+Run: `npx tsc --noEmit && cd server && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `npx vitest run && cd server && npx vitest run`
+Expected: All tests pass.
+
+- [ ] **Step 4: Manual smoke test**
+
+Start dev server:
+```bash
+npm run dev:all
+```
+
+Verify:
+1. Open Settings -> AI Features -> Task Routing disclosure expands
+2. Three group rows render with provider dropdown + model input
+3. Selecting a provider updates model placeholder
+4. Saving with an override persists (refresh shows override)
+5. Reset button clears override
+6. Photo scan, commands, and queries still work
+
+- [ ] **Step 5: Final commit if biome fixes needed**
+
+```bash
+git add -A
+git commit -m "style: fix biome lint issues"
+```

--- a/server/schema.pg.sql
+++ b/server/schema.pg.sql
@@ -144,6 +144,20 @@ CREATE TABLE IF NOT EXISTS user_ai_settings (
 );
 CREATE INDEX IF NOT EXISTS idx_user_ai_settings_user ON user_ai_settings(user_id);
 
+CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+  id              TEXT PRIMARY KEY,
+  user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+  provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+  api_key         TEXT,
+  model           TEXT,
+  endpoint_url    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (now()),
+  updated_at      TEXT NOT NULL DEFAULT (now()),
+  UNIQUE(user_id, task_group)
+);
+CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id);
+
 CREATE TABLE IF NOT EXISTS user_print_settings (
   id         TEXT PRIMARY KEY,
   user_id    TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,

--- a/server/schema.pg.sql
+++ b/server/schema.pg.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS users (
   ai_credits_reset_at TEXT,
   last_active_at TEXT,
   is_admin           BOOLEAN NOT NULL DEFAULT FALSE,
+  suspended_at       TEXT,
+  token_version      INTEGER NOT NULL DEFAULT 0,
   deleted_at         TEXT,
   created_at         TEXT NOT NULL DEFAULT (NOW()),
   updated_at         TEXT NOT NULL DEFAULT (NOW())
@@ -378,3 +380,59 @@ CREATE TABLE IF NOT EXISTS job_locks (
   locked_at  TEXT NOT NULL DEFAULT (NOW()),
   expires_at TEXT NOT NULL
 );
+
+-- Admin audit log (global admin actions, not location-scoped activity_log)
+CREATE TABLE IF NOT EXISTS admin_audit_log (
+  id          TEXT PRIMARY KEY,
+  actor_id    TEXT NOT NULL REFERENCES users(id) ON DELETE SET NULL,
+  actor_name  TEXT NOT NULL,
+  action      TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id   TEXT,
+  target_name TEXT,
+  details     JSONB,
+  created_at  TEXT NOT NULL DEFAULT (NOW())
+);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_created ON admin_audit_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_actor ON admin_audit_log(actor_id);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_action ON admin_audit_log(action);
+
+-- Per-user limit overrides (null = use plan default)
+CREATE TABLE IF NOT EXISTS user_limit_overrides (
+  id                       TEXT PRIMARY KEY,
+  user_id                  TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  max_bins                 INTEGER,
+  max_locations            INTEGER,
+  max_photo_storage_mb     INTEGER,
+  max_members_per_location INTEGER,
+  activity_retention_days  INTEGER,
+  ai_credits_per_month     INTEGER,
+  ai_enabled               INTEGER,
+  created_at               TEXT NOT NULL DEFAULT (NOW()),
+  updated_at               TEXT NOT NULL DEFAULT (NOW())
+);
+
+-- Login history for security auditing
+CREATE TABLE IF NOT EXISTS login_history (
+  id         TEXT PRIMARY KEY,
+  user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  ip_address TEXT,
+  user_agent TEXT,
+  method     TEXT NOT NULL DEFAULT 'password',
+  success    BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TEXT NOT NULL DEFAULT (NOW())
+);
+CREATE INDEX IF NOT EXISTS idx_login_history_user ON login_history(user_id, created_at DESC);
+
+-- Announcement banners
+CREATE TABLE IF NOT EXISTS announcements (
+  id           TEXT PRIMARY KEY,
+  text         TEXT NOT NULL,
+  type         TEXT NOT NULL DEFAULT 'info' CHECK (type IN ('info', 'warning', 'critical')),
+  dismissible  BOOLEAN NOT NULL DEFAULT TRUE,
+  active       BOOLEAN NOT NULL DEFAULT TRUE,
+  expires_at   TEXT,
+  created_by   TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TEXT NOT NULL DEFAULT (NOW())
+);
+CREATE INDEX IF NOT EXISTS idx_announcements_active ON announcements(active) WHERE active = TRUE;

--- a/server/schema.sqlite.sql
+++ b/server/schema.sqlite.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS users (
   ai_credits_reset_at TEXT,
   last_active_at TEXT,
   is_admin           INTEGER NOT NULL DEFAULT 0,
+  suspended_at       TEXT,
+  token_version      INTEGER NOT NULL DEFAULT 0,
   deleted_at         TEXT,
   created_at         TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
@@ -361,3 +363,59 @@ CREATE TABLE IF NOT EXISTS job_locks (
   locked_at  TEXT NOT NULL DEFAULT (datetime('now')),
   expires_at TEXT NOT NULL
 );
+
+-- Admin audit log (global admin actions, not location-scoped activity_log)
+CREATE TABLE IF NOT EXISTS admin_audit_log (
+  id          TEXT PRIMARY KEY,
+  actor_id    TEXT NOT NULL REFERENCES users(id) ON DELETE SET NULL,
+  actor_name  TEXT NOT NULL,
+  action      TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id   TEXT,
+  target_name TEXT,
+  details     TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_created ON admin_audit_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_actor ON admin_audit_log(actor_id);
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_action ON admin_audit_log(action);
+
+-- Per-user limit overrides (null = use plan default)
+CREATE TABLE IF NOT EXISTS user_limit_overrides (
+  id                       TEXT PRIMARY KEY,
+  user_id                  TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  max_bins                 INTEGER,
+  max_locations            INTEGER,
+  max_photo_storage_mb     INTEGER,
+  max_members_per_location INTEGER,
+  activity_retention_days  INTEGER,
+  ai_credits_per_month     INTEGER,
+  ai_enabled               INTEGER,
+  created_at               TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at               TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Login history for security auditing
+CREATE TABLE IF NOT EXISTS login_history (
+  id         TEXT PRIMARY KEY,
+  user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  ip_address TEXT,
+  user_agent TEXT,
+  method     TEXT NOT NULL DEFAULT 'password',
+  success    INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_login_history_user ON login_history(user_id, created_at DESC);
+
+-- Announcement banners
+CREATE TABLE IF NOT EXISTS announcements (
+  id           TEXT PRIMARY KEY,
+  text         TEXT NOT NULL,
+  type         TEXT NOT NULL DEFAULT 'info' CHECK (type IN ('info', 'warning', 'critical')),
+  dismissible  INTEGER NOT NULL DEFAULT 1,
+  active       INTEGER NOT NULL DEFAULT 1,
+  expires_at   TEXT,
+  created_by   TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_announcements_active ON announcements(active) WHERE active = 1;

--- a/server/schema.sqlite.sql
+++ b/server/schema.sqlite.sql
@@ -133,6 +133,20 @@ CREATE TABLE IF NOT EXISTS user_ai_settings (
 );
 CREATE INDEX IF NOT EXISTS idx_user_ai_settings_user ON user_ai_settings(user_id);
 
+CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+  id              TEXT PRIMARY KEY,
+  user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+  provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+  api_key         TEXT,
+  model           TEXT,
+  endpoint_url    TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(user_id, task_group)
+);
+CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id);
+
 CREATE TABLE IF NOT EXISTS user_print_settings (
   id         TEXT PRIMARY KEY,
   user_id    TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,

--- a/server/src/__tests__/taskRouting.test.ts
+++ b/server/src/__tests__/taskRouting.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---- Module-level mocks (hoisted before imports) ----
+
+vi.mock('../db.js', () => ({
+  query: vi.fn(),
+}));
+
+vi.mock('../lib/crypto.js', () => ({
+  decryptApiKey: vi.fn((stored: string) =>
+    stored.startsWith('enc:') ? stored.slice(4) : stored,
+  ),
+  encryptApiKey: vi.fn((plain: string) => `enc:${plain}`),
+}));
+
+vi.mock('../lib/config.js', () => ({
+  config: {
+    aiProvider: 'openai',
+    aiApiKey: 'sk-default',
+    aiModel: 'gpt-4o',
+    aiEndpointUrl: null,
+  },
+  hasEnvAiConfig: () => true,
+  getEnvAiConfig: () => ({
+    provider: 'openai' as const,
+    apiKey: 'sk-default',
+    model: 'gpt-4o',
+    endpointUrl: null,
+  }),
+  getEnvGroupOverride: vi.fn(() => ({
+    provider: null,
+    apiKey: null,
+    model: null,
+    endpointUrl: null,
+  })),
+  isGroupEnvLocked: vi.fn(() => false),
+}));
+
+vi.mock('../lib/aiSettings.js', () => ({
+  NoAiSettingsError: class NoAiSettingsError extends Error {
+    constructor() {
+      super('AI not configured. Set up your AI provider first.');
+      this.name = 'NoAiSettingsError';
+    }
+  },
+}));
+
+// ---- Imports (after mocks) ----
+
+import { query } from '../db.js';
+import { getEnvGroupOverride } from '../lib/config.js';
+import { decryptApiKey } from '../lib/crypto.js';
+import { resolveTaskConfig, TASK_GROUP_MAP } from '../lib/taskRouting.js';
+
+// ---- Helpers ----
+
+const mockQuery = vi.mocked(query);
+const mockGetEnvGroupOverride = vi.mocked(getEnvGroupOverride);
+
+function emptyResult() {
+  return { rows: [], rowCount: 0 };
+}
+
+// ---- Tests ----
+
+describe('TASK_GROUP_MAP', () => {
+  it('maps all AI tasks to correct groups', () => {
+    expect(TASK_GROUP_MAP.analysis).toBe('vision');
+    expect(TASK_GROUP_MAP['analyze-image']).toBe('vision');
+    expect(TASK_GROUP_MAP.command).toBe('quickText');
+    expect(TASK_GROUP_MAP.execute).toBe('quickText');
+    expect(TASK_GROUP_MAP['structure-text']).toBe('quickText');
+    expect(TASK_GROUP_MAP.query).toBe('deepText');
+    expect(TASK_GROUP_MAP.reorganization).toBe('deepText');
+  });
+
+  it('covers all expected task keys', () => {
+    const keys = Object.keys(TASK_GROUP_MAP);
+    expect(keys).toHaveLength(7);
+  });
+});
+
+describe('resolveTaskConfig()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEnvGroupOverride.mockReturnValue({
+      provider: null,
+      apiKey: null,
+      model: null,
+      endpointUrl: null,
+    });
+    // Default: no DB overrides, no DB user settings
+    mockQuery.mockResolvedValue(emptyResult());
+  });
+
+  it('returns env default config when no overrides exist', async () => {
+    const result = await resolveTaskConfig('user-1', 'vision');
+
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-default',
+      model: 'gpt-4o',
+      endpointUrl: null,
+    });
+
+    // Should query for DB override but not for DB default (env default covers it)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('user_ai_task_overrides'),
+      ['user-1', 'vision'],
+    );
+  });
+
+  it('returns full DB override when all fields set', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        provider: 'anthropic',
+        api_key: 'enc:sk-anthropic-key',
+        model: 'claude-3-opus',
+        endpoint_url: null,
+      }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user-1', 'vision');
+
+    expect(result).toEqual({
+      provider: 'anthropic',
+      apiKey: 'sk-anthropic-key',
+      model: 'claude-3-opus',
+      endpointUrl: null,
+    });
+    expect(decryptApiKey).toHaveBeenCalledWith('enc:sk-anthropic-key');
+  });
+
+  it('cascades: model-only DB override inherits provider+key from env default', async () => {
+    // DB override has only model set
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        provider: null,
+        api_key: null,
+        model: 'gpt-4o-mini',
+        endpoint_url: null,
+      }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user-1', 'quickText');
+
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-default',
+      model: 'gpt-4o-mini',
+      endpointUrl: null,
+    });
+  });
+
+  it('env group override takes precedence over DB override', async () => {
+    // Layer 1: env group has a specific vision model
+    mockGetEnvGroupOverride.mockReturnValue({
+      provider: 'gemini' as any,
+      apiKey: 'gemini-key',
+      model: 'gemini-pro-vision',
+      endpointUrl: null,
+    });
+
+    // Layer 2: DB override exists too
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        provider: 'anthropic',
+        api_key: 'enc:sk-anthropic-key',
+        model: 'claude-3-opus',
+        endpoint_url: null,
+      }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user-1', 'vision');
+
+    // Env group override wins
+    expect(result).toEqual({
+      provider: 'gemini',
+      apiKey: 'gemini-key',
+      model: 'gemini-pro-vision',
+      endpointUrl: null,
+    });
+    // DB override row's api_key should not have been decrypted
+    expect(decryptApiKey).not.toHaveBeenCalled();
+  });
+
+  it('env group model-only cascades other fields from env default', async () => {
+    // Env group override sets only model
+    mockGetEnvGroupOverride.mockReturnValue({
+      provider: null,
+      apiKey: null,
+      model: 'gpt-4o-vision',
+      endpointUrl: null,
+    });
+
+    const result = await resolveTaskConfig('user-1', 'vision');
+
+    expect(result).toEqual({
+      provider: 'openai',
+      apiKey: 'sk-default',
+      model: 'gpt-4o-vision',
+      endpointUrl: null,
+    });
+  });
+
+  it('falls back to DB user default when no env default exists', async () => {
+    // Override getEnvAiConfig to return null (no env AI config)
+    const configMod = await import('../lib/config.js');
+    const origGetEnvAiConfig = configMod.getEnvAiConfig;
+    vi.spyOn(configMod, 'getEnvAiConfig').mockReturnValue(null);
+
+    // No DB task override
+    mockQuery.mockResolvedValueOnce(emptyResult());
+    // DB user default
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        provider: 'anthropic',
+        api_key: 'enc:sk-db-default',
+        model: 'claude-3-sonnet',
+        endpoint_url: 'https://custom.endpoint.com',
+      }],
+      rowCount: 1,
+    });
+
+    const result = await resolveTaskConfig('user-1', 'deepText');
+
+    expect(result).toEqual({
+      provider: 'anthropic',
+      apiKey: 'sk-db-default',
+      model: 'claude-3-sonnet',
+      endpointUrl: 'https://custom.endpoint.com',
+    });
+    expect(decryptApiKey).toHaveBeenCalledWith('enc:sk-db-default');
+
+    // Second query should be for user_ai_settings
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery).toHaveBeenNthCalledWith(2,
+      expect.stringContaining('user_ai_settings'),
+      ['user-1'],
+    );
+
+    // Restore
+    vi.mocked(configMod.getEnvAiConfig).mockImplementation(origGetEnvAiConfig);
+  });
+
+  it('throws NoAiSettingsError when no config is available', async () => {
+    const configMod = await import('../lib/config.js');
+    const origGetEnvAiConfig = configMod.getEnvAiConfig;
+    vi.spyOn(configMod, 'getEnvAiConfig').mockReturnValue(null);
+
+    // No DB task override
+    mockQuery.mockResolvedValueOnce(emptyResult());
+    // No DB user default
+    mockQuery.mockResolvedValueOnce(emptyResult());
+
+    await expect(resolveTaskConfig('user-1', 'vision')).rejects.toThrow(
+      'AI not configured. Set up your AI provider first.',
+    );
+
+    vi.mocked(configMod.getEnvAiConfig).mockImplementation(origGetEnvAiConfig);
+  });
+});

--- a/server/src/__tests__/taskRouting.test.ts
+++ b/server/src/__tests__/taskRouting.test.ts
@@ -69,6 +69,7 @@ describe('TASK_GROUP_MAP', () => {
     expect(TASK_GROUP_MAP['analyze-image']).toBe('vision');
     expect(TASK_GROUP_MAP.command).toBe('quickText');
     expect(TASK_GROUP_MAP.execute).toBe('quickText');
+    expect(TASK_GROUP_MAP.structure).toBe('quickText');
     expect(TASK_GROUP_MAP['structure-text']).toBe('quickText');
     expect(TASK_GROUP_MAP.query).toBe('deepText');
     expect(TASK_GROUP_MAP.reorganization).toBe('deepText');
@@ -76,7 +77,7 @@ describe('TASK_GROUP_MAP', () => {
 
   it('covers all expected task keys', () => {
     const keys = Object.keys(TASK_GROUP_MAP);
-    expect(keys).toHaveLength(7);
+    expect(keys).toHaveLength(8);
   });
 });
 

--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -145,6 +145,23 @@ async function runSqliteInit(): Promise<DatabaseEngine> {
   addColumnIfNotExists('ALTER TABLE bin_items ADD COLUMN quantity INTEGER DEFAULT NULL');
   addColumnIfNotExists('ALTER TABLE user_ai_settings ADD COLUMN task_model_overrides TEXT');
 
+  // Per-task-group AI model overrides
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+      id              TEXT PRIMARY KEY,
+      user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+      provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+      api_key         TEXT,
+      model           TEXT,
+      endpoint_url    TEXT,
+      created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(user_id, task_group)
+    );
+    CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id);
+  `);
+
   // Hierarchical areas: add parent_id column
   addColumnIfNotExists('ALTER TABLE areas ADD COLUMN parent_id TEXT REFERENCES areas(id) ON DELETE CASCADE');
 
@@ -459,6 +476,23 @@ async function runPostgresInit(): Promise<DatabaseEngine> {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_bin_shares_active ON bin_shares(bin_id) WHERE revoked_at IS NULL;
     CREATE UNIQUE INDEX IF NOT EXISTS idx_email_log_daily ON email_log(user_id, email_type, (left(sent_at, 10)));
     CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_unique ON users(LOWER(email)) WHERE email IS NOT NULL;
+  `);
+
+  // Per-task-group AI model overrides (new installs get it via schema.pg.sql; this handles existing DBs)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS user_ai_task_overrides (
+      id              TEXT PRIMARY KEY,
+      user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      task_group      TEXT NOT NULL CHECK (task_group IN ('vision', 'quickText', 'deepText')),
+      provider        TEXT CHECK (provider IN ('openai', 'anthropic', 'gemini', 'openai-compatible')),
+      api_key         TEXT,
+      model           TEXT,
+      endpoint_url    TEXT,
+      created_at      TEXT NOT NULL DEFAULT (now()),
+      updated_at      TEXT NOT NULL DEFAULT (now()),
+      UNIQUE(user_id, task_group)
+    );
+    CREATE INDEX IF NOT EXISTS idx_user_ai_task_overrides_user ON user_ai_task_overrides(user_id);
   `);
 
   // api_key_daily_usage: add FK on api_key_id if missing

--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -407,6 +407,74 @@ async function runSqliteInit(): Promise<DatabaseEngine> {
   // Admin usage metrics: last_active_at on users
   addColumnIfNotExists('ALTER TABLE users ADD COLUMN last_active_at TEXT');
 
+  // Admin panel: user suspension and session revocation
+  addColumnIfNotExists('ALTER TABLE users ADD COLUMN suspended_at TEXT');
+  addColumnIfNotExists('ALTER TABLE users ADD COLUMN token_version INTEGER NOT NULL DEFAULT 0');
+
+  // Admin audit log
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS admin_audit_log (
+      id          TEXT PRIMARY KEY,
+      actor_id    TEXT NOT NULL,
+      actor_name  TEXT NOT NULL,
+      action      TEXT NOT NULL,
+      target_type TEXT NOT NULL,
+      target_id   TEXT,
+      target_name TEXT,
+      details     TEXT,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_admin_audit_log_created ON admin_audit_log(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_admin_audit_log_actor ON admin_audit_log(actor_id);
+    CREATE INDEX IF NOT EXISTS idx_admin_audit_log_action ON admin_audit_log(action);
+  `);
+
+  // Per-user limit overrides
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS user_limit_overrides (
+      id                       TEXT PRIMARY KEY,
+      user_id                  TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+      max_bins                 INTEGER,
+      max_locations            INTEGER,
+      max_photo_storage_mb     INTEGER,
+      max_members_per_location INTEGER,
+      activity_retention_days  INTEGER,
+      ai_credits_per_month     INTEGER,
+      ai_enabled               INTEGER,
+      created_at               TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at               TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  // Login history
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS login_history (
+      id         TEXT PRIMARY KEY,
+      user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      ip_address TEXT,
+      user_agent TEXT,
+      method     TEXT NOT NULL DEFAULT 'password',
+      success    INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_login_history_user ON login_history(user_id, created_at DESC);
+  `);
+
+  // Announcement banners
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS announcements (
+      id           TEXT PRIMARY KEY,
+      text         TEXT NOT NULL,
+      type         TEXT NOT NULL DEFAULT 'info' CHECK (type IN ('info', 'warning', 'critical')),
+      dismissible  INTEGER NOT NULL DEFAULT 1,
+      active       INTEGER NOT NULL DEFAULT 1,
+      expires_at   TEXT,
+      created_by   TEXT,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_announcements_active ON announcements(active) WHERE active = 1;
+  `);
+
   } catch (e) {
     log.error('Migration failed — exiting to prevent corrupt state:', e instanceof Error ? e.message : e);
     process.exit(1);
@@ -507,6 +575,49 @@ async function runPostgresInit(): Promise<DatabaseEngine> {
           FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE CASCADE;
       END IF;
     END $$;
+  `);
+
+  // Admin panel: user suspension and session revocation
+  await pool.query(`
+    DO $$ BEGIN
+      ALTER TABLE users ADD COLUMN IF NOT EXISTS suspended_at TEXT;
+      ALTER TABLE users ADD COLUMN IF NOT EXISTS token_version INTEGER NOT NULL DEFAULT 0;
+    END $$;
+  `);
+
+  // New admin tables (idempotent via IF NOT EXISTS in schema.pg.sql, but handle existing DBs)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS admin_audit_log (
+      id TEXT PRIMARY KEY, actor_id TEXT NOT NULL, actor_name TEXT NOT NULL,
+      action TEXT NOT NULL, target_type TEXT NOT NULL, target_id TEXT,
+      target_name TEXT, details JSONB, created_at TEXT NOT NULL DEFAULT (NOW())
+    );
+    CREATE INDEX IF NOT EXISTS idx_admin_audit_log_created ON admin_audit_log(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_admin_audit_log_actor ON admin_audit_log(actor_id);
+    CREATE INDEX IF NOT EXISTS idx_admin_audit_log_action ON admin_audit_log(action);
+
+    CREATE TABLE IF NOT EXISTS user_limit_overrides (
+      id TEXT PRIMARY KEY, user_id TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+      max_bins INTEGER, max_locations INTEGER, max_photo_storage_mb INTEGER,
+      max_members_per_location INTEGER, activity_retention_days INTEGER,
+      ai_credits_per_month INTEGER, ai_enabled INTEGER,
+      created_at TEXT NOT NULL DEFAULT (NOW()), updated_at TEXT NOT NULL DEFAULT (NOW())
+    );
+
+    CREATE TABLE IF NOT EXISTS login_history (
+      id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      ip_address TEXT, user_agent TEXT, method TEXT NOT NULL DEFAULT 'password',
+      success BOOLEAN NOT NULL DEFAULT TRUE, created_at TEXT NOT NULL DEFAULT (NOW())
+    );
+    CREATE INDEX IF NOT EXISTS idx_login_history_user ON login_history(user_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS announcements (
+      id TEXT PRIMARY KEY, text TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'info' CHECK (type IN ('info', 'warning', 'critical')),
+      dismissible BOOLEAN NOT NULL DEFAULT TRUE, active BOOLEAN NOT NULL DEFAULT TRUE,
+      expires_at TEXT, created_by TEXT, created_at TEXT NOT NULL DEFAULT (NOW())
+    );
+    CREATE INDEX IF NOT EXISTS idx_announcements_active ON announcements(active) WHERE active = TRUE;
   `);
 
   const pgEngine = createPostgresEngine();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,10 +13,14 @@ import { createLogger } from './lib/logger.js';
 import { apiLimiter, authLimiter, joinLimiter, registerLimiter, sensitiveAuthLimiter } from './lib/rateLimiters.js';
 import { isRestoreInProgress } from './lib/restore.js';
 import { tryAuthenticate } from './middleware/auth.js';
+import { maintenanceGate } from './middleware/maintenance.js';
 import { requestLogger } from './middleware/requestLogger.js';
 import { requireActiveSubscription } from './middleware/requirePlan.js';
 import activityRoutes from './routes/activity.js';
 import { adminRoutes } from './routes/admin.js';
+import { adminOverridesRoutes } from './routes/adminOverrides.js';
+import { adminSecurityRoutes } from './routes/adminSecurity.js';
+import { adminSystemRoutes } from './routes/adminSystem.js';
 import aiRoutes from './routes/ai.js';
 import { streamRouter as aiStreamRoutes } from './routes/aiStream.js';
 import apiKeysRoutes from './routes/apiKeys.js';
@@ -120,7 +124,7 @@ export function createApp(): express.Express {
 
   // Routes
   app.use('/api', apiLimiter);
-  app.use('/api', tryAuthenticate, requireActiveSubscription());
+  app.use('/api', tryAuthenticate, maintenanceGate, requireActiveSubscription());
   app.use('/api/auth/login', authLimiter);
   app.use('/api/auth/demo-login', authLimiter);
   app.use('/api/auth/register', registerLimiter);
@@ -158,6 +162,9 @@ export function createApp(): express.Express {
   app.use('/api/items', itemsRoutes);
   app.use('/api', batchRoutes);
   app.use('/api/admin', adminRoutes);
+  app.use('/api/admin/security', adminSecurityRoutes);
+  app.use('/api/admin/overrides', adminOverridesRoutes);
+  app.use('/api/admin/system', adminSystemRoutes);
 
   // Global error handler
   app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/server/src/lib/adminAudit.ts
+++ b/server/src/lib/adminAudit.ts
@@ -1,0 +1,30 @@
+import { generateUuid, query } from '../db.js';
+
+export interface AuditEntry {
+  actorId: string;
+  actorName: string;
+  action: string;
+  targetType: string;
+  targetId?: string | null;
+  targetName?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+/** Fire-and-forget admin audit log entry. Never throws. */
+export function logAdminAction(entry: AuditEntry): void {
+  const id = generateUuid();
+  query(
+    `INSERT INTO admin_audit_log (id, actor_id, actor_name, action, target_type, target_id, target_name, details)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+    [
+      id,
+      entry.actorId,
+      entry.actorName,
+      entry.action,
+      entry.targetType,
+      entry.targetId ?? null,
+      entry.targetName ?? null,
+      entry.details ? JSON.stringify(entry.details) : null,
+    ],
+  ).catch(() => {});
+}

--- a/server/src/lib/adminHelpers.ts
+++ b/server/src/lib/adminHelpers.ts
@@ -1,0 +1,23 @@
+import { query } from '../db.js';
+import { NotFoundError } from './httpErrors.js';
+
+export async function getAdminCount(): Promise<number> {
+  const result = await query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM users WHERE is_admin = TRUE');
+  return result.rows[0].cnt;
+}
+
+export async function assertUserExists(userId: string): Promise<{ id: string; username: string }> {
+  const result = await query<{ id: string; username: string }>(
+    'SELECT id, username FROM users WHERE id = $1',
+    [userId],
+  );
+  if (result.rows.length === 0) throw new NotFoundError('User not found');
+  return result.rows[0];
+}
+
+export const VALID_ROLES = ['admin', 'member', 'viewer'] as const;
+export type LocationRole = (typeof VALID_ROLES)[number];
+
+export function isValidRole(role: unknown): role is LocationRole {
+  return typeof role === 'string' && (VALID_ROLES as readonly string[]).includes(role);
+}

--- a/server/src/lib/aiContext.ts
+++ b/server/src/lib/aiContext.ts
@@ -10,6 +10,92 @@ export const AVAILABLE_ICONS = [
   'Scissors', 'Hammer', 'Paintbrush', 'Leaf', 'Apple', 'Coffee', 'Wine', 'Baby', 'Dog', 'Cat',
 ];
 
+function formatItem(item: { name: string; quantity?: number | null }): string {
+  return item.quantity ? `${item.name} (×${item.quantity})` : item.name;
+}
+
+/** Primitive defaults — if a field matches, it's omitted from AI context. */
+const BIN_DEFAULTS: Record<string, unknown> = {
+  notes: '', area_id: null, area_name: '', color: '',
+  visibility: 'location', is_pinned: false, photo_count: 0,
+};
+
+/** Icon has two default forms. */
+const DEFAULT_ICONS = new Set(['Package', '']);
+
+function compactBin<T extends Record<string, unknown>>(bin: T): T {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(bin)) {
+    if (key in BIN_DEFAULTS && value === BIN_DEFAULTS[key]) continue;
+    if (key === 'icon' && DEFAULT_ICONS.has(value as string)) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (key === 'custom_fields' && typeof value === 'object' && value !== null && Object.keys(value as Record<string, unknown>).length === 0) continue;
+    out[key] = value;
+  }
+  return out as T;
+}
+
+export function filterRelevantBins<T extends { id: string; name: string; items: Array<{ name: string } | string>; tags: string[]; area_name?: string }>(
+  bins: T[],
+  userText: string,
+  limit = 30,
+): { relevant: T[]; rest: Array<{ id: string; name: string }> } {
+  const keywords = userText.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+
+  if (keywords.length === 0 || bins.length <= limit) {
+    return { relevant: bins, rest: [] };
+  }
+
+  const scored = bins.map(bin => {
+    const itemNames = bin.items.map(i => typeof i === 'string' ? i : i.name);
+    const searchText = [bin.name, ...itemNames, ...bin.tags, bin.area_name ?? ''].join(' ').toLowerCase();
+    const score = keywords.reduce((s, kw) => s + (searchText.includes(kw) ? 1 : 0), 0);
+    return { bin, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const relevant = scored.filter(s => s.score > 0).map(s => s.bin);
+  const unscored = scored.filter(s => s.score === 0);
+
+  const filler = unscored.slice(0, Math.max(0, limit - relevant.length)).map(s => s.bin);
+  const rest = unscored.slice(Math.max(0, limit - relevant.length)).map(s => ({ id: s.bin.id, name: s.bin.name }));
+
+  return { relevant: [...relevant, ...filler], rest };
+}
+
+/** ~4 chars per token. */
+export const CONTEXT_TOKEN_BUDGET = 6000;
+
+function estimateTokens(obj: unknown): number {
+  return Math.ceil(JSON.stringify(obj).length / 4);
+}
+
+export function budgetContext<T extends { id: string; name: string }>(
+  bins: T[],
+  existingOtherBins: Array<{ id: string; name: string }>,
+  budget = CONTEXT_TOKEN_BUDGET,
+): { bins: T[]; other_bins: Array<{ id: string; name: string }> } {
+  let used = 0;
+  const full: T[] = [];
+  const overflow: Array<{ id: string; name: string }> = [];
+
+  for (const bin of bins) {
+    const cost = estimateTokens(bin);
+    if (used + cost <= budget) {
+      full.push(bin);
+      used += cost;
+    } else {
+      overflow.push({ id: bin.id, name: bin.name });
+    }
+  }
+
+  return {
+    bins: full,
+    other_bins: [...existingOtherBins, ...overflow],
+  };
+}
+
 function appendInClause(sql: string, column: string, startIndex: number, ids: string[]): { sql: string; params: string[] } {
   const placeholders = ids.map((_, i) => `$${startIndex + i}`).join(', ');
   return { sql: `${sql} AND ${column} IN (${placeholders})`, params: ids };
@@ -59,7 +145,6 @@ async function fetchLocationData(locationId: string, userId: string, binIds?: st
     query<{ bin_id: string; field_name: string; value: string }>(cfSql, cfParams),
   ]);
 
-  // Build a map: binId -> Record<fieldName, value>
   const customFieldsByBin = new Map<string, Record<string, string>>();
   for (const row of cfResult.rows) {
     let map = customFieldsByBin.get(row.bin_id);
@@ -75,17 +160,37 @@ function truncateNotes(notes: unknown): string {
   return (notes as string) || '';
 }
 
+/** Apply relevance filtering and token budget to a bins array. */
+function applyContextLimits<T extends { id: string; name: string; items: Array<{ name: string } | string>; tags: string[]; area_name?: string }>(
+  allBins: T[],
+  userText?: string,
+): { bins: T[]; other_bins: Array<{ id: string; name: string }> } {
+  let bins = allBins;
+  let other_bins: Array<{ id: string; name: string }> = [];
+  if (userText) {
+    const filtered = filterRelevantBins(allBins, userText);
+    bins = filtered.relevant;
+    other_bins = filtered.rest;
+  }
+  return budgetContext(bins, other_bins);
+}
+
+const REORDER_INTENT = /reorder|rearrange|sort|move.*(?:up|down|first|last|before|after)/i;
+
 /** Build context for command/execute endpoints. */
-export async function buildCommandContext(locationId: string, userId: string, binIds?: string[]): Promise<CommandRequest['context']> {
+export async function buildCommandContext(locationId: string, userId: string, binIds?: string[], userText?: string): Promise<CommandRequest['context']> {
   const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId, binIds);
 
-  const bins = binsResult.rows.map((r) => {
+  const needsItemIds = userText ? REORDER_INTENT.test(userText) : false;
+
+  const allBins = binsResult.rows.map((r) => {
     const binId = r.id as string;
     const cf = customFieldsByBin.get(binId);
-    return sanitizeBinForContext({
+    const rawItems = r.items as Array<{ id: string; name: string; quantity: number | null }>;
+    const sanitized = sanitizeBinForContext({
       id: binId,
       name: r.name as string,
-      items: r.items as Array<{ id: string; name: string; quantity: number | null }>,
+      items: rawItems,
       tags: r.tags as string[],
       area_id: r.area_id as string | null,
       area_name: r.area_name as string,
@@ -96,6 +201,53 @@ export async function buildCommandContext(locationId: string, userId: string, bi
       is_pinned: !!(r.is_pinned as number),
       photo_count: (r.photo_count as number) || 0,
       ...(cf ? { custom_fields: cf } : {}),
+    });
+    const items: Array<{ id: string; name: string; quantity?: number } | string> = needsItemIds
+      ? sanitized.items.map((i) => {
+          const item: { id: string; name: string; quantity?: number } = { id: i.id, name: i.name };
+          if (i.quantity != null) item.quantity = i.quantity;
+          return item;
+        })
+      : sanitized.items.map(formatItem);
+    return compactBin({ ...sanitized, items });
+  });
+
+  const areas = areasResult.rows.map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+  }));
+
+  const trash_bins = trashResult.rows.map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+  }));
+
+  const budgeted = applyContextLimits(allBins, userText);
+  return { ...budgeted, areas, trash_bins, availableColors: AVAILABLE_COLORS, availableIcons: AVAILABLE_ICONS };
+}
+
+/** Build context for the query (read-only) endpoint. */
+export async function buildInventoryContext(locationId: string, userId: string, binIds?: string[], userText?: string): Promise<InventoryContext> {
+  const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId, binIds);
+
+  const allBins = binsResult.rows.map((r) => {
+    const binId = r.id as string;
+    const cf = customFieldsByBin.get(binId);
+    const sanitized = sanitizeBinForContext({
+      id: binId,
+      name: r.name as string,
+      items: r.items as Array<{ id: string; name: string; quantity: number | null }>,
+      tags: r.tags as string[],
+      area_name: r.area_name as string,
+      notes: truncateNotes(r.notes),
+      visibility: (r.visibility as string) || 'location',
+      is_pinned: !!(r.is_pinned as number),
+      photo_count: (r.photo_count as number) || 0,
+      ...(cf ? { custom_fields: cf } : {}),
+    });
+    return compactBin({
+      ...sanitized,
+      items: sanitized.items.map(formatItem),
     });
   });
 
@@ -109,43 +261,8 @@ export async function buildCommandContext(locationId: string, userId: string, bi
     name: r.name as string,
   }));
 
-  return { bins, areas, trash_bins, availableColors: AVAILABLE_COLORS, availableIcons: AVAILABLE_ICONS };
-}
-
-/** Build context for the query (read-only) endpoint. */
-export async function buildInventoryContext(locationId: string, userId: string, binIds?: string[]): Promise<InventoryContext> {
-  const { binsResult, areasResult, trashResult, customFieldsByBin } = await fetchLocationData(locationId, userId, binIds);
-
-  return {
-    bins: binsResult.rows.map((r) => {
-      const binId = r.id as string;
-      const cf = customFieldsByBin.get(binId);
-      const sanitized = sanitizeBinForContext({
-        id: binId,
-        name: r.name as string,
-        items: r.items as Array<{ id: string; name: string; quantity: number | null }>,
-        tags: r.tags as string[],
-        area_name: r.area_name as string,
-        notes: truncateNotes(r.notes),
-        visibility: (r.visibility as string) || 'location',
-        is_pinned: !!(r.is_pinned as number),
-        photo_count: (r.photo_count as number) || 0,
-        ...(cf ? { custom_fields: cf } : {}),
-      });
-      return {
-        ...sanitized,
-        items: sanitized.items.map((i) => i.quantity ? `${i.name} (×${i.quantity})` : i.name),
-      };
-    }),
-    areas: areasResult.rows.map((r) => ({
-      id: r.id as string,
-      name: r.name as string,
-    })),
-    trash_bins: trashResult.rows.map((r) => ({
-      id: r.id as string,
-      name: r.name as string,
-    })),
-  };
+  const budgeted = applyContextLimits(allBins, userText);
+  return { ...budgeted, areas, trash_bins };
 }
 
 /** Fetch distinct tags for a location (for tag reuse suggestions). */

--- a/server/src/lib/aiProviders.ts
+++ b/server/src/lib/aiProviders.ts
@@ -44,47 +44,54 @@ export interface ImageInput {
   mimeType: string;
 }
 
-function buildTagBlock(existingTags?: string[]): string {
+/** Build a tag-reuse instruction block from existing tags. */
+export function buildTagBlock(existingTags?: string[]): string {
   if (!existingTags || existingTags.length === 0) return '';
   return `EXISTING TAGS in this inventory: [${existingTags.join(', ')}]
 You MUST use tags from this list whenever they are even loosely relevant. Do NOT create synonyms, abbreviations, or variations of existing tags (e.g., if "tools" exists, never output "tool", "tooling", or "hand-tools"). Only create a new tag when the bin's contents represent a category not covered by ANY existing tag. New tags should be rare.`;
 }
 
-function appendCustomFieldsDef(prompt: string, customFieldDefs?: CustomFieldDef[]): string {
-  if (!customFieldDefs || customFieldDefs.length === 0) return prompt;
+function buildCustomFieldsBlock(customFieldDefs?: CustomFieldDef[]): string {
+  if (!customFieldDefs || customFieldDefs.length === 0) return '';
   const fieldList = customFieldDefs.map((f) => `"${f.name}" (id: ${f.id})`).join(', ');
-  return `${prompt}\n\nCUSTOM FIELDS defined for this location: [${fieldList}]
+  return `CUSTOM FIELDS defined for this location: [${fieldList}]
 If any of these fields are relevant to the bin's contents, include a "customFields" object in your response mapping field IDs to suggested values. Only include fields where you can provide a meaningful value.`;
 }
 
-function injectTagBlock(basePrompt: string, tagBlock: string): string {
-  if (!tagBlock) return basePrompt.replace(/\{available_tags\}/g, '');
-  if (basePrompt.includes('{available_tags}')) return basePrompt.replace(/\{available_tags\}/g, tagBlock);
-  return `${basePrompt}\n\n${tagBlock}`;
+/** Build a user-message preamble with per-request tag and custom-field context. */
+export function buildContextPreamble(existingTags?: string[], customFieldDefs?: CustomFieldDef[]): string {
+  const parts: string[] = [];
+  const tagBlock = buildTagBlock(existingTags);
+  if (tagBlock) parts.push(tagBlock);
+  const cfBlock = buildCustomFieldsBlock(customFieldDefs);
+  if (cfBlock) parts.push(cfBlock);
+  return parts.length > 0 ? `${parts.join('\n\n')}\n\n` : '';
 }
 
-export function buildSystemPrompt(existingTags?: string[], customPrompt?: string | null, customFieldDefs?: CustomFieldDef[], isDemoUser?: boolean): string {
+function stripTagPlaceholder(prompt: string): string {
+  return prompt.replace(/\{available_tags\}/g, '');
+}
+
+export function buildSystemPrompt(customPrompt?: string | null, isDemoUser?: boolean): string {
   const basePrompt = resolvePrompt(DEFAULT_AI_PROMPT, customPrompt, isDemoUser);
-  const prompt = injectTagBlock(basePrompt, buildTagBlock(existingTags));
-  return appendCustomFieldsDef(prompt, customFieldDefs) + HARDENING_INSTRUCTION;
+  return stripTagPlaceholder(basePrompt) + HARDENING_INSTRUCTION;
 }
 
-export function buildCorrectionPrompt(existingTags?: string[], customFieldDefs?: CustomFieldDef[]): string {
-  const prompt = injectTagBlock(AI_CORRECTION_PROMPT, buildTagBlock(existingTags));
-  return appendCustomFieldsDef(prompt, customFieldDefs) + HARDENING_INSTRUCTION;
+export function buildCorrectionPrompt(): string {
+  return stripTagPlaceholder(AI_CORRECTION_PROMPT) + HARDENING_INSTRUCTION;
 }
 
-export function buildReanalysisPrompt(existingTags?: string[], customFieldDefs?: CustomFieldDef[]): string {
-  const prompt = injectTagBlock(AI_REANALYSIS_PROMPT, buildTagBlock(existingTags));
-  return appendCustomFieldsDef(prompt, customFieldDefs);
+export function buildReanalysisPrompt(): string {
+  return stripTagPlaceholder(AI_REANALYSIS_PROMPT);
 }
 
 /** Build the user-facing content parts for a reanalysis request (previous result JSON + instruction + images). */
 export function buildReanalysisUserContent(
   previousResult: object,
   imageParts: Array<{ type: 'image'; image: Buffer; mimeType: string }>,
+  contextPreamble?: string,
 ): Array<{ type: 'image'; image: Buffer; mimeType: string } | { type: 'text'; text: string }> {
-  const contextText = `Previous analysis result:\n${JSON.stringify(previousResult, null, 2)}\n\nRe-examine these photos. Be more thorough than last time.`;
+  const contextText = `${contextPreamble ?? ''}Previous analysis result:\n${JSON.stringify(previousResult, null, 2)}\n\nRe-examine these photos. Be more thorough than last time.`;
   return [
     { type: 'text' as const, text: contextText },
     ...imageParts,
@@ -163,7 +170,8 @@ export async function analyzeImages(
 
   const model = createSdkModel(config, pinnedFetch);
 
-  const userText = buildAnalysisUserText(images.length);
+  const preamble = buildContextPreamble(existingTags);
+  const userText = preamble + buildAnalysisUserText(images.length);
 
   const imageParts = images.map((img) => ({
     type: 'image' as const,
@@ -175,7 +183,7 @@ export async function analyzeImages(
     const result = await generateObject({
       model,
       schema: AiSuggestionsSchema,
-      system: buildSystemPrompt(existingTags, customPrompt, undefined, isDemoUser),
+      system: buildSystemPrompt(customPrompt, isDemoUser),
       messages: [{
         role: 'user' as const,
         content: [...imageParts, { type: 'text' as const, text: userText }],
@@ -216,13 +224,14 @@ export async function reanalyzeImages(
     mimeType: img.mimeType,
   }));
 
-  const userContent = buildReanalysisUserContent(previousResult, imageParts);
+  const preamble = buildContextPreamble(existingTags, customFieldDefs);
+  const userContent = buildReanalysisUserContent(previousResult, imageParts, preamble);
 
   try {
     const result = await generateObject({
       model,
       schema: AiSuggestionsSchema,
-      system: buildReanalysisPrompt(existingTags, customFieldDefs),
+      system: buildReanalysisPrompt(),
       messages: [{
         role: 'user' as const,
         content: userContent,
@@ -239,4 +248,3 @@ export async function reanalyzeImages(
     throw mapSdkError(err);
   }
 }
-

--- a/server/src/lib/aiStream.ts
+++ b/server/src/lib/aiStream.ts
@@ -29,23 +29,16 @@ export function initSseResponse(res: Response): (data: object) => void {
 }
 
 /**
- * Stream AI output as SSE to an Express response.
+ * Core streaming logic: stream AI output to an event writer.
  *
- * When `opts.schema` is provided, uses Output.object() to constrain the model
- * to valid JSON matching the given Zod schema.
- *
- * Protocol: each SSE `data:` event carries one of:
- *   { type: 'delta', text: string }   — incremental text chunk
- *   { type: 'done', text: string }    — full accumulated text on finish
- *   { type: 'error', message: string, code: string } — error event
+ * Returns the final cleaned text on success, or null on error/truncation.
+ * The caller is responsible for sending `done`/managing the SSE lifecycle.
  */
-export async function pipeAiStreamToResponse(
-  res: Response,
+export async function streamAiToWriter(
+  writeEvent: (data: object) => void,
   model: LanguageModel,
-  opts: StreamOptions
-): Promise<void> {
-  const writeEvent = initSseResponse(res);
-
+  opts: StreamOptions,
+): Promise<string | null> {
   try {
     const streamResult = streamText({
       model,
@@ -65,8 +58,6 @@ export async function pipeAiStreamToResponse(
     let finalText = await streamResult.text;
 
     // When structured output is requested, prefer the validated output object.
-    // The text stream may be truncated (e.g. max tokens reached) while the
-    // SDK's output channel still provides the complete, validated object.
     if (opts.schema) {
       try {
         const output = await streamResult.output;
@@ -76,17 +67,22 @@ export async function pipeAiStreamToResponse(
       }
     }
 
-    // Guard against truncated JSON (e.g. model hit max tokens)
+    // Guard against truncated JSON
     if (finalText.trim()) {
+      let cleaned = finalText.trim();
+      const fenced = cleaned.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
+      if (fenced) cleaned = fenced[1].trim();
+
       try {
-        JSON.parse(finalText);
+        JSON.parse(cleaned);
+        finalText = cleaned;
       } catch {
         writeEvent({ type: 'error', message: 'AI response was cut short — try a shorter query or increase max tokens', code: 'TRUNCATED_RESPONSE' });
-        return;
+        return null;
       }
     }
 
-    writeEvent({ type: 'done', text: finalText });
+    return finalText;
   } catch (err) {
     const mapped = mapSdkError(err);
     const safeMessage = toSafeAiMessage(mapped) || 'Provider error — check server logs';
@@ -95,6 +91,31 @@ export async function pipeAiStreamToResponse(
       log.error('Stream error:', safeErr);
     }
     writeEvent({ type: 'error', message: safeMessage, code: mapped.code });
+    return null;
+  }
+}
+
+/**
+ * Stream AI output as SSE to an Express response.
+ *
+ * Convenience wrapper around streamAiToWriter that manages the full SSE
+ * lifecycle (headers, done event, res.end).
+ *
+ * Protocol: each SSE `data:` event carries one of:
+ *   { type: 'delta', text: string }   — incremental text chunk
+ *   { type: 'done', text: string }    — full accumulated text on finish
+ *   { type: 'error', message: string, code: string } — error event
+ */
+export async function pipeAiStreamToResponse(
+  res: Response,
+  model: LanguageModel,
+  opts: StreamOptions
+): Promise<string | null> {
+  const writeEvent = initSseResponse(res);
+  try {
+    const result = await streamAiToWriter(writeEvent, model, opts);
+    if (result) writeEvent({ type: 'done', text: result });
+    return result;
   } finally {
     res.end();
   }

--- a/server/src/lib/commandParser.ts
+++ b/server/src/lib/commandParser.ts
@@ -1,10 +1,11 @@
+import { buildTagBlock } from './aiProviders.js';
 import { HARDENING_INSTRUCTION, resolvePrompt, sanitizeForPrompt } from './aiSanitize.js';
 import { DEFAULT_COMMAND_PROMPT } from './defaultPrompts.js';
 
 export interface BinSummary {
   id: string;
   name: string;
-  items: Array<{ id: string; name: string; quantity: number | null }>;
+  items: Array<{ id: string; name: string; quantity?: number } | string>;
   tags: string[];
   area_id: string | null;
   area_name: string;
@@ -48,6 +49,7 @@ export interface CommandRequest {
   text: string;
   context: {
     bins: BinSummary[];
+    other_bins?: Array<{ id: string; name: string }>;
     areas: AreaSummary[];
     trash_bins: Array<{ id: string; name: string }>;
     availableColors: string[];
@@ -60,14 +62,8 @@ export interface CommandResult {
   interpretation: string;
 }
 
-export function buildSystemPrompt(request: CommandRequest, customPrompt?: string, isDemoUser?: boolean): string {
+export function buildSystemPrompt(availableColors: string[], availableIcons: string[], customPrompt?: string, isDemoUser?: boolean): string {
   const basePrompt = resolvePrompt(DEFAULT_COMMAND_PROMPT, customPrompt, isDemoUser);
-
-  // Extract unique tags from bins already in context
-  const existingTags = [...new Set(request.context.bins.flatMap((b) => b.tags))].sort();
-  const tagBlock = existingTags.length > 0
-    ? `\nExisting tags in this inventory: [${existingTags.join(', ')}]\nWhen adding tags (add_tags, create_bin, update_bin), you MUST reuse tags from this list whenever they are even loosely relevant. Only create a new tag when no existing tag covers the category. Do NOT create synonyms or variations of existing tags.`
-    : '';
 
   return `${basePrompt}
 
@@ -94,25 +90,34 @@ Available action types:
 - set_tag_color: Set a tag's display color. Fields: tag, color
 - reorder_items: Reorder items in a bin. Fields: bin_id, bin_name, item_ids[] (item IDs in desired order)
 
-Available colors: ${request.context.availableColors.join(', ')}
-Available icons: ${request.context.availableIcons.join(', ')}
+Available colors: ${availableColors.join(', ')}
+Available icons: ${availableIcons.join(', ')}
 
 IMPORTANT RULES:
 1. Each action object MUST have a "type" field as a top-level property. All other fields are also top-level properties of the action object (NOT nested).
 2. The "interpretation" field is REQUIRED and must always be present.
 3. For create_bin: You MUST include "items" array when the user mentions any contents/items. You MUST include "area_name" when the user mentions a location/room/area. Do NOT put this information only in the interpretation — it must be in the action fields.
+4. Items in the context may appear as strings ("Item Name" or "Item Name (xN)") or objects with id/name/quantity. Match item names regardless of format.
+5. If a user references a bin that only appears in "other_bins" (id+name only), include it in your response. The system will retry with full details if needed.
 
 Example responses:
 {"actions":[{"type":"remove_items","bin_id":"abc","bin_name":"Tools","items":["Hammer"]},{"type":"add_items","bin_id":"def","bin_name":"Garage","items":["Hammer"]}],"interpretation":"Move hammer from Tools to Garage"}
-{"actions":[{"type":"create_bin","name":"Holiday Lights","area_name":"Garage","items":["LED string lights","Extension cord","Light clips"],"tags":["seasonal","holiday"]}],"interpretation":"Create a Holiday Lights bin in the Garage with 3 items."}${tagBlock}${HARDENING_INSTRUCTION}`;
+{"actions":[{"type":"create_bin","name":"Holiday Lights","area_name":"Garage","items":["LED string lights","Extension cord","Light clips"],"tags":["seasonal","holiday"]}],"interpretation":"Create a Holiday Lights bin in the Garage with 3 items."}${HARDENING_INSTRUCTION}`;
 }
 
 export function buildUserMessage(request: CommandRequest): string {
-  const { bins, areas, trash_bins } = request.context;
-  return `Command: ${sanitizeForPrompt(request.text)}
+  const { bins, other_bins, areas, trash_bins } = request.context;
+
+  const existingTags = [...new Set(bins.flatMap((b) => b.tags))].sort();
+  const tagBlock = buildTagBlock(existingTags);
+  const tagSection = tagBlock ? `\n${tagBlock}\n` : '';
+
+  const data: Record<string, unknown> = { bins, areas, trash_bins };
+  if (other_bins?.length) data.other_bins = other_bins;
+  return `Command: ${sanitizeForPrompt(request.text)}${tagSection}
 
 <user_data type="inventory" trust="none">
-${JSON.stringify({ bins, areas, trash_bins })}
+${JSON.stringify(data)}
 </user_data>`;
 }
 
@@ -120,9 +125,9 @@ ${JSON.stringify({ bins, areas, trash_bins })}
  * Build a unified system prompt that handles both commands AND queries.
  * The AI returns `{ actions, interpretation }` for commands or `{ answer, matches }` for queries.
  */
-export function buildUnifiedSystemPrompt(request: CommandRequest, customCommandPrompt?: string, customQueryPrompt?: string, isDemoUser?: boolean, isScoped?: boolean): string {
+export function buildUnifiedSystemPrompt(availableColors: string[], availableIcons: string[], customCommandPrompt?: string, customQueryPrompt?: string, isDemoUser?: boolean, isScoped?: boolean): string {
   // Build the command half (action types, rules, examples)
-  const commandPrompt = buildSystemPrompt(request, customCommandPrompt, isDemoUser);
+  const commandPrompt = buildSystemPrompt(availableColors, availableIcons, customCommandPrompt, isDemoUser);
 
   const defaultQueryBase = 'You are also an inventory search assistant. When the user asks a question (rather than giving a command), search through the inventory context and answer their question.';
   const queryBase = resolvePrompt(defaultQueryBase, customQueryPrompt, isDemoUser);

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -145,6 +145,22 @@ export const config = Object.freeze({
   aiModel: process.env.AI_MODEL || null,
   aiEndpointUrl: process.env.AI_ENDPOINT_URL || null,
 
+  // Per-task-group AI overrides (each field cascades independently to the default AI_* values)
+  aiVisionProvider: (process.env.AI_VISION_PROVIDER as AiProviderType) || null,
+  aiVisionApiKey: process.env.AI_VISION_API_KEY || null,
+  aiVisionModel: process.env.AI_VISION_MODEL || null,
+  aiVisionEndpointUrl: process.env.AI_VISION_ENDPOINT_URL || null,
+
+  aiQuickTextProvider: (process.env.AI_QUICK_TEXT_PROVIDER as AiProviderType) || null,
+  aiQuickTextApiKey: process.env.AI_QUICK_TEXT_API_KEY || null,
+  aiQuickTextModel: process.env.AI_QUICK_TEXT_MODEL || null,
+  aiQuickTextEndpointUrl: process.env.AI_QUICK_TEXT_ENDPOINT_URL || null,
+
+  aiDeepTextProvider: (process.env.AI_DEEP_TEXT_PROVIDER as AiProviderType) || null,
+  aiDeepTextApiKey: process.env.AI_DEEP_TEXT_API_KEY || null,
+  aiDeepTextModel: process.env.AI_DEEP_TEXT_MODEL || null,
+  aiDeepTextEndpointUrl: process.env.AI_DEEP_TEXT_ENDPOINT_URL || null,
+
   // Backup
   backupEnabled: parseBool(process.env.BACKUP_ENABLED, false),
   backupInterval: process.env.BACKUP_INTERVAL || 'daily',
@@ -223,6 +239,46 @@ export function getEnvAiConfig(): AiProviderConfig | null {
     model: config.aiModel!,
     endpointUrl: config.aiEndpointUrl,
   };
+}
+
+export type AiTaskGroup = 'vision' | 'quickText' | 'deepText';
+export const AI_TASK_GROUPS: AiTaskGroup[] = ['vision', 'quickText', 'deepText'];
+
+interface EnvGroupOverride {
+  provider: AiProviderType | null;
+  apiKey: string | null;
+  model: string | null;
+  endpointUrl: string | null;
+}
+
+const ENV_GROUP_MAP: Record<AiTaskGroup, EnvGroupOverride> = {
+  vision: {
+    provider: config.aiVisionProvider,
+    apiKey: config.aiVisionApiKey,
+    model: config.aiVisionModel,
+    endpointUrl: config.aiVisionEndpointUrl,
+  },
+  quickText: {
+    provider: config.aiQuickTextProvider,
+    apiKey: config.aiQuickTextApiKey,
+    model: config.aiQuickTextModel,
+    endpointUrl: config.aiQuickTextEndpointUrl,
+  },
+  deepText: {
+    provider: config.aiDeepTextProvider,
+    apiKey: config.aiDeepTextApiKey,
+    model: config.aiDeepTextModel,
+    endpointUrl: config.aiDeepTextEndpointUrl,
+  },
+};
+
+export function getEnvGroupOverride(group: AiTaskGroup): EnvGroupOverride {
+  return ENV_GROUP_MAP[group];
+}
+
+export function isGroupEnvLocked(group: AiTaskGroup): boolean {
+  const o = ENV_GROUP_MAP[group];
+  return !!(o.provider || o.apiKey || o.model || o.endpointUrl);
 }
 
 /** Returns true if the request user is in the DEMO_USERNAMES list. */

--- a/server/src/lib/intentClassifier.ts
+++ b/server/src/lib/intentClassifier.ts
@@ -1,0 +1,21 @@
+export type Intent = 'command' | 'query' | 'ambiguous';
+
+const QUERY_START =
+  /^(where|what|which|how many|do i have|is there|are there|any|find|search|show|list|tell me|count|does|can you find|can you show|can you list)/i;
+
+const COMMAND_START =
+  /^(add|remove|delete|create|move|rename|set|change|update|put|take|pin|unpin|duplicate|restore|reorder|tag|untag|clear|make|mark|assign|merge|split)/i;
+
+/** Classify user input as command or query using keyword heuristics. */
+export function classifyIntent(text: string): Intent {
+  const trimmed = text.trim();
+
+  // Strong query signals — questions
+  if (QUERY_START.test(trimmed)) return 'query';
+  if (/\?\s*$/.test(trimmed)) return 'query';
+
+  // Strong command signals — imperatives
+  if (COMMAND_START.test(trimmed)) return 'command';
+
+  return 'ambiguous';
+}

--- a/server/src/lib/inventoryQuery.ts
+++ b/server/src/lib/inventoryQuery.ts
@@ -29,6 +29,7 @@ export interface InventoryContext {
     photo_count: number;
     custom_fields?: Record<string, string>;
   }>;
+  other_bins?: Array<{ id: string; name: string }>;
   areas: Array<{ id: string; name: string }>;
   trash_bins: Array<{ id: string; name: string }>;
 }
@@ -42,10 +43,12 @@ IMPORTANT: The "answer" and "matches" fields are both REQUIRED. If no bins match
 }
 
 export function buildUserMessage(question: string, context: InventoryContext): string {
+  const { other_bins, ...rest } = context;
+  const data: Record<string, unknown> = { ...rest };
+  if (other_bins?.length) data.other_bins = other_bins;
   return `Question: ${sanitizeForPrompt(question)}
 
 <user_data type="inventory" trust="none">
-${JSON.stringify(context)}
+${JSON.stringify(data)}
 </user_data>`;
 }
-

--- a/server/src/lib/planGate.ts
+++ b/server/src/lib/planGate.ts
@@ -163,11 +163,60 @@ export function getFeatureMap(plan: PlanTier): PlanFeatures {
   };
 }
 
+export interface UserLimitOverrides {
+  maxBins: number | null;
+  maxLocations: number | null;
+  maxPhotoStorageMb: number | null;
+  maxMembersPerLocation: number | null;
+  activityRetentionDays: number | null;
+  aiCreditsPerMonth: number | null;
+  aiEnabled: boolean | null;
+}
+
+/** Fetch per-user limit overrides. Returns null if no overrides set. */
+export async function getUserLimitOverrides(userId: string): Promise<UserLimitOverrides | null> {
+  const result = await query<{
+    max_bins: number | null; max_locations: number | null;
+    max_photo_storage_mb: number | null; max_members_per_location: number | null;
+    activity_retention_days: number | null; ai_credits_per_month: number | null;
+    ai_enabled: number | null;
+  }>('SELECT max_bins, max_locations, max_photo_storage_mb, max_members_per_location, activity_retention_days, ai_credits_per_month, ai_enabled FROM user_limit_overrides WHERE user_id = $1', [userId]);
+  if (result.rows.length === 0) return null;
+  const r = result.rows[0];
+  return {
+    maxBins: r.max_bins,
+    maxLocations: r.max_locations,
+    maxPhotoStorageMb: r.max_photo_storage_mb,
+    maxMembersPerLocation: r.max_members_per_location,
+    activityRetentionDays: r.activity_retention_days,
+    aiCreditsPerMonth: r.ai_credits_per_month,
+    aiEnabled: r.ai_enabled === null ? null : r.ai_enabled === 1,
+  };
+}
+
+/** Merge plan features with per-user overrides. Override values take precedence. */
+function applyOverrides(features: PlanFeatures, overrides: UserLimitOverrides): PlanFeatures {
+  return {
+    ...features,
+    maxBins: overrides.maxBins ?? features.maxBins,
+    maxLocations: overrides.maxLocations ?? features.maxLocations,
+    maxPhotoStorageMb: overrides.maxPhotoStorageMb ?? features.maxPhotoStorageMb,
+    maxMembersPerLocation: overrides.maxMembersPerLocation ?? features.maxMembersPerLocation,
+    activityRetentionDays: overrides.activityRetentionDays ?? features.activityRetentionDays,
+    aiCreditsPerMonth: overrides.aiCreditsPerMonth ?? features.aiCreditsPerMonth,
+    ai: overrides.aiEnabled ?? features.ai,
+  };
+}
+
 export async function getUserFeatures(userId: string): Promise<PlanFeatures> {
   if (config.selfHosted) return getFeatureMap(Plan.PRO);
-  const planInfo = await getUserPlanInfo(userId);
+  const [planInfo, overrides] = await Promise.all([
+    getUserPlanInfo(userId),
+    getUserLimitOverrides(userId),
+  ]);
   if (!planInfo) return getFeatureMap(Plan.PRO);
-  return getFeatureMap(planInfo.plan);
+  const base = getFeatureMap(planInfo.plan);
+  return overrides ? applyOverrides(base, overrides) : base;
 }
 
 export async function getLocationOwnerFeatures(locationId: string): Promise<PlanFeatures> {

--- a/server/src/lib/planGate.ts
+++ b/server/src/lib/planGate.ts
@@ -315,6 +315,12 @@ export async function checkAndIncrementAiCredits(userId: string): Promise<AiCred
   return { allowed: true, used: ai_credits_used + 1, limit, resetsAt: ai_credits_reset_at };
 }
 
+/** Decrement ai_credits_used by 1 (floor 0). No-op on self-hosted or unlimited plans. */
+export async function refundAiCredit(userId: string): Promise<void> {
+  if (config.selfHosted) return;
+  await query('UPDATE users SET ai_credits_used = ai_credits_used - 1 WHERE id = $1 AND ai_credits_used > 0', [userId]);
+}
+
 export async function getAiCredits(userId: string): Promise<AiCreditInfo> {
   if (config.selfHosted) return { used: 0, limit: 0, resetsAt: null };
 

--- a/server/src/lib/taskRouting.ts
+++ b/server/src/lib/taskRouting.ts
@@ -11,6 +11,7 @@ export const TASK_GROUP_MAP: Record<string, AiTaskGroup> = {
   'analyze-image': 'vision',
   'command': 'quickText',
   'execute': 'quickText',
+  'structure': 'quickText',
   'structure-text': 'quickText',
   'query': 'deepText',
   'reorganization': 'deepText',

--- a/server/src/lib/taskRouting.ts
+++ b/server/src/lib/taskRouting.ts
@@ -1,0 +1,102 @@
+import { query } from '../db.js';
+import type { AiProviderConfig, AiProviderType } from './aiCaller.js';
+import { type AiTaskGroup, getEnvAiConfig, getEnvGroupOverride } from './config.js';
+import { decryptApiKey } from './crypto.js';
+
+export type { AiTaskGroup } from './config.js';
+
+/** Maps each AI route task key to its task group. */
+export const TASK_GROUP_MAP: Record<string, AiTaskGroup> = {
+  'analysis': 'vision',
+  'analyze-image': 'vision',
+  'command': 'quickText',
+  'execute': 'quickText',
+  'structure-text': 'quickText',
+  'query': 'deepText',
+  'reorganization': 'deepText',
+};
+
+/**
+ * Resolve the AI provider config for a specific task group.
+ *
+ * Resolution order per field (first non-null wins):
+ * 1. Env group override (AI_VISION_MODEL, etc.)
+ * 2. DB task override (user_ai_task_overrides row)
+ * 3. Env default (AI_MODEL, etc.)
+ * 4. DB user default (user_ai_settings active row)
+ */
+export async function resolveTaskConfig(
+  userId: string,
+  group: AiTaskGroup,
+): Promise<AiProviderConfig> {
+  // Layer 1: env group override
+  const envGroup = getEnvGroupOverride(group);
+
+  // Layer 2: DB task override
+  const dbOverride = await query(
+    'SELECT provider, api_key, model, endpoint_url FROM user_ai_task_overrides WHERE user_id = $1 AND task_group = $2',
+    [userId, group],
+  );
+  const dbRow = dbOverride.rows[0] ?? null;
+
+  // Layer 3: env default
+  const envDefault = getEnvAiConfig();
+
+  // Layer 4: DB user default (only fetch if needed)
+  interface DbAiRow { provider: string; api_key: string; model: string; endpoint_url: string | null }
+  let dbDefault: DbAiRow | null = null;
+
+  const needsDbDefault =
+    !(envGroup.provider && envGroup.apiKey && envGroup.model) &&
+    !(dbRow?.provider && dbRow?.api_key && dbRow?.model) &&
+    !envDefault;
+
+  if (needsDbDefault) {
+    const dbDefaultResult = await query<DbAiRow>(
+      'SELECT provider, api_key, model, endpoint_url FROM user_ai_settings WHERE user_id = $1 AND is_active = TRUE',
+      [userId],
+    );
+    dbDefault = dbDefaultResult.rows[0] ?? null;
+  }
+
+  // Resolve each field through the cascade
+  const provider =
+    envGroup.provider ??
+    dbRow?.provider ??
+    envDefault?.provider ??
+    dbDefault?.provider ??
+    null;
+
+  const apiKey =
+    envGroup.apiKey ??
+    (dbRow?.api_key ? decryptApiKey(dbRow.api_key) : null) ??
+    envDefault?.apiKey ??
+    (dbDefault?.api_key ? decryptApiKey(dbDefault.api_key) : null) ??
+    null;
+
+  const model =
+    envGroup.model ??
+    dbRow?.model ??
+    envDefault?.model ??
+    dbDefault?.model ??
+    null;
+
+  const endpointUrl =
+    envGroup.endpointUrl ??
+    dbRow?.endpoint_url ??
+    envDefault?.endpointUrl ??
+    dbDefault?.endpoint_url ??
+    null;
+
+  if (!provider || !apiKey || !model) {
+    const { NoAiSettingsError } = await import('./aiSettings.js');
+    throw new NoAiSettingsError();
+  }
+
+  return {
+    provider: provider as AiProviderType,
+    apiKey,
+    model,
+    endpointUrl: endpointUrl ?? null,
+  };
+}

--- a/server/src/lib/taskRouting.ts
+++ b/server/src/lib/taskRouting.ts
@@ -24,11 +24,12 @@ export const TASK_GROUP_MAP: Record<string, AiTaskGroup> = {
  * 1. Env group override (AI_VISION_MODEL, etc.)
  * 2. DB task override (user_ai_task_overrides row)
  * 3. Env default (AI_MODEL, etc.)
- * 4. DB user default (user_ai_settings active row)
+ * 4. DB user default — uses `fallbackConfig` when provided (avoids duplicate query)
  */
 export async function resolveTaskConfig(
   userId: string,
   group: AiTaskGroup,
+  fallbackConfig?: AiProviderConfig,
 ): Promise<AiProviderConfig> {
   // Layer 1: env group override
   const envGroup = getEnvGroupOverride(group);
@@ -43,21 +44,25 @@ export async function resolveTaskConfig(
   // Layer 3: env default
   const envDefault = getEnvAiConfig();
 
-  // Layer 4: DB user default (only fetch if needed)
-  interface DbAiRow { provider: string; api_key: string; model: string; endpoint_url: string | null }
-  let dbDefault: DbAiRow | null = null;
+  // Layer 4: DB user default — prefer caller-provided fallback to avoid re-querying
+  let layer4: AiProviderConfig | null = fallbackConfig ?? null;
 
-  const needsDbDefault =
-    !(envGroup.provider && envGroup.apiKey && envGroup.model) &&
-    !(dbRow?.provider && dbRow?.api_key && dbRow?.model) &&
-    !envDefault;
+  if (!layer4) {
+    const needsDbDefault =
+      !(envGroup.provider && envGroup.apiKey && envGroup.model) &&
+      !(dbRow?.provider && dbRow?.api_key && dbRow?.model) &&
+      !envDefault;
 
-  if (needsDbDefault) {
-    const dbDefaultResult = await query<DbAiRow>(
-      'SELECT provider, api_key, model, endpoint_url FROM user_ai_settings WHERE user_id = $1 AND is_active = TRUE',
-      [userId],
-    );
-    dbDefault = dbDefaultResult.rows[0] ?? null;
+    if (needsDbDefault) {
+      const dbDefaultResult = await query<{ provider: string; api_key: string; model: string; endpoint_url: string | null }>(
+        'SELECT provider, api_key, model, endpoint_url FROM user_ai_settings WHERE user_id = $1 AND is_active = TRUE',
+        [userId],
+      );
+      const row = dbDefaultResult.rows[0];
+      if (row) {
+        layer4 = { provider: row.provider as AiProviderType, apiKey: decryptApiKey(row.api_key), model: row.model, endpointUrl: row.endpoint_url };
+      }
+    }
   }
 
   // Resolve each field through the cascade
@@ -65,28 +70,28 @@ export async function resolveTaskConfig(
     envGroup.provider ??
     dbRow?.provider ??
     envDefault?.provider ??
-    dbDefault?.provider ??
+    layer4?.provider ??
     null;
 
   const apiKey =
     envGroup.apiKey ??
     (dbRow?.api_key ? decryptApiKey(dbRow.api_key) : null) ??
     envDefault?.apiKey ??
-    (dbDefault?.api_key ? decryptApiKey(dbDefault.api_key) : null) ??
+    layer4?.apiKey ??
     null;
 
   const model =
     envGroup.model ??
     dbRow?.model ??
     envDefault?.model ??
-    dbDefault?.model ??
+    layer4?.model ??
     null;
 
   const endpointUrl =
     envGroup.endpointUrl ??
     dbRow?.endpoint_url ??
     envDefault?.endpointUrl ??
-    dbDefault?.endpoint_url ??
+    layer4?.endpointUrl ??
     null;
 
   if (!provider || !apiKey || !model) {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -28,10 +28,17 @@ function extractToken(req: Request): string | undefined {
   return cookie;
 }
 
-async function verifyJwt(token: string): Promise<AuthUser | null> {
+interface JwtPayload {
+  id: string;
+  username: string;
+  tv?: number; // token_version
+}
+
+async function verifyJwt(token: string): Promise<(AuthUser & { tokenVersion: number }) | null> {
   try {
     const { payload } = await jose.jwtVerify(token, JWT_SECRET_KEY, { algorithms: ['HS256'] });
-    return { id: payload.id as string, username: payload.username as string };
+    const p = payload as unknown as JwtPayload;
+    return { id: p.id, username: p.username, tokenVersion: p.tv ?? 0 };
   } catch {
     return null;
   }
@@ -56,9 +63,9 @@ export function tryAuthenticate(req: Request, _res: Response, next: NextFunction
   next();
 }
 
-// Short-lived cache so soft-delete checks don't hit the DB on every request.
-// Soft-deletes are rare admin actions; 60 s staleness is acceptable.
-const deletedCache = new Map<string, { deleted: boolean; expires: number }>();
+// Short-lived cache so status checks don't hit the DB on every request.
+// Soft-deletes/suspensions are rare admin actions; 60 s staleness is acceptable.
+const deletedCache = new Map<string, { status: 'ok' | 'deleted' | 'suspended'; tokenVersion: number; expires: number }>();
 const DELETED_CACHE_TTL = 60_000;
 
 // Debounce last_active_at writes to once per 5 minutes per user
@@ -75,17 +82,34 @@ function maybeUpdateLastActive(userId: string): void {
   query(`UPDATE users SET last_active_at = ${d.now()} WHERE id = $1`, [userId]).catch(() => {});
 }
 
-function checkSoftDeleted(userId: string): Promise<boolean> {
-  const cached = deletedCache.get(userId);
-  if (cached && cached.expires > Date.now()) return Promise.resolve(cached.deleted);
+interface UserStatusRow {
+  deleted_at: string | null;
+  suspended_at: string | null;
+  token_version: number;
+}
 
-  return query<{ deleted_at: string | null }>(
-    'SELECT deleted_at FROM users WHERE id = $1',
+type UserStatus = 'ok' | 'deleted' | 'suspended';
+
+function checkUserStatus(userId: string): Promise<{ status: UserStatus; tokenVersion: number }> {
+  const cached = deletedCache.get(userId);
+  if (cached && cached.expires > Date.now()) return Promise.resolve(cached);
+
+  return query<UserStatusRow>(
+    'SELECT deleted_at, suspended_at, token_version FROM users WHERE id = $1',
     [userId],
   ).then((result) => {
-    const deleted = result.rows.length === 0 || result.rows[0].deleted_at !== null;
-    deletedCache.set(userId, { deleted, expires: Date.now() + DELETED_CACHE_TTL });
-    return deleted;
+    if (result.rows.length === 0) {
+      const entry = { status: 'deleted' as const, tokenVersion: 0, expires: Date.now() + DELETED_CACHE_TTL };
+      deletedCache.set(userId, entry);
+      return entry;
+    }
+    const row = result.rows[0];
+    let status: UserStatus = 'ok';
+    if (row.deleted_at !== null) status = 'deleted';
+    else if (row.suspended_at !== null) status = 'suspended';
+    const entry = { status, tokenVersion: row.token_version ?? 0, expires: Date.now() + DELETED_CACHE_TTL };
+    deletedCache.set(userId, entry);
+    return entry;
   });
 }
 
@@ -94,16 +118,31 @@ export function invalidateDeletedCache(userId: string): void {
   deletedCache.delete(userId);
 }
 
+function handleUserStatus(
+  res: Response,
+  status: 'ok' | 'deleted' | 'suspended',
+  req: Request,
+): boolean {
+  if (status === 'deleted') {
+    req.user = undefined;
+    req.authMethod = undefined;
+    res.status(401).json({ error: 'ACCOUNT_DELETED', message: 'This account has been deleted' });
+    return true;
+  }
+  if (status === 'suspended') {
+    req.user = undefined;
+    req.authMethod = undefined;
+    res.status(403).json({ error: 'ACCOUNT_SUSPENDED', message: 'This account has been suspended' });
+    return true;
+  }
+  return false;
+}
+
 export function authenticate(req: Request, res: Response, next: NextFunction): void {
   if (req.user) {
     const userId = req.user.id;
-    checkSoftDeleted(userId).then((deleted) => {
-      if (deleted) {
-        req.user = undefined;
-        req.authMethod = undefined;
-        res.status(401).json({ error: 'ACCOUNT_DELETED', message: 'This account has been deleted' });
-        return;
-      }
+    checkUserStatus(userId).then(({ status }) => {
+      if (handleUserStatus(res, status, req)) return;
       maybeUpdateLastActive(userId);
       next();
     }).catch(next);
@@ -120,7 +159,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
   if (token.startsWith('sk_openbin_')) {
     const keyHash = crypto.createHash('sha256').update(token).digest('hex');
     query(
-      `SELECT ak.id AS key_id, u.id, u.username, u.deleted_at, u.plan
+      `SELECT ak.id AS key_id, u.id, u.username, u.deleted_at, u.suspended_at, u.plan
        FROM api_keys ak
        JOIN users u ON u.id = ak.user_id
        WHERE ak.key_hash = $1 AND ak.revoked_at IS NULL`,
@@ -130,9 +169,13 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
         res.status(401).json({ error: 'UNAUTHORIZED', message: 'Invalid API key' });
         return;
       }
-      const row = result.rows[0] as { key_id: string; id: string; username: string; deleted_at: string | null; plan: number };
+      const row = result.rows[0] as { key_id: string; id: string; username: string; deleted_at: string | null; suspended_at: string | null; plan: number };
       if (row.deleted_at) {
         res.status(401).json({ error: 'ACCOUNT_DELETED', message: 'This account has been deleted' });
+        return;
+      }
+      if (row.suspended_at) {
+        res.status(403).json({ error: 'ACCOUNT_SUSPENDED', message: 'This account has been suspended' });
         return;
       }
       if (!config.selfHosted && row.plan === 0) {
@@ -156,12 +199,14 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
   // JWT path
   verifyJwt(token).then((user) => {
     if (user) {
-      checkSoftDeleted(user.id).then((deleted) => {
-        if (deleted) {
-          res.status(401).json({ error: 'ACCOUNT_DELETED', message: 'This account has been deleted' });
+      checkUserStatus(user.id).then(({ status, tokenVersion }) => {
+        if (handleUserStatus(res, status, req)) return;
+        // Check token_version — if the token was issued before a revocation, reject it
+        if (user.tokenVersion < tokenVersion) {
+          res.status(401).json({ error: 'SESSION_REVOKED', message: 'Session has been revoked. Please log in again.' });
           return;
         }
-        req.user = user;
+        req.user = { id: user.id, username: user.username };
         req.authMethod = 'jwt';
         maybeUpdateLastActive(user.id);
         next();
@@ -172,9 +217,14 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
   });
 }
 
-export async function signToken(user: AuthUser): Promise<string> {
-  return new jose.SignJWT({ id: user.id, username: user.username })
+export async function signToken(user: AuthUser, tokenVersion = 0): Promise<string> {
+  return new jose.SignJWT({ id: user.id, username: user.username, tv: tokenVersion })
     .setProtectedHeader({ alg: 'HS256' })
     .setExpirationTime(config.accessTokenExpiresIn)
     .sign(JWT_SECRET_KEY);
+}
+
+/** Invalidate the user status cache (call after suspension, deletion, or token_version bump). */
+export function invalidateUserStatusCache(userId: string): void {
+  deletedCache.delete(userId);
 }

--- a/server/src/middleware/maintenance.ts
+++ b/server/src/middleware/maintenance.ts
@@ -1,0 +1,80 @@
+import type { NextFunction, Request, Response } from 'express';
+import { query } from '../db.js';
+
+let maintenanceMode = false;
+let maintenanceMessage = 'System is undergoing maintenance. Please try again later.';
+
+/** Check if maintenance mode is active (cached in-memory). */
+export function isMaintenanceMode(): boolean {
+  return maintenanceMode;
+}
+
+export function getMaintenanceMessage(): string {
+  return maintenanceMessage;
+}
+
+/** Set maintenance mode. Called by admin system routes. */
+export function setMaintenanceMode(enabled: boolean, message?: string): void {
+  maintenanceMode = enabled;
+  if (message) maintenanceMessage = message;
+}
+
+/** Load maintenance mode state from DB on startup. */
+export async function loadMaintenanceMode(): Promise<void> {
+  try {
+    const result = await query<{ value: string }>("SELECT value FROM settings WHERE key = 'maintenance_mode'");
+    if (result.rows.length > 0) {
+      const data = JSON.parse(result.rows[0].value);
+      maintenanceMode = data.enabled === true;
+      if (data.message) maintenanceMessage = data.message;
+    }
+  } catch {
+    // ignore — settings table may not exist yet
+  }
+}
+
+/**
+ * Express middleware that returns 503 for non-admin requests when maintenance mode is on.
+ * Admin routes (/api/admin/*) and auth status are always allowed through.
+ */
+export function maintenanceGate(req: Request, res: Response, next: NextFunction): void {
+  if (!maintenanceMode) {
+    next();
+    return;
+  }
+
+  // Always allow: admin routes, auth status, health check
+  const path = req.path;
+  if (path.startsWith('/api/admin') || path === '/api/auth/status' || path === '/api/health') {
+    next();
+    return;
+  }
+
+  // Allow admins through (if already authenticated via tryAuthenticate)
+  if (req.user) {
+    // Quick check — the requireAdmin middleware does a DB lookup,
+    // but here we just trust tryAuthenticate + a lightweight check.
+    // Admin users are rare, so we do a fast query.
+    query<{ is_admin: number | boolean }>('SELECT is_admin FROM users WHERE id = $1', [req.user.id])
+      .then((result) => {
+        const isAdmin = result.rows[0]?.is_admin;
+        if (isAdmin === 1 || isAdmin === true) {
+          next();
+        } else {
+          res.status(503).json({
+            error: 'MAINTENANCE',
+            message: maintenanceMessage,
+          });
+        }
+      })
+      .catch(() => {
+        res.status(503).json({ error: 'MAINTENANCE', message: maintenanceMessage });
+      });
+    return;
+  }
+
+  res.status(503).json({
+    error: 'MAINTENANCE',
+    message: maintenanceMessage,
+  });
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcrypt';
 import { Router } from 'express';
 import multer from 'multer';
 import { d, generateUuid, isUniqueViolation, query } from '../db.js';
+import { getAdminCount } from '../lib/adminHelpers.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
 import { runBackup } from '../lib/backup.js';
 import { config } from '../lib/config.js';
@@ -23,11 +24,6 @@ import { requireAdmin } from '../middleware/requireAdmin.js';
 
 const log = createLogger('admin');
 const router = Router();
-
-async function getAdminCount(): Promise<number> {
-  const result = await query<{ cnt: number }>('SELECT COUNT(*) as cnt FROM users WHERE is_admin = TRUE');
-  return result.rows[0].cnt;
-}
 
 // All admin routes require authentication + admin role
 router.use(authenticate, requireAdmin);
@@ -81,7 +77,7 @@ router.get('/users', asyncHandler(async (req, res) => {
 
   const usersResult = await query(
     `SELECT u.id, u.username, u.display_name, u.email, u.is_admin, u.plan, u.sub_status,
-       u.active_until, u.deleted_at, u.created_at, u.last_active_at,
+       u.active_until, u.deleted_at, u.suspended_at, u.created_at, u.last_active_at,
        u.ai_credits_used, u.ai_credits_reset_at,
        (SELECT COUNT(*) FROM bins b JOIN location_members lm ON b.location_id = lm.location_id WHERE lm.user_id = u.id AND b.deleted_at IS NULL) AS bin_count,
        (SELECT COUNT(DISTINCT lm.location_id) FROM location_members lm WHERE lm.user_id = u.id) AS location_count,
@@ -110,6 +106,7 @@ router.get('/users', asyncHandler(async (req, res) => {
       status: subStatusLabel(u.sub_status),
       activeUntil: u.active_until || null,
       deletedAt: u.deleted_at || null,
+      suspendedAt: u.suspended_at || null,
       createdAt: u.created_at,
       binCount: u.bin_count ?? 0,
       locationCount: u.location_count ?? 0,
@@ -195,10 +192,11 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
   const userResult = await query<{
     id: string; username: string; display_name: string; email: string | null;
     is_admin: number; plan: PlanTier; sub_status: SubStatusType;
-    active_until: string | null; deleted_at: string | null; created_at: string; updated_at: string;
+    active_until: string | null; deleted_at: string | null; suspended_at: string | null;
+    created_at: string; updated_at: string;
     last_active_at: string | null; ai_credits_used: number | null; ai_credits_reset_at: string | null;
   }>(
-    'SELECT id, username, display_name, email, is_admin, plan, sub_status, active_until, deleted_at, created_at, updated_at, last_active_at, ai_credits_used, ai_credits_reset_at FROM users WHERE id = $1',
+    'SELECT id, username, display_name, email, is_admin, plan, sub_status, active_until, deleted_at, suspended_at, created_at, updated_at, last_active_at, ai_credits_used, ai_credits_reset_at FROM users WHERE id = $1',
     [userId],
   );
 
@@ -230,6 +228,7 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
     status: subStatusLabel(row.sub_status),
     activeUntil: row.active_until || null,
     deletedAt: row.deleted_at || null,
+    suspendedAt: row.suspended_at || null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     lastActiveAt: row.last_active_at || null,

--- a/server/src/routes/adminOverrides.ts
+++ b/server/src/routes/adminOverrides.ts
@@ -1,0 +1,344 @@
+import { Router } from 'express';
+import { d, generateUuid, query } from '../db.js';
+import { logAdminAction } from '../lib/adminAudit.js';
+import { assertUserExists } from '../lib/adminHelpers.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+import { NotFoundError, ValidationError } from '../lib/httpErrors.js';
+import { getFeatureMap, invalidateOverLimitCache, Plan, type PlanTier, planLabel, SubStatus } from '../lib/planGate.js';
+import { authenticate } from '../middleware/auth.js';
+import { requireAdmin } from '../middleware/requireAdmin.js';
+
+const router = Router();
+router.use(authenticate, requireAdmin);
+
+// ---------------------------------------------------------------------------
+// GET /overrides/:userId — current overrides for a user
+// ---------------------------------------------------------------------------
+
+router.get('/overrides/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  await assertUserExists(userId);
+
+  const result = await query<{
+    max_bins: number | null;
+    max_locations: number | null;
+    max_photo_storage_mb: number | null;
+    max_members_per_location: number | null;
+    activity_retention_days: number | null;
+    ai_credits_per_month: number | null;
+    ai_enabled: number | null;
+  }>(
+    'SELECT max_bins, max_locations, max_photo_storage_mb, max_members_per_location, activity_retention_days, ai_credits_per_month, ai_enabled FROM user_limit_overrides WHERE user_id = $1',
+    [userId],
+  );
+
+  const row = result.rows[0];
+  res.json({
+    userId,
+    maxBins: row?.max_bins ?? null,
+    maxLocations: row?.max_locations ?? null,
+    maxPhotoStorageMb: row?.max_photo_storage_mb ?? null,
+    maxMembersPerLocation: row?.max_members_per_location ?? null,
+    activityRetentionDays: row?.activity_retention_days ?? null,
+    aiCreditsPerMonth: row?.ai_credits_per_month ?? null,
+    aiEnabled: row ? (row.ai_enabled === null ? null : row.ai_enabled === 1) : null,
+  });
+}));
+
+// ---------------------------------------------------------------------------
+// PUT /overrides/:userId — set / update overrides
+// ---------------------------------------------------------------------------
+
+router.put('/overrides/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const target = await assertUserExists(userId);
+
+  const { maxBins, maxLocations, maxPhotoStorageMb, maxMembersPerLocation, activityRetentionDays, aiCreditsPerMonth, aiEnabled } = req.body;
+
+  const id = generateUuid();
+  const aiEnabledInt = aiEnabled == null ? null : aiEnabled ? 1 : 0;
+
+  await query(
+    `INSERT INTO user_limit_overrides (id, user_id, max_bins, max_locations, max_photo_storage_mb, max_members_per_location, activity_retention_days, ai_credits_per_month, ai_enabled)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT(user_id) DO UPDATE SET
+       max_bins = $3,
+       max_locations = $4,
+       max_photo_storage_mb = $5,
+       max_members_per_location = $6,
+       activity_retention_days = $7,
+       ai_credits_per_month = $8,
+       ai_enabled = $9,
+       updated_at = ${d.now()}`,
+    [
+      id,
+      userId,
+      maxBins ?? null,
+      maxLocations ?? null,
+      maxPhotoStorageMb ?? null,
+      maxMembersPerLocation ?? null,
+      activityRetentionDays ?? null,
+      aiCreditsPerMonth ?? null,
+      aiEnabledInt,
+    ],
+  );
+
+  invalidateOverLimitCache(userId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'update_overrides',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+    details: { maxBins, maxLocations, maxPhotoStorageMb, maxMembersPerLocation, activityRetentionDays, aiCreditsPerMonth, aiEnabled },
+  });
+
+  res.json({ message: 'Overrides updated' });
+}));
+
+// ---------------------------------------------------------------------------
+// DELETE /overrides/:userId — clear all overrides
+// ---------------------------------------------------------------------------
+
+router.delete('/overrides/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const target = await assertUserExists(userId);
+
+  await query('DELETE FROM user_limit_overrides WHERE user_id = $1', [userId]);
+
+  invalidateOverLimitCache(userId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'clear_overrides',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+  });
+
+  res.json({ message: 'Overrides cleared' });
+}));
+
+// ---------------------------------------------------------------------------
+// POST /ai-credits/grant/:userId — grant additional AI credits
+// ---------------------------------------------------------------------------
+
+router.post('/ai-credits/grant/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const target = await assertUserExists(userId);
+
+  const { amount } = req.body;
+  if (typeof amount !== 'number' || !Number.isInteger(amount) || amount < 1 || amount > 10000) {
+    throw new ValidationError('amount must be a positive integer (max 10000)');
+  }
+
+  await query(
+    'UPDATE users SET ai_credits_used = CASE WHEN ai_credits_used > $1 THEN ai_credits_used - $1 ELSE 0 END WHERE id = $2',
+    [amount, userId],
+  );
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'grant_ai_credits',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+    details: { amount },
+  });
+
+  res.json({ message: 'AI credits granted' });
+}));
+
+// ---------------------------------------------------------------------------
+// POST /ai-credits/reset/:userId — reset AI credits to 0
+// ---------------------------------------------------------------------------
+
+router.post('/ai-credits/reset/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const target = await assertUserExists(userId);
+
+  const nextReset = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  await query(
+    'UPDATE users SET ai_credits_used = 0, ai_credits_reset_at = $1 WHERE id = $2',
+    [nextReset, userId],
+  );
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'reset_ai_credits',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+  });
+
+  res.json({ message: 'AI credits reset' });
+}));
+
+// ---------------------------------------------------------------------------
+// POST /extend-trial/:userId — extend a user's trial period
+// ---------------------------------------------------------------------------
+
+router.post('/extend-trial/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+
+  const { days } = req.body;
+  if (typeof days !== 'number' || !Number.isInteger(days) || days < 1 || days > 90) {
+    throw new ValidationError('days must be an integer between 1 and 90');
+  }
+
+  const userResult = await query<{ id: string; username: string; sub_status: number; active_until: string | null }>(
+    'SELECT id, username, sub_status, active_until FROM users WHERE id = $1',
+    [userId],
+  );
+  const target = userResult.rows[0];
+  if (!target) throw new NotFoundError('User not found');
+
+  if (target.sub_status !== SubStatus.TRIAL) {
+    throw new ValidationError('User is not currently on trial');
+  }
+
+  const now = new Date();
+  const base = target.active_until && new Date(target.active_until) > now
+    ? new Date(target.active_until)
+    : now;
+  const newActiveUntil = new Date(base.getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  await query(
+    `UPDATE users SET active_until = $1, updated_at = ${d.now()} WHERE id = $2`,
+    [newActiveUntil, userId],
+  );
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'extend_trial',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+    details: { days, newActiveUntil },
+  });
+
+  res.json({ message: 'Trial extended', activeUntil: newActiveUntil });
+}));
+
+// ---------------------------------------------------------------------------
+// POST /grant-comp/:userId — grant a complimentary plan
+// ---------------------------------------------------------------------------
+
+router.post('/grant-comp/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const target = await assertUserExists(userId);
+
+  const { plan, days } = req.body;
+  if (plan !== Plan.FREE && plan !== Plan.PLUS && plan !== Plan.PRO) {
+    throw new ValidationError('plan must be 0 (plus), 1 (pro), or 2 (free)');
+  }
+  if (typeof days !== 'number' || !Number.isInteger(days) || days < 1 || days > 365) {
+    throw new ValidationError('days must be an integer between 1 and 365');
+  }
+
+  const activeUntil = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  await query(
+    `UPDATE users SET plan = $1, sub_status = $2, active_until = $3, updated_at = ${d.now()} WHERE id = $4`,
+    [plan, SubStatus.ACTIVE, activeUntil, userId],
+  );
+
+  invalidateOverLimitCache(userId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'grant_comp_plan',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+    details: { plan: planLabel(plan as PlanTier), days, activeUntil },
+  });
+
+  res.json({ message: 'Comp plan granted', activeUntil });
+}));
+
+// ---------------------------------------------------------------------------
+// POST /force-downgrade/:userId — force downgrade with cache invalidation
+// ---------------------------------------------------------------------------
+
+router.post('/force-downgrade/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  const target = await assertUserExists(userId);
+
+  const { plan } = req.body;
+  if (plan !== Plan.FREE && plan !== Plan.PLUS && plan !== Plan.PRO) {
+    throw new ValidationError('plan must be 0 (plus), 1 (pro), or 2 (free)');
+  }
+
+  const oldResult = await query<{ plan: number }>(
+    'SELECT plan FROM users WHERE id = $1',
+    [userId],
+  );
+  const oldPlan = oldResult.rows[0].plan as PlanTier;
+
+  await query(
+    `UPDATE users SET plan = $1, updated_at = ${d.now()} WHERE id = $2`,
+    [plan, userId],
+  );
+
+  invalidateOverLimitCache(userId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'force_downgrade',
+    targetType: 'user',
+    targetId: userId,
+    targetName: target.username,
+    details: { from: planLabel(oldPlan), to: planLabel(plan as PlanTier) },
+  });
+
+  res.json({ message: 'Plan downgraded' });
+}));
+
+// ---------------------------------------------------------------------------
+// GET /ai-usage/:userId — AI usage report
+// ---------------------------------------------------------------------------
+
+router.get('/ai-usage/:userId', asyncHandler(async (req, res) => {
+  const { userId } = req.params;
+  await assertUserExists(userId);
+
+  const userResult = await query<{
+    ai_credits_used: number;
+    ai_credits_reset_at: string | null;
+    plan: number;
+    sub_status: number;
+  }>(
+    'SELECT ai_credits_used, ai_credits_reset_at, plan, sub_status FROM users WHERE id = $1',
+    [userId],
+  );
+  const user = userResult.rows[0];
+  const features = getFeatureMap(user.plan as PlanTier);
+
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+
+  const usageResult = await query<{ date: string; call_count: number }>(
+    'SELECT date, call_count FROM ai_usage WHERE user_id = $1 AND date >= $2 ORDER BY date DESC',
+    [userId, thirtyDaysAgo],
+  );
+
+  res.json({
+    creditsUsed: user.ai_credits_used ?? 0,
+    creditsLimit: features.aiCreditsPerMonth ?? 0,
+    resetsAt: user.ai_credits_reset_at ?? null,
+    dailyUsage: usageResult.rows.map((r) => ({ date: r.date, calls: r.call_count })),
+  });
+}));
+
+export { router as adminOverridesRoutes };

--- a/server/src/routes/adminSecurity.ts
+++ b/server/src/routes/adminSecurity.ts
@@ -1,0 +1,180 @@
+import { Router } from 'express';
+import { d, query } from '../db.js';
+import { logAdminAction } from '../lib/adminAudit.js';
+import { assertUserExists, getAdminCount } from '../lib/adminHelpers.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+import { ForbiddenError, NotFoundError, ValidationError } from '../lib/httpErrors.js';
+import { authenticate, invalidateUserStatusCache } from '../middleware/auth.js';
+import { requireAdmin } from '../middleware/requireAdmin.js';
+
+const router = Router();
+router.use(authenticate, requireAdmin);
+
+// POST /suspend/:id
+router.post('/suspend/:id', asyncHandler(async (req, res) => {
+  const targetId = req.params.id;
+  const { reason } = req.body;
+
+  if (targetId === req.user!.id) {
+    throw new ForbiddenError('Cannot suspend yourself');
+  }
+
+  const targetResult = await query<{ id: string; username: string; is_admin: number; suspended_at: string | null }>(
+    'SELECT id, username, is_admin, suspended_at FROM users WHERE id = $1',
+    [targetId],
+  );
+  const target = targetResult.rows[0];
+  if (!target) throw new NotFoundError('User not found');
+
+  if (target.is_admin && (await getAdminCount()) <= 1) {
+    throw new ForbiddenError('Cannot suspend the only admin');
+  }
+
+  await query(
+    `UPDATE users SET suspended_at = ${d.now()}, token_version = token_version + 1 WHERE id = $1`,
+    [targetId],
+  );
+
+  invalidateUserStatusCache(targetId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'suspend_user',
+    targetType: 'user',
+    targetId,
+    targetName: target.username,
+    details: { reason: reason || null },
+  });
+
+  res.json({ message: 'User suspended' });
+}));
+
+// POST /reactivate/:id
+router.post('/reactivate/:id', asyncHandler(async (req, res) => {
+  const targetId = req.params.id;
+
+  const targetResult = await query<{ id: string; username: string; suspended_at: string | null }>(
+    'SELECT id, username, suspended_at FROM users WHERE id = $1',
+    [targetId],
+  );
+  const target = targetResult.rows[0];
+  if (!target) throw new NotFoundError('User not found');
+
+  if (!target.suspended_at) {
+    throw new ValidationError('User is not suspended');
+  }
+
+  await query(
+    'UPDATE users SET suspended_at = NULL WHERE id = $1',
+    [targetId],
+  );
+
+  invalidateUserStatusCache(targetId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'reactivate_user',
+    targetType: 'user',
+    targetId,
+    targetName: target.username,
+  });
+
+  res.json({ message: 'User reactivated' });
+}));
+
+// POST /revoke-sessions/:id
+router.post('/revoke-sessions/:id', asyncHandler(async (req, res) => {
+  const targetId = req.params.id;
+  const target = await assertUserExists(targetId);
+
+  await Promise.all([
+    query(
+      'UPDATE users SET token_version = token_version + 1 WHERE id = $1',
+      [targetId],
+    ),
+    query(
+      `UPDATE refresh_tokens SET revoked_at = ${d.now()} WHERE user_id = $1 AND revoked_at IS NULL`,
+      [targetId],
+    ),
+  ]);
+
+  invalidateUserStatusCache(targetId);
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'revoke_sessions',
+    targetType: 'user',
+    targetId,
+    targetName: target.username,
+  });
+
+  res.json({ message: 'All sessions revoked' });
+}));
+
+// POST /revoke-all-api-keys/:id
+router.post('/revoke-all-api-keys/:id', asyncHandler(async (req, res) => {
+  const targetId = req.params.id;
+  const target = await assertUserExists(targetId);
+
+  const result = await query(
+    `UPDATE api_keys SET revoked_at = ${d.now()} WHERE user_id = $1 AND revoked_at IS NULL`,
+    [targetId],
+  );
+  const revokedCount = result.rowCount ?? 0;
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'revoke_all_api_keys',
+    targetType: 'user',
+    targetId,
+    targetName: target.username,
+    details: { count: revokedCount },
+  });
+
+  res.json({ message: 'All API keys revoked', count: revokedCount });
+}));
+
+// GET /login-history/:id
+router.get('/login-history/:id', asyncHandler(async (req, res) => {
+  const targetId = req.params.id;
+  const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+  const limit = Math.min(200, Math.max(1, parseInt(req.query.limit as string, 10) || 50));
+  const offset = (page - 1) * limit;
+
+  await assertUserExists(targetId);
+
+  const [countResult, dataResult] = await Promise.all([
+    query<{ cnt: number }>(
+      'SELECT COUNT(*) as cnt FROM login_history WHERE user_id = $1',
+      [targetId],
+    ),
+    query<{
+      id: string;
+      ip_address: string | null;
+      user_agent: string | null;
+      method: string | null;
+      success: number;
+      created_at: string;
+    }>(
+      'SELECT id, ip_address, user_agent, method, success, created_at FROM login_history WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
+      [targetId, limit, offset],
+    ),
+  ]);
+
+  const results = dataResult.rows.map((row) => ({
+    id: row.id,
+    ipAddress: row.ip_address,
+    userAgent: row.user_agent,
+    method: row.method,
+    success: !!row.success,
+    createdAt: row.created_at,
+  }));
+
+  res.json({ results, count: countResult.rows[0].cnt });
+}));
+
+export { router as adminSecurityRoutes };

--- a/server/src/routes/adminSystem.ts
+++ b/server/src/routes/adminSystem.ts
@@ -1,0 +1,553 @@
+import { Router } from 'express';
+import { getDialect } from '../db/dialect.js';
+import { generateUuid, query } from '../db.js';
+import { logAdminAction } from '../lib/adminAudit.js';
+import { isValidRole } from '../lib/adminHelpers.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+import { NotFoundError, ValidationError } from '../lib/httpErrors.js';
+import { authenticate } from '../middleware/auth.js';
+import { setMaintenanceMode } from '../middleware/maintenance.js';
+import { requireAdmin } from '../middleware/requireAdmin.js';
+
+const router = Router();
+router.use(authenticate, requireAdmin);
+
+// ---------------------------------------------------------------------------
+// MAINTENANCE MODE
+// ---------------------------------------------------------------------------
+
+// GET /maintenance
+router.get('/maintenance', asyncHandler(async (_req, res) => {
+  const result = await query<{ value: string }>(
+    "SELECT value FROM settings WHERE key = 'maintenance_mode'",
+  );
+
+  if (!result.rows[0]) {
+    res.json({ enabled: false, message: '' });
+    return;
+  }
+
+  const data = JSON.parse(result.rows[0].value) as { enabled: boolean; message?: string };
+  res.json({ enabled: !!data.enabled, message: data.message ?? '' });
+}));
+
+// POST /maintenance
+router.post('/maintenance', asyncHandler(async (req, res) => {
+  const { enabled, message } = req.body;
+
+  if (typeof enabled !== 'boolean') {
+    throw new ValidationError('enabled must be a boolean');
+  }
+
+  const payload = JSON.stringify({ enabled, message: message ?? '' });
+
+  await query(
+    "INSERT INTO settings (key, value) VALUES ('maintenance_mode', $1) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    [payload],
+  );
+
+  setMaintenanceMode(enabled, message ?? '');
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'toggle_maintenance',
+    targetType: 'system',
+    details: { enabled, message: message ?? '' },
+  });
+
+  res.json({ enabled, message: message ?? '' });
+}));
+
+// ---------------------------------------------------------------------------
+// ANNOUNCEMENTS
+// ---------------------------------------------------------------------------
+
+// GET /announcements
+router.get('/announcements', asyncHandler(async (_req, res) => {
+  const result = await query<{
+    id: string; text: string; type: string; dismissible: number | boolean;
+    active: number | boolean; expires_at: string | null; created_by: string | null;
+    created_at: string;
+  }>('SELECT * FROM announcements ORDER BY created_at DESC');
+
+  const results = result.rows.map((row) => ({
+    id: row.id,
+    text: row.text,
+    type: row.type,
+    dismissible: !!row.dismissible,
+    active: !!row.active,
+    expiresAt: row.expires_at ?? null,
+    createdBy: row.created_by ?? null,
+    createdAt: row.created_at,
+  }));
+
+  res.json({ results, count: results.length });
+}));
+
+// POST /announcements
+router.post('/announcements', asyncHandler(async (req, res) => {
+  const { text, type, dismissible, expiresAt } = req.body;
+
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    throw new ValidationError('text is required');
+  }
+
+  const announcementType = type ?? 'info';
+  if (!['info', 'warning', 'critical'].includes(announcementType)) {
+    throw new ValidationError('type must be one of: info, warning, critical');
+  }
+
+  const isDismissible = dismissible !== undefined ? !!dismissible : true;
+
+  // Deactivate all existing active announcements
+  await query('UPDATE announcements SET active = $1', [false]);
+
+  const id = generateUuid();
+
+  await query(
+    `INSERT INTO announcements (id, text, type, dismissible, active, expires_at, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      id,
+      text.trim(),
+      announcementType,
+      isDismissible,
+      true,
+      expiresAt ?? null,
+      req.user!.id,
+    ],
+  );
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'create_announcement',
+    targetType: 'announcement',
+    targetId: id,
+    details: { text: text.trim(), type: announcementType },
+  });
+
+  res.status(201).json({
+    id,
+    text: text.trim(),
+    type: announcementType,
+    dismissible: isDismissible,
+    active: true,
+    expiresAt: expiresAt ?? null,
+    createdBy: req.user!.id,
+    createdAt: new Date().toISOString(),
+  });
+}));
+
+// DELETE /announcements/:id
+router.delete('/announcements/:id', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  const result = await query(
+    'UPDATE announcements SET active = $1 WHERE id = $2',
+    [false, id],
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw new NotFoundError('Announcement not found');
+  }
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'delete_announcement',
+    targetType: 'announcement',
+    targetId: id,
+  });
+
+  res.json({ message: 'Announcement deactivated' });
+}));
+
+// ---------------------------------------------------------------------------
+// SYSTEM HEALTH
+// ---------------------------------------------------------------------------
+
+// GET /health
+router.get('/health', asyncHandler(async (_req, res) => {
+  // Database size
+  let dbSizeBytes = 0;
+  if (getDialect() === 'sqlite') {
+    const sizeResult = await query<{ db_size: number }>(
+      'SELECT (page_count * page_size) as db_size FROM pragma_page_count(), pragma_page_size()',
+    );
+    dbSizeBytes = sizeResult.rows[0]?.db_size ?? 0;
+  } else {
+    const sizeResult = await query<{ db_size: string }>(
+      'SELECT pg_database_size(current_database()) as db_size',
+    );
+    dbSizeBytes = parseInt(sizeResult.rows[0]?.db_size ?? '0', 10);
+  }
+
+  // User counts
+  const userResult = await query<{ total: number; deleted: number; suspended: number }>(
+    `SELECT
+       COUNT(*) as total,
+       SUM(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END) as deleted,
+       SUM(CASE WHEN suspended_at IS NOT NULL THEN 1 ELSE 0 END) as suspended
+     FROM users`,
+  );
+  const { total, deleted, suspended } = userResult.rows[0];
+
+  // Active sessions
+  const sessionResult = await query<{ cnt: number }>(
+    'SELECT COUNT(*) as cnt FROM refresh_tokens WHERE revoked_at IS NULL AND expires_at > $1',
+    [new Date().toISOString()],
+  );
+
+  res.json({
+    dbSizeBytes,
+    userCount: {
+      total: total ?? 0,
+      active: (total ?? 0) - (deleted ?? 0) - (suspended ?? 0),
+      deleted: deleted ?? 0,
+      suspended: suspended ?? 0,
+    },
+    activeSessions: sessionResult.rows[0].cnt ?? 0,
+    uptime: process.uptime(),
+  });
+}));
+
+// ---------------------------------------------------------------------------
+// ADMIN AUDIT LOG
+// ---------------------------------------------------------------------------
+
+// GET /audit-log
+router.get('/audit-log', asyncHandler(async (req, res) => {
+  const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+  const limit = Math.min(200, Math.max(1, parseInt(req.query.limit as string, 10) || 50));
+  const offset = (page - 1) * limit;
+
+  const action = typeof req.query.action === 'string' ? req.query.action.trim() : '';
+  const actorId = typeof req.query.actorId === 'string' ? req.query.actorId.trim() : '';
+  const targetType = typeof req.query.targetType === 'string' ? req.query.targetType.trim() : '';
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIdx = 0;
+  const nextParam = () => `$${++paramIdx}`;
+
+  if (action) {
+    conditions.push(`action = ${nextParam()}`);
+    params.push(action);
+  }
+  if (actorId) {
+    conditions.push(`actor_id = ${nextParam()}`);
+    params.push(actorId);
+  }
+  if (targetType) {
+    conditions.push(`target_type = ${nextParam()}`);
+    params.push(targetType);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const [countResult, dataResult] = await Promise.all([
+    query<{ cnt: number }>(
+      `SELECT COUNT(*) as cnt FROM admin_audit_log ${whereClause}`,
+      params,
+    ),
+    query<{
+      id: string; actor_id: string; actor_name: string; action: string;
+      target_type: string; target_id: string | null; target_name: string | null;
+      details: string | null; created_at: string;
+    }>(
+      `SELECT id, actor_id, actor_name, action, target_type, target_id, target_name, details, created_at
+       FROM admin_audit_log ${whereClause}
+       ORDER BY created_at DESC
+       LIMIT ${nextParam()} OFFSET ${nextParam()}`,
+      [...params, limit, offset],
+    ),
+  ]);
+
+  const results = dataResult.rows.map((row) => ({
+    id: row.id,
+    actorId: row.actor_id,
+    actorName: row.actor_name,
+    action: row.action,
+    targetType: row.target_type,
+    targetId: row.target_id ?? null,
+    targetName: row.target_name ?? null,
+    details: row.details ? JSON.parse(row.details) : null,
+    createdAt: row.created_at,
+  }));
+
+  res.json({ results, count: countResult.rows[0].cnt });
+}));
+
+// ---------------------------------------------------------------------------
+// ADMIN LOCATIONS
+// ---------------------------------------------------------------------------
+
+// GET /locations
+router.get('/locations', asyncHandler(async (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string, 10) || 25));
+  const offset = (page - 1) * limit;
+
+  let whereClause = '';
+  const params: unknown[] = [];
+  if (q) {
+    whereClause = 'WHERE LOWER(l.name) LIKE $1';
+    params.push(`%${q.toLowerCase()}%`);
+  }
+
+  const [countResult, dataResult] = await Promise.all([
+    query<{ cnt: number }>(
+      `SELECT COUNT(*) as cnt FROM locations l ${whereClause}`,
+      params,
+    ),
+    query<{
+    id: string; name: string; owner_username: string | null; owner_display_name: string | null;
+    member_count: number; bin_count: number; area_count: number; created_at: string;
+  }>(
+    `SELECT l.id, l.name,
+       u.username AS owner_username,
+       u.display_name AS owner_display_name,
+       (SELECT COUNT(*) FROM location_members lm WHERE lm.location_id = l.id) AS member_count,
+       (SELECT COUNT(*) FROM bins b WHERE b.location_id = l.id AND b.deleted_at IS NULL) AS bin_count,
+       (SELECT COUNT(*) FROM areas a WHERE a.location_id = l.id) AS area_count,
+       l.created_at
+     FROM locations l
+     LEFT JOIN users u ON l.created_by = u.id
+     ${whereClause}
+     ORDER BY l.created_at DESC
+     LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+    [...params, limit, offset],
+  ),
+  ]);
+
+  const results = dataResult.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    ownerUsername: row.owner_username ?? null,
+    ownerDisplayName: row.owner_display_name ?? null,
+    memberCount: row.member_count ?? 0,
+    binCount: row.bin_count ?? 0,
+    areaCount: row.area_count ?? 0,
+    createdAt: row.created_at,
+  }));
+
+  res.json({ results, count: countResult.rows[0].cnt });
+}));
+
+// POST /locations/:id/force-join
+router.post('/locations/:id/force-join', asyncHandler(async (req, res) => {
+  const locationId = req.params.id;
+  const { userId, role } = req.body;
+
+  if (!userId || typeof userId !== 'string') {
+    throw new ValidationError('userId is required');
+  }
+  if (!isValidRole(role)) {
+    throw new ValidationError('role must be one of: admin, member, viewer');
+  }
+
+  // Verify user exists
+  const userResult = await query<{ id: string }>('SELECT id FROM users WHERE id = $1', [userId]);
+  if (!userResult.rows[0]) throw new NotFoundError('User not found');
+
+  // Verify location exists
+  const locationResult = await query<{ id: string; name: string }>(
+    'SELECT id, name FROM locations WHERE id = $1',
+    [locationId],
+  );
+  if (!locationResult.rows[0]) throw new NotFoundError('Location not found');
+
+  const memberId = generateUuid();
+  await query(
+    `INSERT INTO location_members (id, location_id, user_id, role)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT(location_id, user_id) DO UPDATE SET role = excluded.role`,
+    [memberId, locationId, userId, role],
+  );
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'force_join_location',
+    targetType: 'location',
+    targetId: locationId,
+    targetName: locationResult.rows[0].name,
+    details: { userId, role, locationId },
+  });
+
+  res.json({ message: 'User joined location' });
+}));
+
+// DELETE /locations/:locationId/members/:userId
+router.delete('/locations/:locationId/members/:userId', asyncHandler(async (req, res) => {
+  const { locationId, userId } = req.params;
+
+  const result = await query(
+    'DELETE FROM location_members WHERE location_id = $1 AND user_id = $2',
+    [locationId, userId],
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw new NotFoundError('Member not found');
+  }
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'remove_member',
+    targetType: 'location_member',
+    targetId: userId,
+    details: { locationId, userId },
+  });
+
+  res.json({ message: 'Member removed' });
+}));
+
+// PUT /locations/:locationId/members/:userId/role
+router.put('/locations/:locationId/members/:userId/role', asyncHandler(async (req, res) => {
+  const { locationId, userId } = req.params;
+  const { role } = req.body;
+
+  if (!isValidRole(role)) {
+    throw new ValidationError('role must be one of: admin, member, viewer');
+  }
+
+  const result = await query(
+    'UPDATE location_members SET role = $1 WHERE location_id = $2 AND user_id = $3',
+    [role, locationId, userId],
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw new NotFoundError('Member not found');
+  }
+
+  logAdminAction({
+    actorId: req.user!.id,
+    actorName: req.user!.username,
+    action: 'change_member_role',
+    targetType: 'location_member',
+    targetId: userId,
+    details: { locationId, userId, role },
+  });
+
+  res.json({ message: 'Role updated' });
+}));
+
+// ---------------------------------------------------------------------------
+// ADMIN CONTENT (Global bin viewing)
+// ---------------------------------------------------------------------------
+
+// GET /bins
+router.get('/bins', asyncHandler(async (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string, 10) || 25));
+  const offset = (page - 1) * limit;
+
+  let whereClause = 'WHERE b.deleted_at IS NULL';
+  const params: unknown[] = [];
+  if (q) {
+    whereClause += ' AND (LOWER(b.name) LIKE $1 OR LOWER(b.short_code) LIKE $1)';
+    params.push(`%${q.toLowerCase()}%`);
+  }
+
+  const countResult = await query<{ cnt: number }>(
+    `SELECT COUNT(*) as cnt FROM bins b ${whereClause}`,
+    params,
+  );
+
+  const dataResult = await query<{
+    id: string; name: string; short_code: string; location_name: string;
+    owner_username: string | null; created_at: string; updated_at: string;
+  }>(
+    `SELECT b.id, b.name, b.short_code,
+       l.name AS location_name,
+       u.username AS owner_username,
+       b.created_at, b.updated_at
+     FROM bins b
+     JOIN locations l ON b.location_id = l.id
+     LEFT JOIN users u ON b.created_by = u.id
+     ${whereClause}
+     ORDER BY b.updated_at DESC
+     LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+    [...params, limit, offset],
+  );
+
+  const results = dataResult.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    shortCode: row.short_code,
+    locationName: row.location_name,
+    ownerUsername: row.owner_username ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+
+  res.json({ results, count: countResult.rows[0].cnt });
+}));
+
+// GET /bins/:id
+router.get('/bins/:id', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  const binResult = await query<{
+    id: string; name: string; short_code: string; location_id: string;
+    area_id: string | null; notes: string; tags: string; icon: string;
+    color: string; card_style: string; visibility: string;
+    created_by: string | null; created_at: string; updated_at: string;
+    deleted_at: string | null; location_name: string; owner_username: string | null;
+  }>(
+    `SELECT b.*, l.name AS location_name, u.username AS owner_username
+     FROM bins b
+     JOIN locations l ON b.location_id = l.id
+     LEFT JOIN users u ON b.created_by = u.id
+     WHERE b.id = $1`,
+    [id],
+  );
+
+  const bin = binResult.rows[0];
+  if (!bin) throw new NotFoundError('Bin not found');
+
+  const itemsResult = await query<{
+    id: string; name: string; quantity: number | null; position: number;
+  }>(
+    'SELECT id, name, quantity, position FROM bin_items WHERE bin_id = $1 ORDER BY position',
+    [id],
+  );
+
+  let tags: string[] = [];
+  try {
+    tags = JSON.parse(bin.tags);
+  } catch { /* default to empty */ }
+
+  res.json({
+    id: bin.id,
+    name: bin.name,
+    shortCode: bin.short_code,
+    locationId: bin.location_id,
+    locationName: bin.location_name,
+    areaId: bin.area_id ?? null,
+    notes: bin.notes,
+    tags,
+    icon: bin.icon,
+    color: bin.color,
+    cardStyle: bin.card_style,
+    visibility: bin.visibility,
+    ownerUsername: bin.owner_username ?? null,
+    createdBy: bin.created_by ?? null,
+    createdAt: bin.created_at,
+    updatedAt: bin.updated_at,
+    deletedAt: bin.deleted_at ?? null,
+    items: itemsResult.rows.map((item) => ({
+      id: item.id,
+      name: item.name,
+      quantity: item.quantity ?? null,
+      position: item.position,
+    })),
+  });
+}));
+
+export { router as adminSystemRoutes };

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -6,7 +6,7 @@ import { buildMockAnalysisResult, loadPhotosForAnalysis } from '../lib/aiPhotoLo
 import type { ImageInput } from '../lib/aiProviders.js';
 import { analyzeImages, reanalyzeImages } from '../lib/aiProviders.js';
 import { aiRouteHandler, validateTextInput } from '../lib/aiRouteHandler.js';
-import { getConfigForTask, getUserAiSettings, parseTaskModelOverrides, TASK_TYPES } from '../lib/aiSettings.js';
+import { getUserAiSettings, parseTaskModelOverrides, TASK_TYPES } from '../lib/aiSettings.js';
 import { verifyOptionalLocationMembership } from '../lib/binAccess.js';
 import { AI_TASK_GROUPS, type AiTaskGroup, config, getEnvAiConfig, isDemoUser, isGroupEnvLocked } from '../lib/config.js';
 import { decryptApiKey, encryptApiKey, maskApiKey, resolveMaskedApiKey } from '../lib/crypto.js';
@@ -15,6 +15,7 @@ import { HttpError, ValidationError } from '../lib/httpErrors.js';
 import { aiRateLimiters } from '../lib/rateLimiters.js';
 import type { StructureTextRequest } from '../lib/structureText.js';
 import { structureText } from '../lib/structureText.js';
+import { resolveTaskConfig } from '../lib/taskRouting.js';
 import { memoryPhotoUpload } from '../lib/uploadConfig.js';
 import { authenticate } from '../middleware/auth.js';
 import { checkAiCredits, requireAiAccess } from '../middleware/requirePlan.js';
@@ -310,7 +311,7 @@ router.post('/analyze-image', memoryPhotoUpload.fields([
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = getConfigForTask(settings, 'analysis');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
 
   const images: ImageInput[] = allFiles.map((f) => ({
     base64: f.buffer.toString('base64'),
@@ -350,7 +351,7 @@ router.post('/analyze', ...aiRateLimiters, requireAiAccess(), checkAiCredits, ai
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = getConfigForTask(settings, 'analysis');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
 
   const loaded = await loadPhotosForAnalysis(ids, req.user!.id);
   if (!loaded) {
@@ -399,7 +400,7 @@ router.post('/reanalyze', ...aiRateLimiters, requireAiAccess(), checkAiCredits, 
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = getConfigForTask(settings, 'analysis');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
 
   const loaded = await loadPhotosForAnalysis(ids, req.user!.id);
   if (!loaded) {
@@ -428,7 +429,7 @@ router.post('/structure-text', ...aiRateLimiters, requireAiAccess(), checkAiCred
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = getConfigForTask(settings, 'structure');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'quickText');
 
   const request: StructureTextRequest = {
     text,

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -6,7 +6,7 @@ import { buildMockAnalysisResult, loadPhotosForAnalysis } from '../lib/aiPhotoLo
 import type { ImageInput } from '../lib/aiProviders.js';
 import { analyzeImages, reanalyzeImages } from '../lib/aiProviders.js';
 import { aiRouteHandler, validateTextInput } from '../lib/aiRouteHandler.js';
-import { getUserAiSettings, parseTaskModelOverrides, TASK_TYPES } from '../lib/aiSettings.js';
+import { getUserAiSettings } from '../lib/aiSettings.js';
 import { verifyOptionalLocationMembership } from '../lib/binAccess.js';
 import { AI_TASK_GROUPS, type AiTaskGroup, config, getEnvAiConfig, isDemoUser, isGroupEnvLocked } from '../lib/config.js';
 import { decryptApiKey, encryptApiKey, maskApiKey, resolveMaskedApiKey } from '../lib/crypto.js';
@@ -133,7 +133,6 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
     maxTokens: activeRow.max_tokens ?? null,
     topP: activeRow.top_p ?? null,
     requestTimeout: activeRow.request_timeout ?? null,
-    taskModelOverrides: parseTaskModelOverrides(activeRow.task_model_overrides),
     providerConfigs,
     taskOverrides,
     taskOverridesEnvLocked,
@@ -155,12 +154,9 @@ router.put('/settings', requireAiAccess(), aiRouteHandler('save AI settings', as
     if (PROMPT_FIELDS.some(f => req.body[f] != null)) {
       throw new HttpError(403, 'DEMO_RESTRICTION', 'Demo accounts cannot customize AI prompts');
     }
-    if (req.body.taskModelOverrides && Object.values(req.body.taskModelOverrides).some((v: unknown) => v)) {
-      throw new HttpError(403, 'DEMO_RESTRICTION', 'Demo accounts cannot set model overrides');
-    }
   }
 
-  const { provider, apiKey, model, endpointUrl, customPrompt, commandPrompt, queryPrompt, structurePrompt, reorganizationPrompt, taskModelOverrides: rawOverrides } = req.body;
+  const { provider, apiKey, model, endpointUrl, customPrompt, commandPrompt, queryPrompt, structurePrompt, reorganizationPrompt } = req.body;
   const { temperature: rawTemp, maxTokens: rawMaxTokens, topP: rawTopP, requestTimeout: rawTimeout } = req.body;
 
   if (!provider || !apiKey || !model) {
@@ -205,21 +201,6 @@ router.put('/settings', requireAiAccess(), aiRouteHandler('save AI settings', as
     return;
   }
 
-  // Validate and serialize task model overrides
-  let finalOverrides: string | null = null;
-  if (rawOverrides && typeof rawOverrides === 'object' && !Array.isArray(rawOverrides)) {
-    const cleaned: Record<string, string> = {};
-    for (const [key, value] of Object.entries(rawOverrides)) {
-      if (!(TASK_TYPES as readonly string[]).includes(key)) continue;
-      if (value === null || value === undefined || value === '') continue;
-      if (typeof value !== 'string') {
-        throw new ValidationError(`taskModelOverrides.${key} must be a string`);
-      }
-      cleaned[key] = value;
-    }
-    finalOverrides = Object.keys(cleaned).length > 0 ? JSON.stringify(cleaned) : null;
-  }
-
   const finalApiKey = await resolveMaskedApiKey(apiKey, req.user!.id, provider);
   const encryptedKey = encryptApiKey(finalApiKey);
   const finalCustomPrompt = (customPrompt && typeof customPrompt === 'string' && customPrompt.trim()) ? customPrompt.trim() : null;
@@ -242,7 +223,7 @@ router.put('/settings', requireAiAccess(), aiRouteHandler('save AI settings', as
      ON CONFLICT (user_id, provider) DO UPDATE SET
        api_key = $4, model = $5, endpoint_url = $6, custom_prompt = $7, command_prompt = $8, query_prompt = $9, structure_prompt = $10, reorganization_prompt = $11, temperature = $12, max_tokens = $13, top_p = $14, request_timeout = $15, task_model_overrides = $16, is_active = TRUE, updated_at = ${d.now()}
      RETURNING id, provider, api_key, model, endpoint_url, custom_prompt, command_prompt, query_prompt, structure_prompt, reorganization_prompt, temperature, max_tokens, top_p, request_timeout, task_model_overrides`,
-    [newId, req.user!.id, provider, encryptedKey, model, endpointUrl || null, finalCustomPrompt, finalCommandPrompt, finalQueryPrompt, finalStructurePrompt, finalReorganizationPrompt, finalTemperature, finalMaxTokens, finalTopP, finalTimeout, finalOverrides]
+    [newId, req.user!.id, provider, encryptedKey, model, endpointUrl || null, finalCustomPrompt, finalCommandPrompt, finalQueryPrompt, finalStructurePrompt, finalReorganizationPrompt, finalTemperature, finalMaxTokens, finalTopP, finalTimeout, null]
   );
 
   // Fetch all rows to build providerConfigs
@@ -275,7 +256,6 @@ router.put('/settings', requireAiAccess(), aiRouteHandler('save AI settings', as
     maxTokens: row.max_tokens ?? null,
     topP: row.top_p ?? null,
     requestTimeout: row.request_timeout ?? null,
-    taskModelOverrides: parseTaskModelOverrides(row.task_model_overrides),
     providerConfigs,
     source: 'user' as const,
   });

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -8,7 +8,7 @@ import { analyzeImages, reanalyzeImages } from '../lib/aiProviders.js';
 import { aiRouteHandler, validateTextInput } from '../lib/aiRouteHandler.js';
 import { getConfigForTask, getUserAiSettings, parseTaskModelOverrides, TASK_TYPES } from '../lib/aiSettings.js';
 import { verifyOptionalLocationMembership } from '../lib/binAccess.js';
-import { config, getEnvAiConfig, isDemoUser } from '../lib/config.js';
+import { AI_TASK_GROUPS, type AiTaskGroup, config, getEnvAiConfig, isDemoUser, isGroupEnvLocked } from '../lib/config.js';
 import { decryptApiKey, encryptApiKey, maskApiKey, resolveMaskedApiKey } from '../lib/crypto.js';
 import { ALL_DEFAULT_PROMPTS } from '../lib/defaultPrompts.js';
 import { HttpError, ValidationError } from '../lib/httpErrors.js';
@@ -73,6 +73,8 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
         maxTokens: null,
         topP: null,
         requestTimeout: null,
+        taskOverrides: {},
+        taskOverridesEnvLocked: AI_TASK_GROUPS.filter(isGroupEnvLocked),
         source: 'env' as const,
       });
       return;
@@ -87,6 +89,23 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
   }
 
   const activeRow = result.rows.find((r: any) => !!r.is_active) || result.rows[0];
+
+  // Fetch task overrides for this user
+  const overridesResult = await query(
+    'SELECT task_group, provider, model, endpoint_url FROM user_ai_task_overrides WHERE user_id = $1',
+    [req.user!.id],
+  );
+
+  const taskOverrides: Record<string, { provider: string | null; model: string | null; endpointUrl: string | null; source: 'user' } | null> = {};
+  for (const row of overridesResult.rows) {
+    taskOverrides[row.task_group] = {
+      provider: row.provider || null,
+      model: row.model || null,
+      endpointUrl: row.endpoint_url || null,
+      source: 'user',
+    };
+  }
+  const taskOverridesEnvLocked: string[] = AI_TASK_GROUPS.filter(isGroupEnvLocked);
 
   // Build providerConfigs from all rows
   const providerConfigs: Record<string, { apiKey: string; model: string; endpointUrl: string | null }> = {};
@@ -115,6 +134,8 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
     requestTimeout: activeRow.request_timeout ?? null,
     taskModelOverrides: parseTaskModelOverrides(activeRow.task_model_overrides),
     providerConfigs,
+    taskOverrides,
+    taskOverridesEnvLocked,
     source: 'user' as const,
   });
 }));
@@ -261,6 +282,7 @@ router.put('/settings', requireAiAccess(), aiRouteHandler('save AI settings', as
 
 // DELETE /api/ai/settings — remove AI config
 router.delete('/settings', requireAiAccess(), aiRouteHandler('delete AI settings', async (req, res) => {
+  await query('DELETE FROM user_ai_task_overrides WHERE user_id = $1', [req.user!.id]);
   await query('DELETE FROM user_ai_settings WHERE user_id = $1', [req.user!.id]);
   res.json({ deleted: true });
 }));
@@ -448,6 +470,48 @@ router.post('/test', ...aiRateLimiters, requireAiAccess(), checkAiCredits, aiRou
     endpointUrl: endpointUrl || null,
   }, isDemoUser(req));
   res.json({ success: true });
+}));
+
+// PUT /api/ai/task-overrides/:taskGroup
+router.put('/task-overrides/:taskGroup', requireAiAccess(), aiRouteHandler('save task override', async (req, res) => {
+  const group = req.params.taskGroup as AiTaskGroup;
+  if (!(AI_TASK_GROUPS as readonly string[]).includes(group)) {
+    throw new ValidationError(`Invalid task group: ${group}. Valid: ${AI_TASK_GROUPS.join(', ')}`);
+  }
+  if (isGroupEnvLocked(group)) {
+    throw new HttpError(409, 'ENV_LOCKED', `Task routing for ${group} is configured by server environment`);
+  }
+  if (isDemoUser(req)) {
+    throw new HttpError(403, 'DEMO_RESTRICTION', 'Demo accounts cannot configure task routing');
+  }
+
+  const { provider, model, endpointUrl } = req.body;
+  if (provider && !['openai', 'anthropic', 'gemini', 'openai-compatible'].includes(provider)) {
+    throw new ValidationError('Invalid provider');
+  }
+
+  const id = generateUuid();
+  await query(
+    `INSERT INTO user_ai_task_overrides (id, user_id, task_group, provider, model, endpoint_url)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (user_id, task_group) DO UPDATE SET
+       provider = $4, model = $5, endpoint_url = $6, updated_at = ${d.now()}`,
+    [id, req.user!.id, group, provider || null, model || null, endpointUrl || null],
+  );
+  res.json({ taskGroup: group, provider: provider || null, model: model || null, endpointUrl: endpointUrl || null });
+}));
+
+// DELETE /api/ai/task-overrides/:taskGroup
+router.delete('/task-overrides/:taskGroup', requireAiAccess(), aiRouteHandler('delete task override', async (req, res) => {
+  const group = req.params.taskGroup as AiTaskGroup;
+  if (!(AI_TASK_GROUPS as readonly string[]).includes(group)) {
+    throw new ValidationError(`Invalid task group: ${group}`);
+  }
+  if (isGroupEnvLocked(group)) {
+    throw new HttpError(409, 'ENV_LOCKED', `Task routing for ${group} is configured by server environment`);
+  }
+  await query('DELETE FROM user_ai_task_overrides WHERE user_id = $1 AND task_group = $2', [req.user!.id, group]);
+  res.json({ deleted: true });
 }));
 
 export default router;

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -38,6 +38,8 @@ const MOCK_AI_SETTINGS = {
   source: 'env' as const,
 } as const;
 
+const VALID_PROVIDERS = ['openai', 'anthropic', 'gemini', 'openai-compatible'] as const;
+
 const router = Router();
 
 // GET /api/ai/default-prompts — public (no auth), returns default prompt strings
@@ -102,7 +104,9 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
     [req.user!.id],
   );
 
-  const taskOverrides: Record<string, { provider: string | null; model: string | null; endpointUrl: string | null; source: 'user' } | null> = {};
+  const taskOverridesEnvLocked = AI_TASK_GROUPS.filter(isGroupEnvLocked);
+
+  const taskOverrides: Record<string, { provider: string | null; model: string | null; endpointUrl: string | null; source: 'env' | 'user' } | null> = {};
   for (const row of overridesResult.rows) {
     taskOverrides[row.task_group] = {
       provider: row.provider || null,
@@ -111,12 +115,10 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
       source: 'user',
     };
   }
-  const taskOverridesEnvLocked: string[] = AI_TASK_GROUPS.filter(isGroupEnvLocked);
-
-  // Populate env override values for env-locked groups
+  // Env-locked groups override DB values with env values
   for (const g of taskOverridesEnvLocked) {
-    const o = getEnvGroupOverride(g as AiTaskGroup);
-    taskOverrides[g] = { provider: o.provider, model: o.model, endpointUrl: o.endpointUrl, source: 'env' as any };
+    const o = getEnvGroupOverride(g);
+    taskOverrides[g] = { provider: o.provider, model: o.model, endpointUrl: o.endpointUrl, source: 'env' };
   }
 
   // Build providerConfigs from all rows
@@ -175,8 +177,7 @@ router.put('/settings', requireAiAccess(), aiRouteHandler('save AI settings', as
     return;
   }
 
-  const validProviders = ['openai', 'anthropic', 'gemini', 'openai-compatible'];
-  if (!validProviders.includes(provider)) {
+  if (!(VALID_PROVIDERS as readonly string[]).includes(provider)) {
     res.status(422).json({ error: 'VALIDATION_ERROR', message: 'Invalid provider' });
     return;
   }
@@ -302,7 +303,7 @@ router.post('/analyze-image', memoryPhotoUpload.fields([
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision', settings.config);
 
   const images: ImageInput[] = allFiles.map((f) => ({
     base64: f.buffer.toString('base64'),
@@ -342,7 +343,7 @@ router.post('/analyze', ...aiRateLimiters, requireAiAccess(), checkAiCredits, ai
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision', settings.config);
 
   const loaded = await loadPhotosForAnalysis(ids, req.user!.id);
   if (!loaded) {
@@ -391,7 +392,7 @@ router.post('/reanalyze', ...aiRateLimiters, requireAiAccess(), checkAiCredits, 
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'vision', settings.config);
 
   const loaded = await loadPhotosForAnalysis(ids, req.user!.id);
   if (!loaded) {
@@ -420,7 +421,7 @@ router.post('/structure-text', ...aiRateLimiters, requireAiAccess(), checkAiCred
   }
 
   const settings = await getUserAiSettings(req.user!.id);
-  const taskConfig = await resolveTaskConfig(req.user!.id, 'quickText');
+  const taskConfig = await resolveTaskConfig(req.user!.id, 'quickText', settings.config);
 
   const request: StructureTextRequest = {
     text,
@@ -478,7 +479,7 @@ router.put('/task-overrides/:taskGroup', requireAiAccess(), aiRouteHandler('save
   }
 
   const { provider, model, endpointUrl } = req.body;
-  if (provider && !['openai', 'anthropic', 'gemini', 'openai-compatible'].includes(provider)) {
+  if (provider && !(VALID_PROVIDERS as readonly string[]).includes(provider)) {
     throw new ValidationError('Invalid provider');
   }
 

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -8,7 +8,7 @@ import { analyzeImages, reanalyzeImages } from '../lib/aiProviders.js';
 import { aiRouteHandler, validateTextInput } from '../lib/aiRouteHandler.js';
 import { getUserAiSettings } from '../lib/aiSettings.js';
 import { verifyOptionalLocationMembership } from '../lib/binAccess.js';
-import { AI_TASK_GROUPS, type AiTaskGroup, config, getEnvAiConfig, isDemoUser, isGroupEnvLocked } from '../lib/config.js';
+import { AI_TASK_GROUPS, type AiTaskGroup, config, getEnvAiConfig, getEnvGroupOverride, isDemoUser, isGroupEnvLocked } from '../lib/config.js';
 import { decryptApiKey, encryptApiKey, maskApiKey, resolveMaskedApiKey } from '../lib/crypto.js';
 import { ALL_DEFAULT_PROMPTS } from '../lib/defaultPrompts.js';
 import { HttpError, ValidationError } from '../lib/httpErrors.js';
@@ -74,7 +74,12 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
         maxTokens: null,
         topP: null,
         requestTimeout: null,
-        taskOverrides: {},
+        taskOverrides: Object.fromEntries(
+          AI_TASK_GROUPS.filter(isGroupEnvLocked).map((g) => {
+            const o = getEnvGroupOverride(g);
+            return [g, { provider: o.provider, model: o.model, endpointUrl: o.endpointUrl, source: 'env' as const }];
+          }),
+        ),
         taskOverridesEnvLocked: AI_TASK_GROUPS.filter(isGroupEnvLocked),
         source: 'env' as const,
       });
@@ -107,6 +112,12 @@ router.get('/settings', requireAiAccess(), aiRouteHandler('get AI settings', asy
     };
   }
   const taskOverridesEnvLocked: string[] = AI_TASK_GROUPS.filter(isGroupEnvLocked);
+
+  // Populate env override values for env-locked groups
+  for (const g of taskOverridesEnvLocked) {
+    const o = getEnvGroupOverride(g as AiTaskGroup);
+    taskOverrides[g] = { provider: o.provider, model: o.model, endpointUrl: o.endpointUrl, source: 'env' as any };
+  }
 
   // Build providerConfigs from all rows
   const providerConfigs: Record<string, { apiKey: string; model: string; endpointUrl: string | null }> = {};

--- a/server/src/routes/aiStream.ts
+++ b/server/src/routes/aiStream.ts
@@ -55,7 +55,7 @@ async function resolveUserModel(userId: string, task: TaskType, isDemoUser = fal
   const settings = await getUserAiSettings(userId);
   const group = TASK_GROUP_MAP[task];
   const taskConfig = group
-    ? await resolveTaskConfig(userId, group)
+    ? await resolveTaskConfig(userId, group, settings.config)
     : getConfigForTask(settings, task);
   const resolvedIps = taskConfig.endpointUrl
     ? await validateEndpointUrl(taskConfig.endpointUrl, isDemoUser)

--- a/server/src/routes/aiStream.ts
+++ b/server/src/routes/aiStream.ts
@@ -18,6 +18,7 @@ import { buildSystemPrompt as buildQuerySysPrompt, buildUserMessage as buildQuer
 import { aiRateLimiters } from '../lib/rateLimiters.js';
 import { createSdkModel } from '../lib/sdkProviderFactory.js';
 import { buildPrompt as buildStructurePrompt, STRUCTURE_TEXT_TOKENS } from '../lib/structureText.js';
+import { resolveTaskConfig, TASK_GROUP_MAP } from '../lib/taskRouting.js';
 import { demoMemoryPhotoUpload, memoryPhotoUpload } from '../lib/uploadConfig.js';
 import { authenticate } from '../middleware/auth.js';
 import { demoConnectionLimiter, isDemoUser as isDemoConn } from '../middleware/demoConnectionLimiter.js';
@@ -49,10 +50,13 @@ async function sendMockJsonStream(res: import('express').Response, data: object)
   res.end();
 }
 
-/** Resolve a user's AI model (settings + SSRF check + SDK model). */
+/** Resolve a user's AI model (task routing + SSRF check + SDK model). */
 async function resolveUserModel(userId: string, task: TaskType, isDemoUser = false) {
   const settings = await getUserAiSettings(userId);
-  const taskConfig = getConfigForTask(settings, task);
+  const group = TASK_GROUP_MAP[task];
+  const taskConfig = group
+    ? await resolveTaskConfig(userId, group)
+    : getConfigForTask(settings, task);
   const resolvedIps = taskConfig.endpointUrl
     ? await validateEndpointUrl(taskConfig.endpointUrl, isDemoUser)
     : undefined;

--- a/server/src/routes/aiStream.ts
+++ b/server/src/routes/aiStream.ts
@@ -2,19 +2,22 @@ import { Router } from 'express';
 import { createPinnedFetch, validateEndpointUrl } from '../lib/aiCaller.js';
 import { buildCommandContext, buildInventoryContext, fetchExistingTags } from '../lib/aiContext.js';
 import { buildMockAnalysisResult, loadPhotosForAnalysis } from '../lib/aiPhotoLoader.js';
-import { buildSystemPrompt as buildAnalysisPrompt, buildAnalysisUserText, buildCorrectionPrompt, buildReanalysisPrompt, buildReanalysisUserContent, IMAGE_TOKENS_MULTI, IMAGE_TOKENS_SINGLE } from '../lib/aiProviders.js';
+import { buildSystemPrompt as buildAnalysisPrompt, buildAnalysisUserText, buildContextPreamble, buildCorrectionPrompt, buildReanalysisPrompt, buildReanalysisUserContent, buildTagBlock, IMAGE_TOKENS_MULTI, IMAGE_TOKENS_SINGLE } from '../lib/aiProviders.js';
 import { aiRouteHandler, validateTextInput } from '../lib/aiRouteHandler.js';
 import { resolvePrompt, sanitizeForPrompt } from '../lib/aiSanitize.js';
 import { QueryResultSchema } from '../lib/aiSchemas.js';
 import type { TaskType, UserAiSettings } from '../lib/aiSettings.js';
 import { getConfigForTask, getUserAiSettings } from '../lib/aiSettings.js';
-import { initSseResponse, pipeAiStreamToResponse } from '../lib/aiStream.js';
+import { initSseResponse, pipeAiStreamToResponse, streamAiToWriter } from '../lib/aiStream.js';
 import { verifyOptionalLocationMembership } from '../lib/binAccess.js';
 import type { CommandRequest } from '../lib/commandParser.js';
 import { buildSystemPrompt as buildCommandSysPrompt, buildUserMessage as buildCommandUserMsg, buildUnifiedSystemPrompt } from '../lib/commandParser.js';
 import { config, isDemoUser } from '../lib/config.js';
 import { fetchCustomFieldDefs } from '../lib/customFieldHelpers.js';
+import { ValidationError } from '../lib/httpErrors.js';
+import { classifyIntent } from '../lib/intentClassifier.js';
 import { buildSystemPrompt as buildQuerySysPrompt, buildUserMessage as buildQueryUserMsg } from '../lib/inventoryQuery.js';
+import { refundAiCredit } from '../lib/planGate.js';
 import { aiRateLimiters } from '../lib/rateLimiters.js';
 import { createSdkModel } from '../lib/sdkProviderFactory.js';
 import { buildPrompt as buildStructurePrompt, STRUCTURE_TEXT_TOKENS } from '../lib/structureText.js';
@@ -28,7 +31,6 @@ import { checkAiCredits, requireAiAccess } from '../middleware/requirePlan.js';
 const streamRouter = Router();
 streamRouter.use(authenticate);
 
-/** Fetch existing tags and custom field definitions for a location (used by analysis/correction routes). */
 async function fetchLocationAiMeta(locationId: string | undefined) {
   const [existingTags, customFieldDefs] = await Promise.all([
     locationId ? fetchExistingTags(locationId) : Promise.resolve(undefined),
@@ -37,7 +39,6 @@ async function fetchLocationAiMeta(locationId: string | undefined) {
   return { existingTags, customFieldDefs };
 }
 
-/** Stream a JSON object as fake SSE chunks (mock mode). */
 async function sendMockJsonStream(res: import('express').Response, data: object): Promise<void> {
   const writeEvent = initSseResponse(res);
   const json = JSON.stringify(data);
@@ -50,7 +51,6 @@ async function sendMockJsonStream(res: import('express').Response, data: object)
   res.end();
 }
 
-/** Resolve a user's AI model (task routing + SSRF check + SDK model). */
 async function resolveUserModel(userId: string, task: TaskType, isDemoUser = false) {
   const settings = await getUserAiSettings(userId);
   const group = TASK_GROUP_MAP[task];
@@ -65,7 +65,6 @@ async function resolveUserModel(userId: string, task: TaskType, isDemoUser = fal
   return { settings, model };
 }
 
-/** Build common StreamOptions from user AI settings. */
 function streamOpts(settings: UserAiSettings, overrides?: { maxTokens?: number; temperature?: number }) {
   return {
     maxTokens: overrides?.maxTokens ?? settings.max_tokens ?? 4096,
@@ -75,12 +74,17 @@ function streamOpts(settings: UserAiSettings, overrides?: { maxTokens?: number; 
   };
 }
 
-/** Validate and sanitize optional binIds from request body. */
+function assertBinsFound(binIds: string[] | undefined, bins: { length: number }): void {
+  if (binIds?.length && bins.length === 0) {
+    throw new ValidationError('No matching bins found for the provided IDs');
+  }
+}
+
 function validateBinIds(binIds: unknown): string[] | undefined {
   if (!binIds) return undefined;
   if (!Array.isArray(binIds)) return undefined;
   const valid = binIds
-    .filter((id): id is string => typeof id === 'string' && /^[a-zA-Z0-9]{1,10}$/.test(id))
+    .filter((id): id is string => typeof id === 'string' && /^[a-zA-Z0-9-]{1,36}$/.test(id))
     .slice(0, 100);
   return valid.length > 0 ? valid : undefined;
 }
@@ -91,7 +95,7 @@ streamRouter.post('/query/stream', ...aiRateLimiters, requireAiAccess(), checkAi
   const { locationId } = req.body;
   const [{ settings, model }, context] = await Promise.all([
     resolveUserModel(req.user!.id, 'query', isDemoUser(req)),
-    buildInventoryContext(locationId, req.user!.id),
+    buildInventoryContext(locationId, req.user!.id, undefined, question),
   ]);
 
   await pipeAiStreamToResponse(res, model, {
@@ -108,7 +112,7 @@ streamRouter.post('/command/stream', ...aiRateLimiters, requireAiAccess(), check
   const { locationId } = req.body;
   const [{ settings, model }, context] = await Promise.all([
     resolveUserModel(req.user!.id, 'command', isDemoUser(req)),
-    buildCommandContext(locationId, req.user!.id),
+    buildCommandContext(locationId, req.user!.id, undefined, text),
   ]);
   const request: CommandRequest = { text, context };
 
@@ -116,7 +120,7 @@ streamRouter.post('/command/stream', ...aiRateLimiters, requireAiAccess(), check
   // reliable JSON, and structured-output mode causes providers like Gemini
   // to aggressively omit optional fields (items, area_name in create_bin).
   await pipeAiStreamToResponse(res, model, {
-    system: buildCommandSysPrompt(request, settings.command_prompt ?? undefined, isDemoUser(req)),
+    system: buildCommandSysPrompt(context.availableColors, context.availableIcons, settings.command_prompt ?? undefined, isDemoUser(req)),
     userContent: buildCommandUserMsg(request),
     ...streamOpts(settings, { maxTokens: 2500, temperature: 0.2 }),
   });
@@ -127,25 +131,43 @@ streamRouter.post('/ask/stream', ...aiRateLimiters, requireAiAccess(), checkAiCr
   const text = validateTextInput(req.body.text, 'text');
   const { locationId, binIds: rawBinIds } = req.body;
   const binIds = validateBinIds(rawBinIds);
-
-  const [{ settings, model }, context] = await Promise.all([
-    resolveUserModel(req.user!.id, 'command', isDemoUser(req)),
-    buildCommandContext(locationId, req.user!.id, binIds),
-  ]);
-
-  if (binIds?.length && context.bins.length === 0) {
-    const { ValidationError } = await import('../lib/httpErrors.js');
-    throw new ValidationError('No matching bins found for the provided IDs');
-  }
-
   const isScoped = (binIds?.length ?? 0) > 0;
-  const request: CommandRequest = { text, context };
 
-  await pipeAiStreamToResponse(res, model, {
-    system: buildUnifiedSystemPrompt(request, settings.command_prompt ?? undefined, settings.query_prompt ?? undefined, isDemoUser(req), isScoped),
-    userContent: buildCommandUserMsg(request),
-    ...streamOpts(settings, { maxTokens: 2500, temperature: 0.2 }),
-  });
+  const scopeNote = isScoped
+    ? '\nSELECTION SCOPE: The user selected specific bins. The inventory context below contains ONLY these bins. Apply actions or answer based only on the bins provided.\n'
+    : '';
+  const intent = classifyIntent(text);
+
+  if (intent === 'query') {
+    const [{ settings, model }, queryContext] = await Promise.all([
+      resolveUserModel(req.user!.id, 'query', isDemoUser(req)),
+      buildInventoryContext(locationId, req.user!.id, binIds, text),
+    ]);
+    assertBinsFound(binIds, queryContext.bins);
+
+    await pipeAiStreamToResponse(res, model, {
+      schema: QueryResultSchema,
+      system: buildQuerySysPrompt(settings.query_prompt ?? undefined, isDemoUser(req)),
+      userContent: buildQueryUserMsg(`${scopeNote}${text}`, queryContext),
+      ...streamOpts(settings, { maxTokens: 4096 }),
+    });
+  } else {
+    const [{ settings, model }, context] = await Promise.all([
+      resolveUserModel(req.user!.id, 'command', isDemoUser(req)),
+      buildCommandContext(locationId, req.user!.id, binIds, text),
+    ]);
+    assertBinsFound(binIds, context.bins);
+
+    const system = intent === 'command'
+      ? buildCommandSysPrompt(context.availableColors, context.availableIcons, settings.command_prompt ?? undefined, isDemoUser(req))
+      : buildUnifiedSystemPrompt(context.availableColors, context.availableIcons, settings.command_prompt ?? undefined, settings.query_prompt ?? undefined, isDemoUser(req), isScoped);
+    const request: CommandRequest = { text: intent === 'command' ? `${scopeNote}${text}` : text, context };
+    await pipeAiStreamToResponse(res, model, {
+      system,
+      userContent: buildCommandUserMsg(request),
+      ...streamOpts(settings, { maxTokens: 2500, temperature: 0.2 }),
+    });
+  }
 }));
 
 // POST /api/ai/structure-text/stream
@@ -215,9 +237,10 @@ streamRouter.post('/analyze-image/stream', demoConnectionLimiter, demoAwareAnaly
     mimeType: f.mimetype,
   }));
 
+  const preamble = buildContextPreamble(existingTags, customFieldDefs);
   await pipeAiStreamToResponse(res, model, {
-    system: buildAnalysisPrompt(existingTags, settings.custom_prompt, customFieldDefs, isDemoUser(req)),
-    userContent: [...imageParts, { type: 'text' as const, text: buildAnalysisUserText(allFiles.length) }],
+    system: buildAnalysisPrompt(settings.custom_prompt, isDemoUser(req)),
+    userContent: [...imageParts, { type: 'text' as const, text: preamble + buildAnalysisUserText(allFiles.length) }],
     ...streamOpts(settings, { maxTokens: allFiles.length > 1 ? IMAGE_TOKENS_MULTI : IMAGE_TOKENS_SINGLE }),
   });
 }));
@@ -255,9 +278,10 @@ streamRouter.post('/analyze/stream', ...aiRateLimiters, requireAiAccess(), check
     mimeType: img.mimeType,
   }));
 
+  const preambleStored = buildContextPreamble(loaded.existingTags, loaded.customFieldDefs);
   await pipeAiStreamToResponse(res, model, {
-    system: buildAnalysisPrompt(loaded.existingTags, settings.custom_prompt, loaded.customFieldDefs, isDemoUser(req)),
-    userContent: [...imageParts, { type: 'text' as const, text: buildAnalysisUserText(loaded.images.length) }],
+    system: buildAnalysisPrompt(settings.custom_prompt, isDemoUser(req)),
+    userContent: [...imageParts, { type: 'text' as const, text: preambleStored + buildAnalysisUserText(loaded.images.length) }],
     ...streamOpts(settings, { maxTokens: loaded.images.length > 1 ? IMAGE_TOKENS_MULTI : IMAGE_TOKENS_SINGLE }),
   });
 }));
@@ -296,10 +320,11 @@ streamRouter.post('/correct/stream', ...aiRateLimiters, requireAiAccess(), check
   }
   const { existingTags, customFieldDefs } = await fetchLocationAiMeta(locationId);
 
-  const system = buildCorrectionPrompt(existingTags, customFieldDefs);
+  const system = buildCorrectionPrompt();
 
+  const correctionPreamble = buildContextPreamble(existingTags, customFieldDefs);
   const sanitizedCorrection = sanitizeForPrompt(correctionText);
-  const userMessage = `<user_data type="previous_result" trust="none">\n${JSON.stringify(safePrevious, null, 2)}\n</user_data>\n\n<user_data type="correction" trust="none">\n${sanitizedCorrection}\n</user_data>`;
+  const userMessage = `${correctionPreamble}<user_data type="previous_result" trust="none">\n${JSON.stringify(safePrevious, null, 2)}\n</user_data>\n\n<user_data type="correction" trust="none">\n${sanitizedCorrection}\n</user_data>`;
 
   await pipeAiStreamToResponse(res, model, {
     system,
@@ -386,9 +411,10 @@ streamRouter.post('/reanalyze/stream', ...aiRateLimiters, requireAiAccess(), che
 
   const safePrevious = sanitizePreviousResult(previousResult);
 
+  const reanalyzePreamble = buildContextPreamble(loaded.existingTags, loaded.customFieldDefs);
   await pipeAiStreamToResponse(res, model, {
-    system: buildReanalysisPrompt(loaded.existingTags, loaded.customFieldDefs),
-    userContent: buildReanalysisUserContent(safePrevious, imageParts),
+    system: buildReanalysisPrompt(),
+    userContent: buildReanalysisUserContent(safePrevious, imageParts, reanalyzePreamble),
     ...streamOpts(settings, { maxTokens: loaded.images.length > 1 ? IMAGE_TOKENS_MULTI : IMAGE_TOKENS_SINGLE }),
   });
 }));
@@ -444,9 +470,10 @@ streamRouter.post('/reanalyze-image/stream', memoryPhotoUpload.fields([
 
   const safePrevious = sanitizePreviousResult(previousResult);
 
+  const reanalyzeImagePreamble = buildContextPreamble(existingTags, customFieldDefs);
   await pipeAiStreamToResponse(res, model, {
-    system: buildReanalysisPrompt(existingTags, customFieldDefs),
-    userContent: buildReanalysisUserContent(safePrevious, imageParts),
+    system: buildReanalysisPrompt(),
+    userContent: buildReanalysisUserContent(safePrevious, imageParts, reanalyzeImagePreamble),
     ...streamOpts(settings, { maxTokens: allFiles.length > 1 ? IMAGE_TOKENS_MULTI : IMAGE_TOKENS_SINGLE }),
   });
 }));
@@ -515,14 +542,11 @@ streamRouter.post('/reorganize/stream', ...aiRateLimiters, requireAiAccess(), ch
 
   const notesInstruction = userNotes?.trim() ? `Additional user guidance: ${sanitizeForPrompt(userNotes.trim())}` : '';
 
-  // Extract unique tags from input bins for reuse guidance
   const existingTags = [...new Set(
     inputBins.flatMap((b: { tags?: string[] }) => b.tags ?? [])
   )].sort();
-
-  const tagBlock = existingTags.length > 0
-    ? `EXISTING TAGS from these bins: [${existingTags.join(', ')}]\nYou MUST reuse these tags whenever they are even loosely relevant. Only create a new tag when no existing tag covers the category.`
-    : '';
+  const reorgTagBlock = buildTagBlock(existingTags);
+  const reorgTagSection = reorgTagBlock ? `${reorgTagBlock}\n\n` : '';
 
   const system = basePrompt
     .replace('{max_bins_instruction}', maxBinsInstruction)
@@ -534,13 +558,14 @@ streamRouter.post('/reorganize/stream', ...aiRateLimiters, requireAiAccess(), ch
     .replace('{outliers_instruction}', outliersInstruction)
     .replace('{items_per_bin_instruction}', itemsPerBinInstruction)
     .replace('{notes_instruction}', notesInstruction)
-    .replace('{available_tags}', tagBlock);
+    .replace('{available_tags}', '');
 
-  // Build user message: list of bins with items (sanitized)
+  // Build user message: list of bins with items (sanitized), tag context prepended
   const binDescriptions = inputBins.map((b: { name: string; items: string[] }) =>
     `- ${sanitizeForPrompt(b.name)}: ${b.items.length > 0 ? b.items.map((i: string) => sanitizeForPrompt(i)).join(', ') : '(empty)'}`
   ).join('\n');
-  const userContent = `Here are the bins to reorganize:\n\n${binDescriptions}`;
+  const totalInputItems = inputBins.reduce((sum: number, b: { items: string[] }) => sum + b.items.length, 0);
+  const userContent = `${reorgTagSection}Here are the bins to reorganize (${totalInputItems} items total):\n\n${binDescriptions}\n\nIMPORTANT: The input contains exactly ${totalInputItems} items. Your output MUST contain exactly ${totalInputItems} items total across all bins.`;
 
   if (config.aiMock) {
     await sendMockJsonStream(res, {
@@ -550,11 +575,44 @@ streamRouter.post('/reorganize/stream', ...aiRateLimiters, requireAiAccess(), ch
     return;
   }
 
-  await pipeAiStreamToResponse(res, model, {
-    system,
-    userContent,
-    ...streamOpts(settings, { temperature: 0.3, maxTokens: 16000 }),
-  });
+  // Retry up to 3 times if the AI drops or duplicates items
+  const MAX_ATTEMPTS = 3;
+  const writeEvent = initSseResponse(res);
+  const sOpts = streamOpts(settings, { temperature: 0.3, maxTokens: 16000 });
+  let finalText: string | null = null;
+  let mismatch = false;
+
+  try {
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      if (attempt > 1) writeEvent({ type: 'retry', attempt });
+
+      finalText = await streamAiToWriter(writeEvent, model, {
+        system,
+        userContent,
+        ...sOpts,
+      });
+
+      if (!finalText) break; // error or truncation — stop retrying
+
+      try {
+        const parsed = JSON.parse(finalText);
+        const outputItems = Array.isArray(parsed.bins)
+          ? parsed.bins.reduce((sum: number, b: { items?: string[] }) => sum + (b.items?.length ?? 0), 0)
+          : 0;
+        mismatch = outputItems !== totalInputItems;
+      } catch {
+        finalText = null;
+        break;
+      }
+
+      if (!mismatch) break; // counts match — done
+    }
+
+    if (finalText) writeEvent({ type: 'done', text: finalText });
+    if (mismatch) await refundAiCredit(req.user!.id);
+  } finally {
+    res.end();
+  }
 }));
 
 export { streamRouter };

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,6 +14,7 @@ import { isSelfHosted, Plan, planLabel, SubStatus, subStatusLabel } from '../lib
 import { createRefreshToken, revokeAllUserTokens, revokeSingleToken, rotateRefreshToken } from '../lib/refreshTokens.js';
 import { validateDisplayName, validateEmail, validatePassword, validateUsername } from '../lib/validation.js';
 import { authenticate, signToken } from '../middleware/auth.js';
+import { getMaintenanceMessage, isMaintenanceMode } from '../middleware/maintenance.js';
 
 import { getRegistrationMode } from './admin.js';
 
@@ -33,6 +34,23 @@ router.get('/status', async (_req, res) => {
   if (config.qrPayloadMode === 'url' && config.baseUrl) {
     body.baseUrl = config.baseUrl;
   }
+
+  // Include active announcement banner if any
+  try {
+    const announcementResult = await query<{ id: string; text: string; type: string; dismissible: number | boolean }>(
+      "SELECT id, text, type, dismissible FROM announcements WHERE active = TRUE OR active = 1 ORDER BY created_at DESC LIMIT 1",
+    );
+    if (announcementResult.rows.length > 0) {
+      const a = announcementResult.rows[0];
+      body.announcement = { id: a.id, text: a.text, type: a.type, dismissible: !!a.dismissible };
+    }
+  } catch { /* ignore — table may not exist yet */ }
+
+  // Include maintenance mode status
+  if (isMaintenanceMode()) {
+    body.maintenance = { enabled: true, message: getMaintenanceMessage() };
+  }
+
   res.json(body);
 });
 
@@ -229,9 +247,12 @@ router.post('/login', asyncHandler(async (req, res) => {
   }
 
   const result = await query(
-    'SELECT id, username, password_hash, display_name, email, avatar_path, active_location_id, deleted_at, is_admin FROM users WHERE username = $1',
+    'SELECT id, username, password_hash, display_name, email, avatar_path, active_location_id, deleted_at, suspended_at, token_version, is_admin FROM users WHERE username = $1',
     [username.toLowerCase()]
   );
+
+  const ip = req.ip || req.socket.remoteAddress || null;
+  const ua = req.headers['user-agent'] || null;
 
   if (result.rows.length === 0) {
     // Constant-time rejection — prevent timing-based username enumeration
@@ -244,14 +265,24 @@ router.post('/login', asyncHandler(async (req, res) => {
   const valid = await bcrypt.compare(password, user.password_hash);
   if (!valid) {
     log.warn(`Login failed: bad password for user "${username}"`);
+    // Record failed login
+    query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 0)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
     throw new UnauthorizedError('Invalid username or password');
   }
   if (user.deleted_at) {
     log.warn(`Login failed: deleted user "${username}"`);
     throw new UnauthorizedError('Invalid username or password');
   }
+  if (user.suspended_at) {
+    log.warn(`Login failed: suspended user "${username}"`);
+    query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 0)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
+    throw new ForbiddenError('This account has been suspended');
+  }
 
-  const token = await signToken({ id: user.id, username: user.username });
+  // Record successful login
+  query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 1)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
+
+  const token = await signToken({ id: user.id, username: user.username }, user.token_version ?? 0);
   const refresh = await createRefreshToken(user.id);
 
   setAccessTokenCookie(res, token);
@@ -314,18 +345,22 @@ router.post('/refresh', asyncHandler(async (req, res) => {
     throw new UnauthorizedError('Invalid or expired refresh token');
   }
 
-  // Look up user for new access token (reject soft-deleted users)
-  const userResult = await query<{ id: string; username: string; deleted_at: string | null }>(
-    'SELECT id, username, deleted_at FROM users WHERE id = $1',
+  // Look up user for new access token (reject soft-deleted/suspended users)
+  const userResult = await query<{ id: string; username: string; deleted_at: string | null; suspended_at: string | null; token_version: number }>(
+    'SELECT id, username, deleted_at, suspended_at, token_version FROM users WHERE id = $1',
     [rotated.userId],
   );
   if (userResult.rows.length === 0 || userResult.rows[0].deleted_at !== null) {
     clearAuthCookies(res);
     throw new UnauthorizedError('User not found');
   }
+  if (userResult.rows[0].suspended_at !== null) {
+    clearAuthCookies(res);
+    throw new ForbiddenError('This account has been suspended');
+  }
 
   const user = userResult.rows[0];
-  const accessToken = await signToken({ id: user.id, username: user.username });
+  const accessToken = await signToken({ id: user.id, username: user.username }, user.token_version ?? 0);
 
   setAccessTokenCookie(res, accessToken);
   setRefreshTokenCookie(res, rotated.rawToken);

--- a/server/src/start.ts
+++ b/server/src/start.ts
@@ -20,6 +20,9 @@ const log = createLogger('startup');
 await initialize();
 loadEmailTemplates();
 
+// Load persisted maintenance mode state
+import('./middleware/maintenance.js').then(m => m.loadMaintenanceMode()).catch(() => {});
+
 const app = createApp();
 
 if (config.disableRateLimit && process.env.NODE_ENV !== 'test') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,10 @@ const AdminUserDetailPage = lazyWithRetry(() =>
   import('@/features/admin/AdminUserDetailPage').then((m) => ({ default: m.AdminUserDetailPage }))
 );
 
+const AdminSystemPage = lazyWithRetry(() =>
+  import('@/features/admin/AdminSystemPage').then((m) => ({ default: m.AdminSystemPage }))
+);
+
 function LoadingFallback() {
   return (
     <div className="flex items-center justify-center py-20">
@@ -362,6 +366,7 @@ export default function App() {
                 <Route path="/capture" element={<RouteWithBoundary><CapturePage /></RouteWithBoundary>} />
                 <Route path="/admin/users" element={<RouteWithBoundary><AdminUsersPage /></RouteWithBoundary>} />
                 <Route path="/admin/users/:id" element={<RouteWithBoundary><AdminUserDetailPage /></RouteWithBoundary>} />
+                <Route path="/admin/system" element={<RouteWithBoundary><AdminSystemPage /></RouteWithBoundary>} />
                 <Route path="*" element={<NotFoundPage />} />
               </Route>
             </Routes>

--- a/src/features/admin/AdminSystemPage.tsx
+++ b/src/features/admin/AdminSystemPage.tsx
@@ -1,0 +1,548 @@
+import {
+  MapPin,
+  Plus,
+  Search,
+  Server,
+  ShieldAlert,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { EmptyState } from '@/components/ui/empty-state';
+import { FormField } from '@/components/ui/form-field';
+import { Input } from '@/components/ui/input';
+import { OptionGroup } from '@/components/ui/option-group';
+import { PageHeader } from '@/components/ui/page-header';
+import { Pagination } from '@/components/ui/pagination';
+import { SearchInput } from '@/components/ui/search-input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Table, TableHeader, TableRow } from '@/components/ui/table';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { useAuth } from '@/lib/auth';
+import { getErrorMessage, relativeTime } from '@/lib/utils';
+import {
+  fetchMaintenanceStatus,
+  fetchSystemHealth,
+  type MaintenanceStatus,
+  type SystemHealth,
+  toggleMaintenance,
+  useAdminLocations,
+  useAnnouncements,
+  useAuditLog,
+} from './useAdminSystem';
+
+type Tab = 'system' | 'audit' | 'locations';
+
+const PAGE_SIZE = 25;
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function HealthCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col gap-0.5 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-input)]">
+      <span className="text-[12px] text-[var(--text-tertiary)] uppercase tracking-wide">{label}</span>
+      <span className="text-[20px] font-bold text-[var(--text-primary)] leading-tight tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+// ── System Tab ──────────────────────────────────────────────────────
+
+function SystemTab() {
+  const { showToast } = useToast();
+  const [health, setHealth] = useState<SystemHealth | null>(null);
+  const [maintenance, setMaintenance] = useState<MaintenanceStatus | null>(null);
+  const [maintenanceMsg, setMaintenanceMsg] = useState('');
+  const [loadingHealth, setLoadingHealth] = useState(true);
+
+  const { announcements, isLoading: announcementsLoading, createAnnouncement, deleteAnnouncement } = useAnnouncements();
+  const [newBannerOpen, setNewBannerOpen] = useState(false);
+  const [bannerForm, setBannerForm] = useState({ text: '', type: 'info' as 'info' | 'warning' | 'critical' });
+  const [bannerSaving, setBannerSaving] = useState(false);
+
+  useEffect(() => {
+    Promise.all([fetchSystemHealth(), fetchMaintenanceStatus()])
+      .then(([h, m]) => {
+        setHealth(h);
+        setMaintenance(m);
+        setMaintenanceMsg(m.message || '');
+      })
+      .catch(() => {})
+      .finally(() => setLoadingHealth(false));
+  }, []);
+
+  const handleToggleMaintenance = useCallback(async (enabled: boolean) => {
+    try {
+      const result = await toggleMaintenance(enabled, maintenanceMsg || undefined);
+      setMaintenance(result);
+      showToast({ message: enabled ? 'Maintenance mode enabled' : 'Maintenance mode disabled', variant: 'success' });
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to toggle maintenance'), variant: 'error' });
+    }
+  }, [maintenanceMsg, showToast]);
+
+  const handleCreateBanner = useCallback(async () => {
+    if (!bannerForm.text.trim()) return;
+    setBannerSaving(true);
+    try {
+      await createAnnouncement({ text: bannerForm.text, type: bannerForm.type });
+      showToast({ message: 'Announcement created', variant: 'success' });
+      setNewBannerOpen(false);
+      setBannerForm({ text: '', type: 'info' });
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to create announcement'), variant: 'error' });
+    } finally {
+      setBannerSaving(false);
+    }
+  }, [bannerForm, createAnnouncement, showToast]);
+
+  const handleDeleteBanner = useCallback(async (id: string) => {
+    try {
+      await deleteAnnouncement(id);
+      showToast({ message: 'Announcement deleted', variant: 'success' });
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to delete announcement'), variant: 'error' });
+    }
+  }, [deleteAnnouncement, showToast]);
+
+  if (loadingHealth) {
+    return (
+      <Card>
+        <CardHeader><Skeleton className="h-5 w-28" /></CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            {Array.from({ length: 8 }, (_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+              <div key={i} className="flex flex-col gap-1.5 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-input)]">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-5 w-12" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      {/* Health */}
+      {health && (
+        <Card>
+          <CardHeader><CardTitle>System Health</CardTitle></CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+              <HealthCard label="DB Size" value={formatBytes(health.dbSizeBytes)} />
+              <HealthCard label="Total Users" value={health.userCount.total} />
+              <HealthCard label="Active Users" value={health.userCount.active} />
+              <HealthCard label="Deleted Users" value={health.userCount.deleted} />
+              <HealthCard label="Suspended Users" value={health.userCount.suspended} />
+              <HealthCard label="Active Sessions" value={health.activeSessions} />
+              <HealthCard label="Uptime" value={formatUptime(health.uptime)} />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Maintenance */}
+      <Card>
+        <CardHeader><CardTitle>Maintenance Mode</CardTitle></CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-3">
+            <div className="row-spread">
+              <div>
+                <span className="text-[14px] text-[var(--text-secondary)]">Maintenance mode</span>
+                {maintenance?.enabled && (
+                  <p className="text-[12px] text-[var(--color-warning)]">Currently active</p>
+                )}
+              </div>
+              <Switch
+                checked={maintenance?.enabled ?? false}
+                onCheckedChange={handleToggleMaintenance}
+              />
+            </div>
+            <FormField label="Message (shown to users)" htmlFor="maint-msg">
+              <Input
+                id="maint-msg"
+                value={maintenanceMsg}
+                onChange={(e) => setMaintenanceMsg(e.target.value)}
+                placeholder="We are performing scheduled maintenance..."
+                className="text-[14px]"
+              />
+            </FormField>
+            {maintenanceMsg !== (maintenance?.message || '') && (
+              <Button size="sm" className="self-start" onClick={() => handleToggleMaintenance(maintenance?.enabled ?? false)}>
+                Update Message
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Announcements */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Announcements</CardTitle>
+            <Button variant="outline" size="sm" onClick={() => setNewBannerOpen(true)}>
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              New
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {announcementsLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 2 }, (_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : announcements.length === 0 ? (
+            <p className="text-[14px] text-[var(--text-tertiary)] py-2">No active announcements.</p>
+          ) : (
+            <div className="flex flex-col divide-y divide-[var(--border-subtle)]">
+              {announcements.map((a) => (
+                <div key={a.id} className="row-spread py-2.5 first:pt-0 last:pb-0">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Badge variant={a.type === 'critical' ? 'destructive' : a.type === 'warning' ? 'outline' : 'secondary'} className="text-[11px] shrink-0">
+                      {a.type}
+                    </Badge>
+                    <span className="text-[14px] text-[var(--text-primary)] truncate">{a.text}</span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => handleDeleteBanner(a.id)}
+                    aria-label="Delete announcement"
+                    className="text-[var(--destructive)] hover:text-[var(--destructive)] shrink-0"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create announcement dialog */}
+      <Dialog open={newBannerOpen} onOpenChange={(open) => !open && setNewBannerOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Announcement</DialogTitle>
+            <DialogDescription>Create a banner announcement visible to all users.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <FormField label="Type" htmlFor="banner-type">
+              <OptionGroup
+                options={[
+                  { key: 'info' as const, label: 'Info' },
+                  { key: 'warning' as const, label: 'Warning' },
+                  { key: 'critical' as const, label: 'Critical' },
+                ]}
+                value={bannerForm.type}
+                onChange={(type) => setBannerForm(f => ({ ...f, type }))}
+                size="sm"
+              />
+            </FormField>
+            <FormField label="Message" htmlFor="banner-text">
+              <Textarea
+                id="banner-text"
+                value={bannerForm.text}
+                onChange={(e) => setBannerForm(f => ({ ...f, text: e.target.value }))}
+                placeholder="Announcement text..."
+                rows={3}
+              />
+            </FormField>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setNewBannerOpen(false)}>Cancel</Button>
+            <Button onClick={handleCreateBanner} disabled={!bannerForm.text.trim() || bannerSaving}>
+              {bannerSaving ? 'Creating...' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ── Audit Log Tab ───────────────────────────────────────────────────
+
+function AuditLogTab() {
+  const [page, setPage] = useState(1);
+  const [actionFilter, setActionFilter] = useState('');
+  const { entries, count, isLoading } = useAuditLog(page, { action: actionFilter || undefined });
+  const totalPages = Math.ceil(count / PAGE_SIZE);
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <SearchInput
+          placeholder="Filter by action..."
+          value={actionFilter}
+          onChange={(e) => { setActionFilter(e.target.value); setPage(1); }}
+          onClear={actionFilter ? () => { setActionFilter(''); setPage(1); } : undefined}
+          className="flex-1"
+        />
+      </div>
+
+      {isLoading ? (
+        <Table>
+          <TableHeader>
+            <div className="w-28"><Skeleton className="h-3 w-10" /></div>
+            <div className="w-24"><Skeleton className="h-3 w-10" /></div>
+            <div className="w-28"><Skeleton className="h-3 w-12" /></div>
+            <div className="flex-1"><Skeleton className="h-3 w-10" /></div>
+            <div className="hidden lg:block flex-1"><Skeleton className="h-3 w-12" /></div>
+          </TableHeader>
+          {Array.from({ length: 8 }, (_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+            <div key={i} className="flex items-center gap-3 px-3 py-2.5 border-b border-[var(--border-subtle)]">
+              <div className="w-28"><Skeleton className="h-4 w-20" /></div>
+              <div className="w-24"><Skeleton className="h-4 w-16" /></div>
+              <div className="w-28"><Skeleton className="h-4 w-20" /></div>
+              <div className="flex-1"><Skeleton className="h-4 w-24" /></div>
+              <div className="hidden lg:block flex-1"><Skeleton className="h-4 w-16" /></div>
+            </div>
+          ))}
+        </Table>
+      ) : entries.length === 0 ? (
+        <EmptyState
+          icon={Search}
+          title="No audit entries found"
+          subtitle={actionFilter ? 'Try a different filter' : undefined}
+          variant="search"
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <div className="w-28">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Time</span>
+            </div>
+            <div className="w-24">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Actor</span>
+            </div>
+            <div className="w-28">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Action</span>
+            </div>
+            <div className="flex-1">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Target</span>
+            </div>
+            <div className="hidden lg:block flex-1">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Details</span>
+            </div>
+          </TableHeader>
+          {entries.map((entry) => (
+            <TableRow key={entry.id} className="cursor-default [@media(hover:hover)]:hover:bg-[var(--bg-hover)]">
+              <div className="w-28">
+                <span className="text-[12px] text-[var(--text-tertiary)] whitespace-nowrap">{relativeTime(entry.createdAt)}</span>
+              </div>
+              <div className="w-24 truncate">
+                <span className="text-[14px] text-[var(--text-secondary)]">{entry.actorName}</span>
+              </div>
+              <div className="w-28">
+                <Badge variant="secondary" className="text-[11px]">{entry.action}</Badge>
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="text-[14px] text-[var(--text-primary)] truncate block">
+                  {entry.targetName || entry.targetId || '—'}
+                </span>
+                {entry.targetType && (
+                  <span className="text-[12px] text-[var(--text-tertiary)]">{entry.targetType}</span>
+                )}
+              </div>
+              <div className="hidden lg:block flex-1 min-w-0">
+                <span className="text-[12px] text-[var(--text-tertiary)] truncate block">
+                  {entry.details ? Object.entries(entry.details).map(([k, v]) => `${k}: ${v}`).join(', ') : '—'}
+                </span>
+              </div>
+            </TableRow>
+          ))}
+        </Table>
+      )}
+
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+        totalCount={count}
+        pageSize={PAGE_SIZE}
+        itemLabel="entries"
+      />
+    </>
+  );
+}
+
+// ── Locations Tab ───────────────────────────────────────────────────
+
+function LocationsTab() {
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const { locations, count, isLoading } = useAdminLocations(search, page);
+  const totalPages = Math.ceil(count / PAGE_SIZE);
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <SearchInput
+          placeholder="Search locations..."
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          onClear={search ? () => { setSearch(''); setPage(1); } : undefined}
+          className="flex-1"
+        />
+        <Badge variant="secondary" className="text-[11px]">{count}</Badge>
+      </div>
+
+      {isLoading ? (
+        <Table>
+          <TableHeader>
+            <div className="flex-1"><Skeleton className="h-3 w-12" /></div>
+            <div className="w-24"><Skeleton className="h-3 w-10" /></div>
+            <div className="hidden sm:block w-16"><Skeleton className="h-3 w-10" /></div>
+            <div className="hidden sm:block w-14"><Skeleton className="h-3 w-8" /></div>
+            <div className="hidden lg:block w-14"><Skeleton className="h-3 w-10" /></div>
+            <div className="hidden sm:block w-24"><Skeleton className="h-3 w-14" /></div>
+          </TableHeader>
+          {Array.from({ length: 8 }, (_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+            <div key={i} className="flex items-center gap-3 px-3 py-2.5 border-b border-[var(--border-subtle)]">
+              <div className="flex-1 min-w-0"><Skeleton className="h-4 w-28" /></div>
+              <div className="w-24"><Skeleton className="h-4 w-16" /></div>
+              <div className="hidden sm:block w-16"><Skeleton className="h-4 w-8" /></div>
+              <div className="hidden sm:block w-14"><Skeleton className="h-4 w-8" /></div>
+              <div className="hidden lg:block w-14"><Skeleton className="h-4 w-8" /></div>
+              <div className="hidden sm:block w-24"><Skeleton className="h-3 w-16" /></div>
+            </div>
+          ))}
+        </Table>
+      ) : locations.length === 0 ? (
+        <EmptyState
+          icon={Search}
+          title="No locations found"
+          subtitle={search ? 'Try a different search term' : undefined}
+          variant="search"
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <div className="flex-1">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Name</span>
+            </div>
+            <div className="w-24">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Owner</span>
+            </div>
+            <div className="hidden sm:block w-16">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Members</span>
+            </div>
+            <div className="hidden sm:block w-14">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Bins</span>
+            </div>
+            <div className="hidden lg:block w-14">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Areas</span>
+            </div>
+            <div className="hidden sm:block w-24">
+              <span className="text-[12px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Created</span>
+            </div>
+          </TableHeader>
+          {locations.map((loc) => (
+            <TableRow key={loc.id} className="cursor-default [@media(hover:hover)]:hover:bg-[var(--bg-hover)]">
+              <div className="flex-1 min-w-0">
+                <span className="text-[14px] font-medium text-[var(--text-primary)] truncate block">{loc.name}</span>
+              </div>
+              <div className="w-24 truncate">
+                <span className="text-[14px] text-[var(--text-secondary)]">{loc.ownerDisplayName || loc.ownerUsername}</span>
+              </div>
+              <div className="hidden sm:block w-16 text-[14px] text-[var(--text-secondary)] tabular-nums">{loc.memberCount}</div>
+              <div className="hidden sm:block w-14 text-[14px] text-[var(--text-secondary)] tabular-nums">{loc.binCount}</div>
+              <div className="hidden lg:block w-14 text-[14px] text-[var(--text-secondary)] tabular-nums">{loc.areaCount}</div>
+              <div className="hidden sm:block w-24">
+                <span className="text-[12px] text-[var(--text-tertiary)] whitespace-nowrap">{new Date(loc.createdAt).toLocaleDateString()}</span>
+              </div>
+            </TableRow>
+          ))}
+        </Table>
+      )}
+
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+        totalCount={count}
+        pageSize={PAGE_SIZE}
+        itemLabel="locations"
+      />
+    </>
+  );
+}
+
+// ── Main Page ───────────────────────────────────────────────────────
+
+export function AdminSystemPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  // Redirect non-admins
+  useEffect(() => {
+    if (user && !user.isAdmin) navigate('/', { replace: true });
+  }, [user, navigate]);
+
+  const [tab, setTab] = useState<Tab>('system');
+
+  // Prevent flash of admin content for non-admins
+  if (user && !user.isAdmin) return null;
+
+  return (
+    <div className="page-content-wide">
+      <PageHeader
+        title="System"
+        back
+        backTo="/admin/users"
+        actions={
+          <OptionGroup
+            options={[
+              { key: 'system' as const, label: 'System', icon: Server },
+              { key: 'audit' as const, label: 'Audit Log', icon: ShieldAlert },
+              { key: 'locations' as const, label: 'Locations', icon: MapPin },
+            ]}
+            value={tab}
+            onChange={setTab}
+          />
+        }
+      />
+
+      {tab === 'system' && <SystemTab />}
+      {tab === 'audit' && <AuditLogTab />}
+      {tab === 'locations' && <LocationsTab />}
+    </div>
+  );
+}

--- a/src/features/admin/AdminUserDetailPage.tsx
+++ b/src/features/admin/AdminUserDetailPage.tsx
@@ -1,7 +1,9 @@
 import {
   KeyRound,
+  LogOut,
   Mail,
   Pencil,
+  ShieldOff,
   Trash2,
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -27,7 +29,7 @@ import { useToast } from '@/components/ui/toast';
 import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
 import { cn, getErrorMessage, relativeTime } from '@/lib/utils';
-import { capitalize, deleteUser, regenerateApiKey, sendPasswordReset, statusVariant, updateUser, useAdminCount, useAdminUserDetail } from './useAdminUsers';
+import { capitalize, clearOverrides, deleteUser, fetchOverrides, grantAiCredits, reactivateUser, regenerateApiKey, resetAiCredits, revokeAllApiKeys, revokeSessions, sendPasswordReset, statusVariant, suspendUser, type UserLimitOverrides, updateOverrides, updateUser, useAdminCount, useAdminUserDetail } from './useAdminUsers';
 
 function StatItem({ label, value }: { label: string; value: string | number }) {
   return (
@@ -77,6 +79,12 @@ export function AdminUserDetailPage() {
   const [editForm, setEditForm] = useState({ email: '', displayName: '', password: '' });
   const [activeUntilInput, setActiveUntilInput] = useState('');
   const [saving, setSaving] = useState(false);
+  const [suspendOpen, setSuspendOpen] = useState(false);
+  const [revokeSessionsOpen, setRevokeSessionsOpen] = useState(false);
+  const [revokeKeysOpen, setRevokeKeysOpen] = useState(false);
+  const [overrides, setOverrides] = useState<Partial<UserLimitOverrides>>({});
+  const [savingOverrides, setSavingOverrides] = useState(false);
+  const [grantAmount, setGrantAmount] = useState('');
 
   useEffect(() => {
     if (notFound) navigate('/admin/users');
@@ -85,6 +93,12 @@ export function AdminUserDetailPage() {
   useEffect(() => {
     if (detail) setActiveUntilInput(detail.activeUntil ? detail.activeUntil.slice(0, 16) : '');
   }, [detail]);
+
+  // Load overrides when detail loads
+  useEffect(() => {
+    if (!detail || planInfo.selfHosted) return;
+    fetchOverrides(detail.id).then(o => setOverrides(o)).catch(() => {});
+  }, [detail, planInfo.selfHosted]);
 
   const handleSaveActiveUntil = useCallback(async () => {
     if (!detail) return;
@@ -208,6 +222,101 @@ export function AdminUserDetailPage() {
     }
   }, [detail, showToast]);
 
+  const handleSuspend = useCallback(async () => {
+    if (!detail) return;
+    try {
+      await suspendUser(detail.id);
+      showToast({ message: `User ${detail.username} suspended`, variant: 'success' });
+      refresh();
+      setSuspendOpen(false);
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to suspend user'), variant: 'error' });
+    }
+  }, [detail, showToast, refresh]);
+
+  const handleReactivate = useCallback(async () => {
+    if (!detail) return;
+    try {
+      await reactivateUser(detail.id);
+      showToast({ message: `User ${detail.username} reactivated`, variant: 'success' });
+      refresh();
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to reactivate user'), variant: 'error' });
+    }
+  }, [detail, showToast, refresh]);
+
+  const handleRevokeSessions = useCallback(async () => {
+    if (!detail) return;
+    try {
+      await revokeSessions(detail.id);
+      showToast({ message: 'All sessions revoked', variant: 'success' });
+      setRevokeSessionsOpen(false);
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to revoke sessions'), variant: 'error' });
+    }
+  }, [detail, showToast]);
+
+  const handleRevokeAllApiKeys = useCallback(async () => {
+    if (!detail) return;
+    try {
+      const result = await revokeAllApiKeys(detail.id);
+      showToast({ message: `${result.count} API keys revoked`, variant: 'success' });
+      setRevokeKeysOpen(false);
+      refresh();
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to revoke API keys'), variant: 'error' });
+    }
+  }, [detail, showToast, refresh]);
+
+  const handleSaveOverrides = useCallback(async () => {
+    if (!detail) return;
+    setSavingOverrides(true);
+    try {
+      await updateOverrides(detail.id, overrides);
+      showToast({ message: 'Overrides saved', variant: 'success' });
+      refresh();
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to save overrides'), variant: 'error' });
+    } finally {
+      setSavingOverrides(false);
+    }
+  }, [detail, overrides, showToast, refresh]);
+
+  const handleClearOverrides = useCallback(async () => {
+    if (!detail) return;
+    try {
+      await clearOverrides(detail.id);
+      setOverrides({});
+      showToast({ message: 'Overrides cleared', variant: 'success' });
+      refresh();
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to clear overrides'), variant: 'error' });
+    }
+  }, [detail, showToast, refresh]);
+
+  const handleGrantCredits = useCallback(async () => {
+    if (!detail || !grantAmount) return;
+    try {
+      await grantAiCredits(detail.id, Number(grantAmount));
+      showToast({ message: `${grantAmount} AI credits granted`, variant: 'success' });
+      setGrantAmount('');
+      refresh();
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to grant credits'), variant: 'error' });
+    }
+  }, [detail, grantAmount, showToast, refresh]);
+
+  const handleResetCredits = useCallback(async () => {
+    if (!detail) return;
+    try {
+      await resetAiCredits(detail.id);
+      showToast({ message: 'AI credits reset', variant: 'success' });
+      refresh();
+    } catch (err) {
+      showToast({ message: getErrorMessage(err, 'Failed to reset credits'), variant: 'error' });
+    }
+  }, [detail, showToast, refresh]);
+
   // Prevent flash of admin content for non-admins
   if (currentUser && !currentUser.isAdmin) return null;
 
@@ -268,6 +377,7 @@ export function AdminUserDetailPage() {
           <CardTitle>Identity</CardTitle>
           <div className="flex flex-wrap items-center gap-2 pt-1">
             {detail.deletedAt && <Badge variant="destructive">Deleted</Badge>}
+            {detail.suspendedAt && <Badge variant="destructive">Suspended</Badge>}
             {detail.isAdmin && <Badge variant="default">Admin</Badge>}
             <Badge variant="secondary">{capitalize(detail.plan)}</Badge>
             <Badge variant={statusVariant(detail.status)}>{capitalize(detail.status)}</Badge>
@@ -345,7 +455,7 @@ export function AdminUserDetailPage() {
           <CardTitle>Actions</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-col divide-y divide-[var(--border-flat)]">
+          <div className="flex flex-col divide-y divide-[var(--border-subtle)]">
             <div className="row-spread py-3 first:pt-0">
               <span className="text-[14px] text-[var(--text-secondary)]">Admin role</span>
               <span className={cn('flex items-center gap-1.5', adminDisabled && 'opacity-50')}>
@@ -446,6 +556,166 @@ export function AdminUserDetailPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Security */}
+      <Card>
+        <CardHeader><CardTitle>Security</CardTitle></CardHeader>
+        <CardContent>
+          <div className="flex flex-col divide-y divide-[var(--border-subtle)]">
+            {/* Suspend/Reactivate */}
+            <div className="row-spread py-3 first:pt-0">
+              <div>
+                <span className="text-[14px] text-[var(--text-secondary)]">Account status</span>
+                {detail.suspendedAt && (
+                  <p className="text-[12px] text-[var(--destructive)]">
+                    Suspended {new Date(detail.suspendedAt).toLocaleString()}
+                  </p>
+                )}
+              </div>
+              {detail.suspendedAt ? (
+                <Button variant="outline" size="sm" onClick={handleReactivate}>Reactivate</Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSuspendOpen(true)}
+                  disabled={isSelf}
+                  className="text-[var(--destructive)] hover:text-[var(--destructive)]"
+                >
+                  <ShieldOff className="h-3.5 w-3.5 mr-1.5" />
+                  Suspend
+                </Button>
+              )}
+            </div>
+
+            {/* Revoke sessions */}
+            <div className="row-spread py-3">
+              <span className="text-[14px] text-[var(--text-secondary)]">Revoke all sessions</span>
+              <Button variant="outline" size="sm" onClick={() => setRevokeSessionsOpen(true)}>
+                <LogOut className="h-3.5 w-3.5 mr-1.5" />
+                Revoke
+              </Button>
+            </div>
+
+            {/* Revoke all API keys */}
+            <div className="row-spread py-3 last:pb-0">
+              <span className="text-[14px] text-[var(--text-secondary)]">Revoke all API keys</span>
+              <Button variant="outline" size="sm" onClick={() => setRevokeKeysOpen(true)}>
+                <KeyRound className="h-3.5 w-3.5 mr-1.5" />
+                Revoke All
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Limit Overrides (cloud only) */}
+      {!planInfo.selfHosted && (
+        <Card>
+          <CardHeader><CardTitle>Limit Overrides</CardTitle></CardHeader>
+          <CardContent>
+            <p className="text-[13px] text-[var(--text-tertiary)] mb-3">
+              Override plan limits for this user. Leave blank to use plan defaults.
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <FormField label="Max Bins" htmlFor="ov-bins">
+                <Input id="ov-bins" type="number" min={0} placeholder="Plan default" value={overrides.maxBins ?? ''} onChange={(e) => setOverrides(o => ({ ...o, maxBins: e.target.value ? Number(e.target.value) : null }))} className="h-8 text-[14px]" />
+              </FormField>
+              <FormField label="Max Locations" htmlFor="ov-locs">
+                <Input id="ov-locs" type="number" min={0} placeholder="Plan default" value={overrides.maxLocations ?? ''} onChange={(e) => setOverrides(o => ({ ...o, maxLocations: e.target.value ? Number(e.target.value) : null }))} className="h-8 text-[14px]" />
+              </FormField>
+              <FormField label="Photo Storage (MB)" htmlFor="ov-storage">
+                <Input id="ov-storage" type="number" min={0} placeholder="Plan default" value={overrides.maxPhotoStorageMb ?? ''} onChange={(e) => setOverrides(o => ({ ...o, maxPhotoStorageMb: e.target.value ? Number(e.target.value) : null }))} className="h-8 text-[14px]" />
+              </FormField>
+              <FormField label="Members/Location" htmlFor="ov-members">
+                <Input id="ov-members" type="number" min={0} placeholder="Plan default" value={overrides.maxMembersPerLocation ?? ''} onChange={(e) => setOverrides(o => ({ ...o, maxMembersPerLocation: e.target.value ? Number(e.target.value) : null }))} className="h-8 text-[14px]" />
+              </FormField>
+              <FormField label="AI Credits/Month" htmlFor="ov-ai">
+                <Input id="ov-ai" type="number" min={0} placeholder="Plan default" value={overrides.aiCreditsPerMonth ?? ''} onChange={(e) => setOverrides(o => ({ ...o, aiCreditsPerMonth: e.target.value ? Number(e.target.value) : null }))} className="h-8 text-[14px]" />
+              </FormField>
+              <FormField label="Retention (days)" htmlFor="ov-retention">
+                <Input id="ov-retention" type="number" min={0} placeholder="Plan default" value={overrides.activityRetentionDays ?? ''} onChange={(e) => setOverrides(o => ({ ...o, activityRetentionDays: e.target.value ? Number(e.target.value) : null }))} className="h-8 text-[14px]" />
+              </FormField>
+            </div>
+            <div className="flex items-center gap-2 mt-4">
+              <Button size="sm" onClick={handleSaveOverrides} disabled={savingOverrides}>
+                {savingOverrides ? 'Saving...' : 'Save Overrides'}
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleClearOverrides}>Clear All</Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* AI Credits (cloud only) */}
+      {!planInfo.selfHosted && detail.stats.aiCreditsLimit > 0 && (
+        <Card>
+          <CardHeader><CardTitle>AI Credits</CardTitle></CardHeader>
+          <CardContent>
+            <div className="flex flex-col divide-y divide-[var(--border-subtle)]">
+              <div className="row-spread py-3 first:pt-0">
+                <span className="text-[14px] text-[var(--text-secondary)]">Grant credits</span>
+                <div className="flex items-center gap-2">
+                  <Input type="number" min={1} max={10000} placeholder="Amount" value={grantAmount} onChange={(e) => setGrantAmount(e.target.value)} className="w-24 h-8 text-[14px]" />
+                  <Button size="sm" onClick={handleGrantCredits} disabled={!grantAmount}>Grant</Button>
+                </div>
+              </div>
+              <div className="row-spread py-3 last:pb-0">
+                <span className="text-[14px] text-[var(--text-secondary)]">Reset credits to 0</span>
+                <Button variant="outline" size="sm" onClick={handleResetCredits}>Reset</Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Suspend confirmation dialog */}
+      <Dialog open={suspendOpen} onOpenChange={(open) => !open && setSuspendOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Suspend User</DialogTitle>
+            <DialogDescription>
+              Suspend <strong>{detail.username}</strong>? They will be immediately logged out and unable to access the app.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSuspendOpen(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleSuspend}>Suspend</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Revoke sessions confirmation */}
+      <Dialog open={revokeSessionsOpen} onOpenChange={(open) => !open && setRevokeSessionsOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke All Sessions</DialogTitle>
+            <DialogDescription>
+              This will log <strong>{detail.username}</strong> out of all devices immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRevokeSessionsOpen(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleRevokeSessions}>Revoke Sessions</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Revoke all API keys confirmation */}
+      <Dialog open={revokeKeysOpen} onOpenChange={(open) => !open && setRevokeKeysOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke All API Keys</DialogTitle>
+            <DialogDescription>
+              This will immediately invalidate all API keys for <strong>{detail.username}</strong>. Any integrations using these keys will stop working.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRevokeKeysOpen(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleRevokeAllApiKeys}>Revoke All Keys</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Delete confirmation dialog */}
       <Dialog open={deleteOpen} onOpenChange={(open) => !open && setDeleteOpen(false)}>

--- a/src/features/admin/AdminUsersPage.tsx
+++ b/src/features/admin/AdminUsersPage.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Globe, Lock, Mail, Search, UserPlus, Users } from 'lucide-react';
+import { BarChart3, Globe, Lock, Mail, Search, Settings, UserPlus, Users } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
@@ -148,6 +148,10 @@ export function AdminUsersPage() {
                 onChange={setTab}
               />
             )}
+            <Button variant="outline" size="sm" onClick={() => navigate('/admin/system')}>
+              <Settings className="h-3.5 w-3.5 mr-1.5" />
+              System
+            </Button>
             <Button variant="outline" size="sm" onClick={() => setCreateOpen(true)}>
               <UserPlus className="h-3.5 w-3.5 mr-1.5" />
               Create User

--- a/src/features/admin/AdminUsersTable.tsx
+++ b/src/features/admin/AdminUsersTable.tsx
@@ -150,7 +150,7 @@ export function AdminUsersTable({
             onClick={() => onClickUser(u.id)}
             tabIndex={0}
             onKeyDown={(e) => { if (e.key === 'Enter') onClickUser(u.id); }}
-            className={cn(u.deletedAt && 'opacity-50')}
+            className={cn((u.deletedAt || u.suspendedAt) && 'opacity-50')}
           >
             <div className="flex-1 min-w-0">
               <div className="font-medium text-[14px] text-[var(--text-primary)] truncate">{u.displayName || u.username}</div>
@@ -170,6 +170,7 @@ export function AdminUsersTable({
             <div className="w-24 text-[14px]">
               <span className="flex items-center gap-1.5">
                 {u.deletedAt && <Badge variant="destructive" className="text-[11px]">Deleted</Badge>}
+                {u.suspendedAt && <Badge variant="destructive" className="text-[11px]">Suspended</Badge>}
                 <Badge variant={statusVariant(u.status)} className="text-[11px]">{capitalize(u.status)}</Badge>
               </span>
             </div>

--- a/src/features/admin/useAdminSystem.ts
+++ b/src/features/admin/useAdminSystem.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/api';
+
+export interface AuditLogEntry {
+  id: string;
+  actorId: string;
+  actorName: string;
+  action: string;
+  targetType: string;
+  targetId: string | null;
+  targetName: string | null;
+  details: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface Announcement {
+  id: string;
+  text: string;
+  type: 'info' | 'warning' | 'critical';
+  dismissible: boolean;
+  active: boolean;
+  expiresAt: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface SystemHealth {
+  dbSizeBytes: number;
+  userCount: { total: number; active: number; deleted: number; suspended: number };
+  activeSessions: number;
+  uptime: number;
+}
+
+export interface AdminLocation {
+  id: string;
+  name: string;
+  ownerUsername: string;
+  ownerDisplayName: string;
+  memberCount: number;
+  binCount: number;
+  areaCount: number;
+  createdAt: string;
+}
+
+export interface MaintenanceStatus {
+  enabled: boolean;
+  message: string;
+}
+
+export function useAuditLog(page = 1, filters: { action?: string; actorId?: string; targetType?: string } = {}) {
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [count, setCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchEntries = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set('page', String(page));
+      if (filters.action) params.set('action', filters.action);
+      if (filters.actorId) params.set('actorId', filters.actorId);
+      if (filters.targetType) params.set('targetType', filters.targetType);
+      const data = await apiFetch<{ results: AuditLogEntry[]; count: number }>(`/api/admin/system/audit-log?${params}`);
+      setEntries(data.results);
+      setCount(data.count);
+    } catch {
+      setEntries([]);
+      setCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, filters.action, filters.actorId, filters.targetType]);
+
+  useEffect(() => { fetchEntries(); }, [fetchEntries]);
+
+  return { entries, count, isLoading, refresh: fetchEntries };
+}
+
+export function useAnnouncements() {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchAnnouncements = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await apiFetch<{ results: Announcement[]; count: number }>('/api/admin/system/announcements');
+      setAnnouncements(data.results);
+    } catch {
+      setAnnouncements([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchAnnouncements(); }, [fetchAnnouncements]);
+
+  const createAnnouncement = useCallback(async (body: { text: string; type?: string; dismissible?: boolean; expiresAt?: string }) => {
+    await apiFetch('/api/admin/system/announcements', { method: 'POST', body });
+    await fetchAnnouncements();
+  }, [fetchAnnouncements]);
+
+  const deleteAnnouncement = useCallback(async (id: string) => {
+    await apiFetch(`/api/admin/system/announcements/${id}`, { method: 'DELETE' });
+    await fetchAnnouncements();
+  }, [fetchAnnouncements]);
+
+  return { announcements, isLoading, createAnnouncement, deleteAnnouncement, refresh: fetchAnnouncements };
+}
+
+export async function fetchSystemHealth(): Promise<SystemHealth> {
+  return apiFetch<SystemHealth>('/api/admin/system/health');
+}
+
+export async function fetchMaintenanceStatus(): Promise<MaintenanceStatus> {
+  return apiFetch<MaintenanceStatus>('/api/admin/system/maintenance');
+}
+
+export async function toggleMaintenance(enabled: boolean, message?: string) {
+  return apiFetch<MaintenanceStatus>('/api/admin/system/maintenance', { method: 'POST', body: { enabled, message } });
+}
+
+export function useAdminLocations(query = '', page = 1) {
+  const [locations, setLocations] = useState<AdminLocation[]>([]);
+  const [count, setCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchLocations = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (query) params.set('q', query);
+      params.set('page', String(page));
+      const data = await apiFetch<{ results: AdminLocation[]; count: number }>(`/api/admin/system/locations?${params}`);
+      setLocations(data.results);
+      setCount(data.count);
+    } catch {
+      setLocations([]);
+      setCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [query, page]);
+
+  useEffect(() => { fetchLocations(); }, [fetchLocations]);
+
+  return { locations, count, isLoading, refresh: fetchLocations };
+}
+
+export async function forceJoinLocation(locationId: string, userId: string, role: string) {
+  await apiFetch(`/api/admin/system/locations/${locationId}/force-join`, { method: 'POST', body: { userId, role } });
+}
+
+export async function removeLocationMember(locationId: string, userId: string) {
+  await apiFetch(`/api/admin/system/locations/${locationId}/members/${userId}`, { method: 'DELETE' });
+}
+
+export async function changeLocationMemberRole(locationId: string, userId: string, role: string) {
+  await apiFetch(`/api/admin/system/locations/${locationId}/members/${userId}/role`, { method: 'PUT', body: { role } });
+}

--- a/src/features/admin/useAdminUsers.ts
+++ b/src/features/admin/useAdminUsers.ts
@@ -10,6 +10,7 @@ export interface AdminUser {
   plan: 'free' | 'plus' | 'pro';
   status: 'active' | 'inactive' | 'trial';
   activeUntil: string | null;
+  suspendedAt: string | null;
   deletedAt: string | null;
   createdAt: string;
   binCount: number;
@@ -105,6 +106,7 @@ export interface AdminUserDetail {
   plan: 'free' | 'plus' | 'pro';
   status: 'active' | 'inactive' | 'trial';
   activeUntil: string | null;
+  suspendedAt: string | null;
   deletedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -202,4 +204,76 @@ export function useAdminUserDetail(id: string) {
   }, [id]);
 
   return { detail, isLoading, notFound, refresh };
+}
+
+export interface LoginHistoryEntry {
+  id: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  method: string;
+  success: boolean;
+  createdAt: string;
+}
+
+export interface UserLimitOverrides {
+  userId: string;
+  maxBins: number | null;
+  maxLocations: number | null;
+  maxPhotoStorageMb: number | null;
+  maxMembersPerLocation: number | null;
+  activityRetentionDays: number | null;
+  aiCreditsPerMonth: number | null;
+  aiEnabled: boolean | null;
+}
+
+export async function suspendUser(id: string, reason?: string) {
+  await apiFetch(`/api/admin/security/suspend/${id}`, { method: 'POST', body: { reason } });
+}
+
+export async function reactivateUser(id: string) {
+  await apiFetch(`/api/admin/security/reactivate/${id}`, { method: 'POST' });
+}
+
+export async function revokeSessions(id: string) {
+  await apiFetch(`/api/admin/security/revoke-sessions/${id}`, { method: 'POST' });
+}
+
+export async function revokeAllApiKeys(id: string) {
+  return apiFetch<{ message: string; count: number }>(`/api/admin/security/revoke-all-api-keys/${id}`, { method: 'POST' });
+}
+
+export async function fetchLoginHistory(id: string, page = 1, limit = 50) {
+  return apiFetch<{ results: LoginHistoryEntry[]; count: number }>(`/api/admin/security/login-history/${id}?page=${page}&limit=${limit}`);
+}
+
+export async function fetchOverrides(userId: string) {
+  return apiFetch<UserLimitOverrides>(`/api/admin/overrides/overrides/${userId}`);
+}
+
+export async function updateOverrides(userId: string, overrides: Partial<UserLimitOverrides>) {
+  await apiFetch(`/api/admin/overrides/overrides/${userId}`, { method: 'PUT', body: overrides });
+}
+
+export async function clearOverrides(userId: string) {
+  await apiFetch(`/api/admin/overrides/overrides/${userId}`, { method: 'DELETE' });
+}
+
+export async function grantAiCredits(userId: string, amount: number) {
+  await apiFetch(`/api/admin/overrides/ai-credits/grant/${userId}`, { method: 'POST', body: { amount } });
+}
+
+export async function resetAiCredits(userId: string) {
+  await apiFetch(`/api/admin/overrides/ai-credits/reset/${userId}`, { method: 'POST' });
+}
+
+export async function extendTrial(userId: string, days: number) {
+  return apiFetch<{ message: string; activeUntil: string }>(`/api/admin/overrides/extend-trial/${userId}`, { method: 'POST', body: { days } });
+}
+
+export async function grantCompPlan(userId: string, plan: number, days: number) {
+  return apiFetch<{ message: string; activeUntil: string }>(`/api/admin/overrides/grant-comp/${userId}`, { method: 'POST', body: { plan, days } });
+}
+
+export async function forceDowngrade(userId: string, plan: number) {
+  await apiFetch(`/api/admin/overrides/force-downgrade/${userId}`, { method: 'POST', body: { plan } });
 }

--- a/src/features/ai/AiSettingsSection.tsx
+++ b/src/features/ai/AiSettingsSection.tsx
@@ -11,9 +11,11 @@ import { useToast } from '@/components/ui/toast';
 import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
 import { cn, getErrorMessage } from '@/lib/utils';
+import type { AiTaskGroup } from '@/types';
 import { AI_PROVIDERS, KEY_PLACEHOLDERS, MODEL_HINTS } from './aiConstants';
+import { TaskRoutingSection } from './TaskRoutingSection';
 import { useAiProviderSetup } from './useAiProviderSetup';
-import { deleteAiSettings, saveAiSettings, testAiConnection, useAiSettings } from './useAiSettings';
+import { deleteAiSettings, deleteTaskOverride, saveAiSettings, saveTaskOverride, testAiConnection, useAiSettings } from './useAiSettings';
 import { useDefaultPrompts } from './useDefaultPrompts';
 
 type PromptTab = 'analysis' | 'command' | 'query' | 'structure' | 'reorganization';
@@ -46,7 +48,7 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
   const [structurePrompt, setStructurePrompt] = useState('');
   const [reorganizationPrompt, setReorganizationPrompt] = useState('');
   const [activePromptTab, setActivePromptTab] = useState<PromptTab>('analysis');
-  const [taskModelOverrides, setTaskModelOverrides] = useState<Record<string, string>>({});
+  const [taskOverrides, setTaskOverrides] = useState<Partial<Record<AiTaskGroup, { provider: string | null; model: string | null; endpointUrl: string | null }>>>({});
   const [temperature, setTemperature] = useState<string>('');
   const [maxTokens, setMaxTokens] = useState<string>('');
   const [topP, setTopP] = useState<string>('');
@@ -66,7 +68,13 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
       setQueryPrompt(settings.queryPrompt || '');
       setStructurePrompt(settings.structurePrompt || '');
       setReorganizationPrompt(settings.reorganizationPrompt || '');
-      setTaskModelOverrides(settings.taskModelOverrides ? Object.fromEntries(Object.entries(settings.taskModelOverrides).filter(([, v]) => v)) as Record<string, string> : {});
+      setTaskOverrides(settings.taskOverrides
+        ? Object.fromEntries(
+            Object.entries(settings.taskOverrides)
+              .filter(([, v]) => v)
+              .map(([k, v]) => [k, { provider: v?.provider, model: v?.model, endpointUrl: v?.endpointUrl }])
+          )
+        : {});
       setTemperature(settings.temperature != null ? String(settings.temperature) : '');
       setMaxTokens(settings.maxTokens != null ? String(settings.maxTokens) : '');
       setTopP(settings.topP != null ? String(settings.topP) : '');
@@ -109,8 +117,22 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
         maxTokens: maxTokens ? Number(maxTokens) : null,
         topP: topP ? Number(topP) : null,
         requestTimeout: requestTimeout ? Number(requestTimeout) : null,
-        taskModelOverrides: Object.keys(taskModelOverrides).length > 0 ? taskModelOverrides : null,
       });
+
+      // Save task overrides
+      const groups: AiTaskGroup[] = ['vision', 'quickText', 'deepText'];
+      for (const group of groups) {
+        const override = taskOverrides[group];
+        const original = settings?.taskOverrides?.[group];
+        const isEnvLocked = settings?.taskOverridesEnvLocked?.includes(group);
+        if (isEnvLocked) continue;
+        if (override && (override.provider || override.model)) {
+          await saveTaskOverride(group, override);
+        } else if (original) {
+          await deleteTaskOverride(group);
+        }
+      }
+
       setSettings(saved);
       showToast({ message: 'AI settings saved', variant: 'success' });
     } catch (err) {
@@ -131,7 +153,7 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
       setQueryPrompt('');
       setStructurePrompt('');
       setReorganizationPrompt('');
-      setTaskModelOverrides({});
+      setTaskOverrides({});
       setTemperature('');
       setMaxTokens('');
       setTopP('');
@@ -243,6 +265,24 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
                   </p>
                 )}
 
+                {/* Task Routing */}
+                {settings && (
+                  <TaskRoutingSection
+                    settings={settings}
+                    overrides={taskOverrides}
+                    onChange={(group, override) => {
+                      setTaskOverrides((prev) => {
+                        if (!override) {
+                          const { [group]: _, ...rest } = prev;
+                          return rest;
+                        }
+                        return { ...prev, [group]: override };
+                      });
+                    }}
+                    disabled={demoMode}
+                  />
+                )}
+
                 {/* Custom Prompts */}
                 {(() => {
                   const promptMap = {
@@ -314,38 +354,6 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
                               Load default to customize
                             </button>
                           ))}
-                        </div>
-                        <div className="space-y-1.5 pt-1">
-                          <label htmlFor={`model-override-${activePromptTab}`} className="text-[13px] text-[var(--text-secondary)]">Model override</label>
-                          <div className="relative">
-                            <Input
-                              id={`model-override-${activePromptTab}`}
-                              value={taskModelOverrides[activePromptTab] ?? ''}
-                              onChange={(e) => {
-                                const val = e.target.value;
-                                setTaskModelOverrides((prev) => {
-                                  if (!val) {
-                                    const { [activePromptTab]: _, ...rest } = prev;
-                                    return rest;
-                                  }
-                                  return { ...prev, [activePromptTab]: val };
-                                });
-                              }}
-                              placeholder={setup.model || 'Default model'}
-                              disabled={demoMode}
-                              className={taskModelOverrides[activePromptTab] ? 'pr-8' : undefined}
-                            />
-                            {taskModelOverrides[activePromptTab] && !demoMode && (
-                              <button
-                                type="button"
-                                onClick={() => setTaskModelOverrides(({ [activePromptTab]: _, ...rest }) => rest)}
-                                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
-                              >
-                                <RotateCcw className="h-3 w-3" />
-                              </button>
-                            )}
-                          </div>
-                          <p className="text-[11px] text-[var(--text-tertiary)]">Leave empty to use default model{setup.model ? ` (${setup.model})` : ''}</p>
                         </div>
                       </div>
                     </Disclosure>

--- a/src/features/ai/AiSettingsSection.tsx
+++ b/src/features/ai/AiSettingsSection.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
 import { cn, getErrorMessage } from '@/lib/utils';
 import type { AiTaskGroup } from '@/types';
-import { AI_PROVIDERS, KEY_PLACEHOLDERS, MODEL_HINTS } from './aiConstants';
+import { AI_PROVIDERS, KEY_PLACEHOLDERS, MODEL_HINTS, TASK_GROUP_META } from './aiConstants';
 import { TaskRoutingSection } from './TaskRoutingSection';
 import { useAiProviderSetup } from './useAiProviderSetup';
 import { deleteAiSettings, deleteTaskOverride, saveAiSettings, saveTaskOverride, testAiConnection, useAiSettings } from './useAiSettings';
@@ -119,19 +119,18 @@ export function AiSettingsSection({ aiEnabled, onToggle }: AiSettingsSectionProp
         requestTimeout: requestTimeout ? Number(requestTimeout) : null,
       });
 
-      // Save task overrides
-      const groups: AiTaskGroup[] = ['vision', 'quickText', 'deepText'];
-      for (const group of groups) {
-        const override = taskOverrides[group];
-        const original = settings?.taskOverrides?.[group];
-        const isEnvLocked = settings?.taskOverridesEnvLocked?.includes(group);
-        if (isEnvLocked) continue;
-        if (override && (override.provider || override.model)) {
-          await saveTaskOverride(group, override);
-        } else if (original) {
-          await deleteTaskOverride(group);
-        }
-      }
+      // Save task overrides in parallel
+      const overrideOps = TASK_GROUP_META.map((g) => g.key)
+        .filter((group) => !settings?.taskOverridesEnvLocked?.includes(group))
+        .map((group) => {
+          const override = taskOverrides[group];
+          const original = settings?.taskOverrides?.[group];
+          if (override && (override.provider || override.model)) return saveTaskOverride(group, override);
+          if (original) return deleteTaskOverride(group);
+          return null;
+        })
+        .filter(Boolean);
+      if (overrideOps.length > 0) await Promise.all(overrideOps);
 
       setSettings(saved);
       showToast({ message: 'AI settings saved', variant: 'success' });

--- a/src/features/ai/TaskRoutingSection.tsx
+++ b/src/features/ai/TaskRoutingSection.tsx
@@ -1,0 +1,142 @@
+import { RotateCcw } from 'lucide-react';
+import { Disclosure } from '@/components/ui/disclosure';
+import { Input } from '@/components/ui/input';
+import { cn, inputBase } from '@/lib/utils';
+import type { AiProvider, AiSettings, AiTaskGroup } from '@/types';
+import { AI_PROVIDERS, MODEL_HINTS, TASK_GROUP_META } from './aiConstants';
+
+interface TaskRoutingSectionProps {
+  settings: AiSettings;
+  overrides: Partial<Record<AiTaskGroup, { provider: string | null; model: string | null; endpointUrl: string | null }>>;
+  onChange: (group: AiTaskGroup, override: { provider: string | null; model: string | null; endpointUrl: string | null } | null) => void;
+  disabled?: boolean;
+}
+
+export function TaskRoutingSection({ settings, overrides, onChange, disabled }: TaskRoutingSectionProps) {
+  const envLocked = settings.taskOverridesEnvLocked ?? [];
+  const hasAnyOverride = Object.values(overrides).some((o) => o && (o.provider || o.model));
+
+  const configuredProviders = settings.providerConfigs
+    ? Object.keys(settings.providerConfigs) as AiProvider[]
+    : [settings.provider];
+
+  return (
+    <Disclosure label="Task Routing" indicator={hasAnyOverride}>
+      <div className="flex flex-col">
+        {TASK_GROUP_META.map((group, i) => {
+          const isLocked = envLocked.includes(group.key);
+          const envOverride = settings.taskOverrides?.[group.key];
+          const override = isLocked ? envOverride : overrides[group.key];
+          const hasOverride = !!(override?.provider || override?.model);
+          const selectedProvider = override?.provider || '';
+          const selectedModel = override?.model || '';
+          const selectedEndpoint = override?.endpointUrl || '';
+
+          return (
+            <div key={group.key}>
+              {i > 0 && <div className="border-t border-[var(--border-subtle)] my-3" />}
+              <div className="space-y-2">
+                <div>
+                  <span className="text-[13px] font-medium text-[var(--text-primary)]">{group.label}</span>
+                  <span className="text-[11px] text-[var(--text-tertiary)] ml-1.5">{group.description}</span>
+                </div>
+
+                {isLocked && (
+                  <div className="px-3 py-2 rounded-[var(--radius-sm)] bg-[var(--accent)]/10 border border-[var(--accent)]/20">
+                    <p className="text-[12px] text-[var(--text-secondary)]">
+                      Configured by server
+                      {envOverride?.provider && ` \u2014 ${envOverride.provider}`}
+                      {envOverride?.model && ` / ${envOverride.model}`}
+                    </p>
+                  </div>
+                )}
+
+                {!isLocked && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <label htmlFor={`task-provider-${group.key}`} className="text-[12px] text-[var(--text-tertiary)]">Provider</label>
+                      <select
+                        id={`task-provider-${group.key}`}
+                        value={selectedProvider}
+                        onChange={(e) => {
+                          const provider = e.target.value || null;
+                          onChange(group.key, {
+                            provider,
+                            model: provider ? selectedModel : null,
+                            endpointUrl: provider === 'openai-compatible' ? selectedEndpoint : null,
+                          });
+                        }}
+                        disabled={disabled}
+                        className={cn(inputBase, 'text-[13px]')}
+                      >
+                        <option value="">Default ({AI_PROVIDERS.find((p) => p.key === settings.provider)?.label ?? settings.provider})</option>
+                        {configuredProviders.map((p) => (
+                          <option key={p} value={p}>
+                            {AI_PROVIDERS.find((ap) => ap.key === p)?.label ?? p}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <label htmlFor={`task-model-${group.key}`} className="text-[12px] text-[var(--text-tertiary)]">Model</label>
+                      <Input
+                        id={`task-model-${group.key}`}
+                        value={selectedModel}
+                        onChange={(e) => {
+                          onChange(group.key, {
+                            provider: selectedProvider || null,
+                            model: e.target.value || null,
+                            endpointUrl: selectedEndpoint || null,
+                          });
+                        }}
+                        placeholder={
+                          selectedProvider
+                            ? (MODEL_HINTS[selectedProvider as AiProvider] ?? '')
+                            : settings.model
+                        }
+                        disabled={disabled}
+                        className="text-[13px]"
+                      />
+                    </div>
+
+                    {hasOverride && !disabled && (
+                      <button
+                        type="button"
+                        onClick={() => onChange(group.key, null)}
+                        className="self-end sm:self-center p-1.5 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+                        title="Reset to default"
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {!isLocked && selectedProvider === 'openai-compatible' && (
+                  <div className="space-y-1">
+                    <label htmlFor={`task-endpoint-${group.key}`} className="text-[12px] text-[var(--text-tertiary)]">Endpoint URL</label>
+                    <Input
+                      id={`task-endpoint-${group.key}`}
+                      value={selectedEndpoint}
+                      onChange={(e) => {
+                        onChange(group.key, {
+                          provider: selectedProvider,
+                          model: selectedModel || null,
+                          endpointUrl: e.target.value || null,
+                        });
+                      }}
+                      placeholder="http://localhost:11434/v1"
+                      disabled={disabled}
+                      className="text-[13px]"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Disclosure>
+  );
+}

--- a/src/features/ai/aiConstants.ts
+++ b/src/features/ai/aiConstants.ts
@@ -1,4 +1,4 @@
-import type { AiProvider } from '@/types';
+import type { AiProvider, AiTaskGroup } from '@/types';
 
 export const AI_PROVIDERS: { key: AiProvider; label: string }[] = [
   { key: 'openai', label: 'OpenAI' },
@@ -27,3 +27,9 @@ export const KEY_PLACEHOLDERS: Record<AiProvider, string> = {
   gemini: 'AIza...',
   'openai-compatible': 'API key (if required)',
 };
+
+export const TASK_GROUP_META: { key: AiTaskGroup; label: string; description: string }[] = [
+  { key: 'vision', label: 'Vision', description: 'Photo Scan' },
+  { key: 'quickText', label: 'Quick Text', description: 'Commands, Text Extraction' },
+  { key: 'deepText', label: 'Deep Text', description: 'Queries, Reorganize' },
+];

--- a/src/features/ai/useAiSettings.ts
+++ b/src/features/ai/useAiSettings.ts
@@ -99,3 +99,19 @@ export async function testAiConnection(opts: {
     body: opts,
   });
 }
+
+export async function saveTaskOverride(
+  taskGroup: string,
+  override: { provider?: string | null; model?: string | null; endpointUrl?: string | null },
+): Promise<void> {
+  await apiFetch(`/api/ai/task-overrides/${taskGroup}`, {
+    method: 'PUT',
+    body: override,
+  });
+  notifyAiSettingsChanged();
+}
+
+export async function deleteTaskOverride(taskGroup: string): Promise<void> {
+  await apiFetch(`/api/ai/task-overrides/${taskGroup}`, { method: 'DELETE' });
+  notifyAiSettingsChanged();
+}

--- a/src/features/ai/useAiSettings.ts
+++ b/src/features/ai/useAiSettings.ts
@@ -73,7 +73,6 @@ export async function saveAiSettings(opts: {
   maxTokens?: number | null;
   topP?: number | null;
   requestTimeout?: number | null;
-  taskModelOverrides?: Partial<Record<string, string>> | null;
 }): Promise<AiSettings> {
   const result = await apiFetch<AiSettings>('/api/ai/settings', {
     method: 'PUT',

--- a/src/features/ai/useAiSettings.ts
+++ b/src/features/ai/useAiSettings.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/api';
 import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
-import type { AiProvider, AiSettings } from '@/types';
+import type { AiProvider, AiSettings, AiTaskGroup } from '@/types';
 
 export function useAiSettings() {
   const { token } = useAuth();
@@ -100,7 +100,7 @@ export async function testAiConnection(opts: {
 }
 
 export async function saveTaskOverride(
-  taskGroup: string,
+  taskGroup: AiTaskGroup,
   override: { provider?: string | null; model?: string | null; endpointUrl?: string | null },
 ): Promise<void> {
   await apiFetch(`/api/ai/task-overrides/${taskGroup}`, {
@@ -110,7 +110,7 @@ export async function saveTaskOverride(
   notifyAiSettingsChanged();
 }
 
-export async function deleteTaskOverride(taskGroup: string): Promise<void> {
+export async function deleteTaskOverride(taskGroup: AiTaskGroup): Promise<void> {
   await apiFetch(`/api/ai/task-overrides/${taskGroup}`, { method: 'DELETE' });
   notifyAiSettingsChanged();
 }

--- a/src/features/ai/useAiStream.ts
+++ b/src/features/ai/useAiStream.ts
@@ -18,6 +18,7 @@ export function useAiStream<T>(
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [partialText, setPartialText] = useState('');
+  const [retryCount, setRetryCount] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
 
   const stream = useCallback(async (body: object): Promise<T | null> => {
@@ -29,6 +30,7 @@ export function useAiStream<T>(
     setError(null);
     setResult(null);
     setPartialText('');
+    setRetryCount(0);
 
     try {
       for await (const event of apiStream(endpoint, {
@@ -39,10 +41,7 @@ export function useAiStream<T>(
           setPartialText(prev => prev + event.text);
         } else if (event.type === 'done') {
           try {
-            // Strip markdown code block wrappers if present
-            let text = event.text.trim();
-            const fenced = text.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
-            if (fenced) text = fenced[1].trim();
+            const text = event.text.trim();
             if (!text) {
               setError(`${errorFallback} — empty response from AI`);
               return null;
@@ -54,6 +53,9 @@ export function useAiStream<T>(
           } catch {
             setError(`${errorFallback} — unexpected response format`);
           }
+        } else if (event.type === 'retry') {
+          setPartialText('');
+          setRetryCount(c => c + 1);
         } else if (event.type === 'error') {
           setError(event.message);
         }
@@ -77,5 +79,5 @@ export function useAiStream<T>(
     setPartialText('');
   }, []);
 
-  return { result, isStreaming, error, partialText, stream, cancel, clear };
+  return { result, isStreaming, error, partialText, retryCount, stream, cancel, clear };
 }

--- a/src/features/reorganize/ReorganizePage.tsx
+++ b/src/features/reorganize/ReorganizePage.tsx
@@ -75,6 +75,7 @@ export function ReorganizePage() {
     error,
     applyError,
     isApplying,
+    retryCount,
     startReorg,
     apply,
     cancel,
@@ -464,7 +465,7 @@ export function ReorganizePage() {
                 <AiProgressBar
                   active={isStreaming}
                   complete={progressComplete}
-                  label={isStreaming ? `Reorganizing ${t.bins}` : 'Complete'}
+                  label={isStreaming ? (retryCount > 0 ? `Retrying (attempt ${retryCount + 1} of 3)` : `Reorganizing ${t.bins}`) : 'Complete'}
                 />
                 {isStreaming && (
                   <div className="flex justify-end mt-3">
@@ -486,6 +487,7 @@ export function ReorganizePage() {
                   isStreaming={isStreaming}
                   isApplying={isApplying}
                   originalCount={selection.selectedIds.size}
+                  originalItemCount={itemCount}
                   onAccept={() => setConfirmOpen(true)}
                   onCancel={handleCancel}
                   onRegenerate={handleRegenerate}

--- a/src/features/reorganize/ReorganizePreview.tsx
+++ b/src/features/reorganize/ReorganizePreview.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Loader2, Package, RefreshCw } from 'lucide-react';
+import { AlertTriangle, ChevronDown, Loader2, Package, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -16,6 +16,7 @@ interface ReorganizePreviewProps {
   isStreaming: boolean;
   isApplying: boolean;
   originalCount: number;
+  originalItemCount: number;
   onAccept: () => void;
   onCancel: () => void;
   onRegenerate?: () => void;
@@ -27,6 +28,7 @@ export function ReorganizePreview({
   isStreaming,
   isApplying,
   originalCount,
+  originalItemCount,
   onAccept,
   onCancel,
   onRegenerate,
@@ -38,6 +40,7 @@ export function ReorganizePreview({
   if (displayBins.length === 0 && !isStreaming) return null;
 
   const totalItems = displayBins.reduce((sum, b) => sum + b.items.length, 0);
+  const itemMismatch = !isStreaming && result && totalItems !== originalItemCount;
 
   return (
     <div className="space-y-4">
@@ -52,6 +55,19 @@ export function ReorganizePreview({
 
       {summary && (
         <p className="text-[13px] text-[var(--text-secondary)] leading-relaxed">{summary}</p>
+      )}
+
+      {itemMismatch && (
+        <div role="alert" className="flex items-start gap-2.5 rounded-[var(--radius-sm)] bg-[var(--destructive-soft)] px-3 py-2.5">
+          <AlertTriangle className="h-4 w-4 text-[var(--destructive)] shrink-0 mt-0.5" />
+          <p className="text-[13px] text-[var(--text-secondary)]">
+            Item count mismatch: expected {originalItemCount}, got {totalItems}.
+            {totalItems < originalItemCount
+              ? ` ${originalItemCount - totalItems} item${originalItemCount - totalItems !== 1 ? 's' : ''} may have been dropped.`
+              : ` ${totalItems - originalItemCount} extra item${totalItems - originalItemCount !== 1 ? 's' : ''} added.`}
+            {' '}Try regenerating. This attempt did not count against your AI credits.
+          </p>
+        </div>
       )}
 
       <ul className="grid gap-3 sm:grid-cols-2" aria-label="Proposed bins">

--- a/src/features/reorganize/useReorganize.ts
+++ b/src/features/reorganize/useReorganize.ts
@@ -25,7 +25,7 @@ export interface ReorgOptions {
 
 export function useReorganize() {
   const { activeLocationId } = useAuth();
-  const { result, isStreaming, error, partialText, stream, cancel, clear } =
+  const { result, isStreaming, error, partialText, retryCount, stream, cancel, clear } =
     useAiStream<ReorgResponse>('/api/ai/reorganize/stream', 'Failed to generate reorganization');
   const [isApplying, setIsApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
@@ -93,6 +93,7 @@ export function useReorganize() {
     error,
     applyError,
     isApplying,
+    retryCount,
     startReorg,
     apply,
     cancel,

--- a/src/lib/apiStream.ts
+++ b/src/lib/apiStream.ts
@@ -17,7 +17,12 @@ export interface StreamErrorEvent {
   code: string;
 }
 
-export type StreamEvent = StreamDeltaEvent | StreamDoneEvent | StreamErrorEvent;
+export interface StreamRetryEvent {
+  type: 'retry';
+  attempt: number;
+}
+
+export type StreamEvent = StreamDeltaEvent | StreamDoneEvent | StreamErrorEvent | StreamRetryEvent;
 
 /**
  * Consume a server-sent event stream from an AI streaming endpoint.

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,7 +233,6 @@ export interface AiSettings {
   maxTokens: number | null;
   topP: number | null;
   requestTimeout: number | null;
-  taskModelOverrides?: Partial<Record<string, string>> | null;
   providerConfigs?: Partial<Record<AiProvider, {
     apiKey: string;
     model: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,15 @@ export type ExportData = ExportDataV2;
 
 export type AiProvider = 'openai' | 'anthropic' | 'gemini' | 'openai-compatible';
 
+export type AiTaskGroup = 'vision' | 'quickText' | 'deepText';
+
+export interface AiTaskOverride {
+  provider: AiProvider | null;
+  model: string | null;
+  endpointUrl: string | null;
+  source: 'env' | 'user';
+}
+
 export interface AiSettings {
   id: string;
   provider: AiProvider;
@@ -231,6 +240,8 @@ export interface AiSettings {
     endpointUrl: string | null;
   }>>;
   source?: 'user' | 'env';
+  taskOverrides?: Partial<Record<AiTaskGroup, AiTaskOverride | null>>;
+  taskOverridesEnvLocked?: AiTaskGroup[];
 }
 
 export interface ApiKey {


### PR DESCRIPTION
## Summary

- **Task routing**: Per-group (vision/quickText/deepText) AI provider+model overrides with a 4-layer cascade (env → admin → user → default). New `user_ai_task_overrides` table, CRUD endpoints, and UI section in AI settings.
- **Intent classification & context budgeting**: Classifies AI chat intents (query/command/describe/reorganize) and budgets context tokens accordingly. Adds retry loop for reorganize streaming.
- **Global admin panel**: Security controls (registration mode, maintenance mode, session management), per-user plan/subscription overrides, system stats, and audit log. Protected by `isAdmin` flag with constant-time comparison.
- **CI**: Docker image now builds on every push to main with `edge` and SHA tags.
- **Refactors**: Eliminated duplicate DB queries in AI handlers, parallelized saves, removed legacy `taskModelOverrides`.

## Test plan

- [ ] Verify task routing cascade: env var overrides take precedence, then admin, then user settings
- [ ] Test CRUD for task overrides via AI settings UI
- [ ] Confirm intent classification routes to correct handler
- [ ] Test admin panel: user overrides, security controls, maintenance mode toggle
- [ ] Run `server/src/__tests__/taskRouting.test.ts`
- [ ] Verify Docker build with `edge` tag on push to main