### PR TITLE
ci(akifbayram-openbin): add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@1c30734416d9b05948ccd7f4b3cf60baada87e9e
+        with:
+          mode: validate


### PR DESCRIPTION
This adds a lightweight metadata validation workflow to the package.

- MCP server exposing inventory tools via Model Context Protocol  
- Express server on port 1453
- Alpine container running as non-root node user

This PR adds one workflow under `.github/workflows/` that runs the HOL skill validator in validate-only mode. It checks schema and trust signals without publishing and leaves the runtime code untouched.

Let me know if you'd prefer a different workflow filename or location.