### PR TITLE
feat: use email as primary identity instead of username

### DIFF
--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -129,8 +129,6 @@ components:
         id:
           type: string
           format: uuid
-        username:
-          type: string
         displayName:
           type: string
         email:
@@ -161,10 +159,11 @@ components:
 
     LoginRequest:
       type: object
-      required: [username, password]
+      required: [email, password]
       properties:
-        username:
+        email:
           type: string
+          format: email
         password:
           type: string
 
@@ -180,12 +179,11 @@ components:
 
     RegisterRequest:
       type: object
-      required: [username, password, displayName]
+      required: [email, password, displayName]
       properties:
-        username:
+        email:
           type: string
-          minLength: 3
-          maxLength: 50
+          format: email
         password:
           type: string
           minLength: 8
@@ -355,8 +353,6 @@ components:
           type: string
           format: date-time
         display_name:
-          type: string
-        username:
           type: string
 
     CreateLocationRequest:
@@ -1670,14 +1666,14 @@ paths:
                 error: FORBIDDEN
                 message: Registration is currently disabled
         '409':
-          description: Username already taken
+          description: Email already registered
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: CONFLICT
-                message: Username already taken
+                message: Email already registered
         '422':
           $ref: '#/components/responses/ValidationError'
         '429':
@@ -1686,7 +1682,7 @@ paths:
   /auth/login:
     post:
       tags: [Auth]
-      summary: Log in with username and password
+      summary: Log in with email and password
       description: Returns JWT token and user info. Rate limited to 5 per 15 minutes.
       security: []
       requestBody:
@@ -1710,7 +1706,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: UNAUTHORIZED
-                message: Invalid username or password
+                message: Invalid email or password
         '429':
           $ref: '#/components/responses/RateLimited'
 

--- a/server/schema.pg.sql
+++ b/server/schema.pg.sql
@@ -1,9 +1,8 @@
 CREATE TABLE IF NOT EXISTS users (
   id                 TEXT PRIMARY KEY,
-  username           TEXT UNIQUE NOT NULL,
   password_hash      TEXT,
-  display_name       TEXT NOT NULL DEFAULT '',
-  email              TEXT,
+  display_name       TEXT NOT NULL,
+  email              TEXT UNIQUE NOT NULL,
   avatar_path        TEXT,
   active_location_id TEXT,
   plan               INTEGER NOT NULL DEFAULT 1,

--- a/server/schema.sqlite.sql
+++ b/server/schema.sqlite.sql
@@ -1,9 +1,8 @@
 CREATE TABLE IF NOT EXISTS users (
   id                 TEXT PRIMARY KEY,
-  username           TEXT UNIQUE NOT NULL,
   password_hash      TEXT,
-  display_name       TEXT NOT NULL DEFAULT '',
-  email              TEXT,
+  display_name       TEXT NOT NULL,
+  email              TEXT UNIQUE NOT NULL,
   avatar_path        TEXT,
   active_location_id TEXT REFERENCES locations(id) ON DELETE SET NULL,
   plan               INTEGER NOT NULL DEFAULT 1,

--- a/server/scripts/reset-password.ts
+++ b/server/scripts/reset-password.ts
@@ -1,33 +1,33 @@
 #!/usr/bin/env node
-// Usage: npx tsx scripts/reset-password.ts <username>
+// Usage: npx tsx scripts/reset-password.ts <email>
 // Generates a one-time password reset token for the given user.
-// Run inside Docker: docker exec openbin npx tsx scripts/reset-password.ts <username>
+// Run inside Docker: docker exec openbin npx tsx scripts/reset-password.ts <email>
 
 import { query } from '../src/db.js';
 import { createPasswordResetToken } from '../src/lib/passwordReset.js';
 
 async function main() {
-  const username = process.argv[2];
+  const email = process.argv[2];
 
-  if (!username) {
-    console.error('Usage: npx tsx scripts/reset-password.ts <username>');
+  if (!email) {
+    console.error('Usage: npx tsx scripts/reset-password.ts <email>');
     process.exit(1);
   }
 
-  const result = await query<{ id: string; username: string }>(
-    'SELECT id, username FROM users WHERE username = $1',
-    [username.toLowerCase()],
+  const result = await query<{ id: string; email: string }>(
+    'SELECT id, email FROM users WHERE email = $1',
+    [email.toLowerCase()],
   );
 
   if (result.rows.length === 0) {
-    console.error(`Error: User "${username}" not found.`);
+    console.error(`Error: User "${email}" not found.`);
     process.exit(1);
   }
 
   const user = result.rows[0];
   const { rawToken, expiresAt } = await createPasswordResetToken(user.id, null);
 
-  console.log(`\nPassword reset token generated for "${user.username}".\n`);
+  console.log(`\nPassword reset token generated for "${user.email}".\n`);
   console.log(`Token: ${rawToken}`);
   console.log(`Expires: ${expiresAt}\n`);
   console.log(`Give the user this link:`);

--- a/server/src/__tests__/admin.test.ts
+++ b/server/src/__tests__/admin.test.ts
@@ -42,16 +42,17 @@ describe('GET /api/admin/users', () => {
   it('filters by search query', async () => {
     const { token, user } = await createTestUser(app);
     makeAdmin(user.id);
-    const { user: other } = await createTestUser(app, { username: `searchable_${Date.now()}` });
+    const searchEmail = `searchable_${Date.now()}@test.local`;
+    const { user: other } = await createTestUser(app, { email: searchEmail });
 
     const res = await request(app)
       .get('/api/admin/users')
-      .query({ q: other.username })
+      .query({ q: searchEmail })
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(200);
     expect(res.body.results.length).toBe(1);
-    expect(res.body.results[0].username).toBe(other.username);
+    expect(res.body.results[0].email).toBe(other.email);
   });
 });
 
@@ -63,21 +64,21 @@ describe('POST /api/admin/users', () => {
     const res = await request(app)
       .post('/api/admin/users')
       .set('Authorization', `Bearer ${token}`)
-      .send({ username: `newuser_${Date.now()}`, password: 'StrongPass1!', displayName: 'New User' });
+      .send({ email: `newuser_${Date.now()}@test.local`, password: 'StrongPass1!', displayName: 'New User' });
 
     expect(res.status).toBe(201);
-    expect(res.body.username).toBeDefined();
+    expect(res.body.email).toBeDefined();
     expect(res.body.displayName).toBe('New User');
   });
 
-  it('rejects duplicate username (409)', async () => {
+  it('rejects duplicate email (409)', async () => {
     const { token, user } = await createTestUser(app);
     makeAdmin(user.id);
 
     const res = await request(app)
       .post('/api/admin/users')
       .set('Authorization', `Bearer ${token}`)
-      .send({ username: user.username, password: 'StrongPass1!' });
+      .send({ email: user.email, password: 'StrongPass1!', displayName: 'Duplicate' });
 
     expect(res.status).toBe(409);
   });
@@ -89,7 +90,7 @@ describe('POST /api/admin/users', () => {
     const res = await request(app)
       .post('/api/admin/users')
       .set('Authorization', `Bearer ${token}`)
-      .send({ username: `weakpw_${Date.now()}`, password: '123' });
+      .send({ email: `weakpw_${Date.now()}@test.local`, password: '123', displayName: 'Weak PW' });
 
     expect(res.status).toBe(422);
   });
@@ -195,7 +196,7 @@ describe('PUT /api/admin/users/:id', () => {
     // Verify new password works
     const loginRes = await request(app)
       .post('/api/auth/login')
-      .send({ username: target.username, password: 'NewStrongPass1!' });
+      .send({ email: target.email, password: 'NewStrongPass1!' });
     expect(loginRes.status).toBe(200);
   });
 

--- a/server/src/__tests__/adminSecurity.test.ts
+++ b/server/src/__tests__/adminSecurity.test.ts
@@ -14,7 +14,7 @@ describe('POST /api/admin/security/force-password-change/:id', () => {
   it('sets force_password_change flag on a user', async () => {
     const { token, user } = await createTestUser(app);
     makeAdmin(user.id);
-    const { user: target } = await createTestUser(app, { username: `target_${Date.now()}` });
+    const { user: target } = await createTestUser(app, { email: `target_${Date.now()}@test.local` });
 
     const res = await request(app)
       .post(`/api/admin/security/force-password-change/${target.id}`)
@@ -31,7 +31,7 @@ describe('POST /api/admin/security/force-password-change/:id', () => {
   it('clears force_password_change flag when enabled is false', async () => {
     const { token, user } = await createTestUser(app);
     makeAdmin(user.id);
-    const { user: target } = await createTestUser(app, { username: `target2_${Date.now()}` });
+    const { user: target } = await createTestUser(app, { email: `target2_${Date.now()}@test.local` });
 
     const db = getDb();
     db.prepare('UPDATE users SET force_password_change = 1 WHERE id = ?').run(target.id);
@@ -60,7 +60,7 @@ describe('POST /api/admin/security/force-password-change/:id', () => {
   it('logs an audit entry', async () => {
     const { token, user } = await createTestUser(app);
     makeAdmin(user.id);
-    const { user: target } = await createTestUser(app, { username: `audit_target_${Date.now()}` });
+    const { user: target } = await createTestUser(app, { email: `audit_target_${Date.now()}@test.local` });
 
     await request(app)
       .post(`/api/admin/security/force-password-change/${target.id}`)
@@ -76,14 +76,15 @@ describe('POST /api/admin/security/force-password-change/:id', () => {
 describe('Login rejects users with force_password_change', () => {
   it('returns FORCE_PASSWORD_CHANGE error code on login', async () => {
     const password = 'TestPass123!';
-    const { user } = await createTestUser(app, { username: `fpc_user_${Date.now()}`, password });
+    const email = `fpc_user_${Date.now()}@test.local`;
+    const { user } = await createTestUser(app, { email, password });
 
     const db = getDb();
     db.prepare('UPDATE users SET force_password_change = 1 WHERE id = ?').run(user.id);
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: user.username, password });
+      .send({ email, password });
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('FORCE_PASSWORD_CHANGE');
@@ -91,7 +92,8 @@ describe('Login rejects users with force_password_change', () => {
 
   it('allows login after password is changed', async () => {
     const password = 'TestPass123!';
-    const { user } = await createTestUser(app, { username: `fpc_clear_${Date.now()}`, password });
+    const email = `fpc_clear_${Date.now()}@test.local`;
+    const { user } = await createTestUser(app, { email, password });
 
     const db = getDb();
     db.prepare('UPDATE users SET force_password_change = 1 WHERE id = ?').run(user.id);
@@ -99,7 +101,7 @@ describe('Login rejects users with force_password_change', () => {
     // Should fail
     const failRes = await request(app)
       .post('/api/auth/login')
-      .send({ username: user.username, password });
+      .send({ email, password });
     expect(failRes.status).toBe(403);
 
     // Clear the flag (simulating password change)
@@ -108,7 +110,7 @@ describe('Login rejects users with force_password_change', () => {
     // Should succeed
     const successRes = await request(app)
       .post('/api/auth/login')
-      .send({ username: user.username, password });
+      .send({ email, password });
     expect(successRes.status).toBe(200);
   });
 });
@@ -119,7 +121,7 @@ describe('POST /api/admin/security/force-logout-all', () => {
     makeAdmin(user.id);
 
     // Create a second user
-    const { user: other } = await createTestUser(app, { username: `other_${Date.now()}` });
+    const { user: other } = await createTestUser(app, { email: `other_${Date.now()}@test.local` });
 
     // Verify initial token_version is 0
     const db = getDb();

--- a/server/src/__tests__/auth.test.ts
+++ b/server/src/__tests__/auth.test.ts
@@ -35,41 +35,41 @@ describe('POST /api/auth/register', () => {
   it('registers a new user', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'newuser', password: 'StrongPass1!' });
+      .send({ email: 'newuser@test.local', password: 'StrongPass1!', displayName: 'New User' });
 
     expect(res.status).toBe(201);
     expect(getAccessCookie(res)).toBeDefined();
-    expect(res.body.user.username).toBe('newuser');
+    expect(res.body.user.email).toBe('newuser@test.local');
     expect(res.body.user.id).toBeDefined();
   });
 
   it('sets httpOnly cookies on register', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'cookieuser', password: 'StrongPass1!' });
+      .send({ email: 'cookieuser@test.local', password: 'StrongPass1!', displayName: 'Cookie User' });
 
     expect(res.status).toBe(201);
     expect(getAccessCookie(res)).toBeDefined();
     expect(getRefreshCookie(res)).toBeDefined();
   });
 
-  it('lowercases the username', async () => {
+  it('lowercases the email', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'MixedCase', password: 'StrongPass1!' });
+      .send({ email: 'MixedCase@Test.Local', password: 'StrongPass1!', displayName: 'Mixed Case' });
 
     expect(res.status).toBe(201);
-    expect(res.body.user.username).toBe('mixedcase');
+    expect(res.body.user.email).toBe('mixedcase@test.local');
   });
 
-  it('returns 409 for duplicate username', async () => {
+  it('returns 409 for duplicate email', async () => {
     await request(app)
       .post('/api/auth/register')
-      .send({ username: 'duplicate', password: 'StrongPass1!' });
+      .send({ email: 'duplicate@test.local', password: 'StrongPass1!', displayName: 'Duplicate' });
 
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'duplicate', password: 'StrongPass1!' });
+      .send({ email: 'duplicate@test.local', password: 'StrongPass1!', displayName: 'Duplicate2' });
 
     expect(res.status).toBe(409);
     expect(res.body.error).toBe('CONFLICT');
@@ -78,7 +78,7 @@ describe('POST /api/auth/register', () => {
   it('returns 422 for weak password', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'weakpw', password: '123' });
+      .send({ email: 'weakpw@test.local', password: '123', displayName: 'Weak' });
 
     expect(res.status).toBe(422);
     expect(res.body.error).toBe('VALIDATION_ERROR');
@@ -95,7 +95,7 @@ describe('POST /api/auth/register', () => {
   it('uses displayName when provided', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'withname', password: 'StrongPass1!', displayName: 'My Name' });
+      .send({ email: 'withname@test.local', password: 'StrongPass1!', displayName: 'My Name' });
 
     expect(res.status).toBe(201);
     expect(res.body.user.displayName).toBe('My Name');
@@ -106,25 +106,25 @@ describe('POST /api/auth/login', () => {
   it('logs in with valid credentials', async () => {
     await request(app)
       .post('/api/auth/register')
-      .send({ username: 'logintest', password: 'StrongPass1!' });
+      .send({ email: 'logintest@test.local', password: 'StrongPass1!', displayName: 'Login Test' });
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: 'logintest', password: 'StrongPass1!' });
+      .send({ email: 'logintest@test.local', password: 'StrongPass1!' });
 
     expect(res.status).toBe(200);
     expect(getAccessCookie(res)).toBeDefined();
-    expect(res.body.user.username).toBe('logintest');
+    expect(res.body.user.email).toBe('logintest@test.local');
   });
 
   it('sets httpOnly cookies on login', async () => {
     await request(app)
       .post('/api/auth/register')
-      .send({ username: 'cookielogin', password: 'StrongPass1!' });
+      .send({ email: 'cookielogin@test.local', password: 'StrongPass1!', displayName: 'Cookie Login' });
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: 'cookielogin', password: 'StrongPass1!' });
+      .send({ email: 'cookielogin@test.local', password: 'StrongPass1!' });
 
     expect(res.status).toBe(200);
     expect(getAccessCookie(res)).toBeDefined();
@@ -134,11 +134,11 @@ describe('POST /api/auth/login', () => {
   it('returns 401 for wrong password', async () => {
     await request(app)
       .post('/api/auth/register')
-      .send({ username: 'wrongpw', password: 'StrongPass1!' });
+      .send({ email: 'wrongpw@test.local', password: 'StrongPass1!', displayName: 'Wrong PW' });
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: 'wrongpw', password: 'WrongPass1!' });
+      .send({ email: 'wrongpw@test.local', password: 'WrongPass1!' });
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe('UNAUTHORIZED');
@@ -147,7 +147,7 @@ describe('POST /api/auth/login', () => {
   it('returns 401 for non-existent user', async () => {
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: 'nobody', password: 'StrongPass1!' });
+      .send({ email: 'nobody@test.local', password: 'StrongPass1!' });
 
     expect(res.status).toBe(401);
   });
@@ -161,13 +161,13 @@ describe('POST /api/auth/login', () => {
   });
 
   it('returns activeLocationId when user has a location', async () => {
-    const { token } = await createTestUser(app);
+    const { token, user } = await createTestUser(app);
     await createTestLocation(app, token, 'My Location');
 
     // Login again to check activeLocationId
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: (await request(app).get('/api/auth/me').set('Authorization', `Bearer ${token}`)).body.username, password: 'TestPass123!' });
+      .send({ email: user.email, password: 'TestPass123!' });
 
     expect(res.status).toBe(200);
     expect(res.body.activeLocationId).toBeDefined();
@@ -184,13 +184,13 @@ describe('GET /api/auth/me', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.id).toBeDefined();
-    expect(res.body.username).toBeDefined();
+    expect(res.body.email).toBeDefined();
   });
 
   it('authenticates via access cookie', async () => {
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'cookieme', password: 'StrongPass1!' });
+      .send({ email: 'cookieme@test.local', password: 'StrongPass1!', displayName: 'Cookie Me' });
 
     const accessCookie = getAccessCookie(regRes);
     expect(accessCookie).toBeDefined();
@@ -200,7 +200,7 @@ describe('GET /api/auth/me', () => {
       .set('Cookie', `openbin-access=${accessCookie}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.username).toBe('cookieme');
+    expect(res.body.email).toBe('cookieme@test.local');
   });
 
   it('returns 401 without token', async () => {
@@ -222,7 +222,7 @@ describe('POST /api/auth/refresh', () => {
   it('issues new tokens when refresh cookie is valid', async () => {
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'refreshuser', password: 'StrongPass1!' });
+      .send({ email: 'refreshuser@test.local', password: 'StrongPass1!', displayName: 'Refresh User' });
 
     const refreshCookie = getRefreshCookie(regRes);
     expect(refreshCookie).toBeDefined();
@@ -257,7 +257,7 @@ describe('POST /api/auth/refresh', () => {
   it('detects replay attack and revokes entire family', async () => {
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'replayuser', password: 'StrongPass1!' });
+      .send({ email: 'replayuser@test.local', password: 'StrongPass1!', displayName: 'Replay User' });
 
     const originalRefresh = getRefreshCookie(regRes)!;
 
@@ -287,7 +287,7 @@ describe('POST /api/auth/logout', () => {
   it('revokes refresh token and clears cookies', async () => {
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'logoutuser', password: 'StrongPass1!' });
+      .send({ email: 'logoutuser@test.local', password: 'StrongPass1!', displayName: 'Logout User' });
 
     const refreshCookie = getRefreshCookie(regRes)!;
 
@@ -317,14 +317,14 @@ describe('POST /api/auth/logout-all', () => {
   it('revokes all refresh tokens for user', async () => {
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'logoutall', password: 'StrongPass1!' });
+      .send({ email: 'logoutall@test.local', password: 'StrongPass1!', displayName: 'Logout All' });
 
     const token = getAccessCookie(regRes)!;
 
     // Login again to create a second refresh token
     const loginRes = await request(app)
       .post('/api/auth/login')
-      .send({ username: 'logoutall', password: 'StrongPass1!' });
+      .send({ email: 'logoutall@test.local', password: 'StrongPass1!' });
 
     const secondRefresh = getRefreshCookie(loginRes)!;
 
@@ -384,7 +384,7 @@ describe('PUT /api/auth/password', () => {
   it('changes password and revokes all refresh tokens', async () => {
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: 'pwchangeuser', password: 'StrongPass1!' });
+      .send({ email: 'pwchangeuser@test.local', password: 'StrongPass1!', displayName: 'PW Change User' });
 
     const token = getAccessCookie(regRes)!;
     const refreshCookie = getRefreshCookie(regRes)!;
@@ -405,7 +405,7 @@ describe('PUT /api/auth/password', () => {
     // Verify new password works
     const loginRes = await request(app)
       .post('/api/auth/login')
-      .send({ username: 'pwchangeuser', password: 'NewStrongPass1!' });
+      .send({ email: 'pwchangeuser@test.local', password: 'NewStrongPass1!' });
 
     expect(loginRes.status).toBe(200);
   });
@@ -449,8 +449,9 @@ describe('POST /api/auth/register — invite code', () => {
     const res = await request(app)
       .post('/api/auth/register')
       .send({
-        username: `inviteuser_${Date.now()}`,
+        email: `inviteuser_${Date.now()}@test.local`,
         password: 'TestPass123!',
+        displayName: 'Invite User',
         inviteCode: location.invite_code,
       });
 
@@ -472,8 +473,9 @@ describe('POST /api/auth/register — invite code', () => {
     const res = await request(app)
       .post('/api/auth/register')
       .send({
-        username: `badinvite_${Date.now()}`,
+        email: `badinvite_${Date.now()}@test.local`,
         password: 'TestPass123!',
+        displayName: 'Bad Invite',
         inviteCode: 'nonexistent-code',
       });
 
@@ -514,7 +516,7 @@ describe('POST /api/auth/register — plan initialization', () => {
     // Default test environment is self-hosted (SELF_HOSTED=true by default in config)
     const regRes = await request(app)
       .post('/api/auth/register')
-      .send({ username: `plantest_sh_${Date.now()}`, password: 'StrongPass1!' });
+      .send({ email: `plantest_sh_${Date.now()}@test.local`, password: 'StrongPass1!', displayName: 'Plan Test' });
     expect(regRes.status).toBe(201);
 
     const token = getAccessCookie(regRes);

--- a/server/src/__tests__/demoGuard.test.ts
+++ b/server/src/__tests__/demoGuard.test.ts
@@ -6,8 +6,8 @@ vi.mock('../lib/config.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../lib/config.js')>();
   return {
     ...original,
-    isDemoUser: (req: { user?: { username: string } }) =>
-      !!req.user && req.user.username.toLowerCase() === 'demo',
+    isDemoUser: (req: { user?: { email: string } }) =>
+      !!req.user && req.user.email.toLowerCase() === 'demo@openbin.local',
   };
 });
 
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('demo user AI key guards', () => {
   describe('GET /api/ai/settings', () => {
     it('demo user sees sk-**** masked keys', async () => {
-      const { token, user } = await createTestUser(app, { username: 'demo' });
+      const { token, user } = await createTestUser(app, { email: 'demo@openbin.local' });
 
       // Insert settings directly for the demo user
       const { query: dbQuery } = await import('../db.js');
@@ -63,7 +63,7 @@ describe('demo user AI key guards', () => {
 
   describe('PUT /api/ai/settings', () => {
     it('blocks demo user with 403 DEMO_RESTRICTION', async () => {
-      const { token } = await createTestUser(app, { username: 'demo' });
+      const { token } = await createTestUser(app, { email: 'demo@openbin.local' });
 
       const res = await request(app)
         .put('/api/ai/settings')
@@ -86,7 +86,7 @@ describe('demo user AI key guards', () => {
     });
 
     it('blocks demo user setting customPrompt with 403 DEMO_RESTRICTION', async () => {
-      const { token, user } = await createTestUser(app, { username: 'demo' });
+      const { token, user } = await createTestUser(app, { email: 'demo@openbin.local' });
 
       const { query: dbQuery } = await import('../db.js');
       dbQuery(
@@ -105,7 +105,7 @@ describe('demo user AI key guards', () => {
     });
 
     it('blocks demo user setting commandPrompt with 403 DEMO_RESTRICTION', async () => {
-      const { token, user } = await createTestUser(app, { username: 'demo' });
+      const { token, user } = await createTestUser(app, { email: 'demo@openbin.local' });
 
       const { query: dbQuery } = await import('../db.js');
       dbQuery(
@@ -123,7 +123,7 @@ describe('demo user AI key guards', () => {
     });
 
     it('allows demo user to change temperature without prompt fields', async () => {
-      const { token, user } = await createTestUser(app, { username: 'demo' });
+      const { token, user } = await createTestUser(app, { email: 'demo@openbin.local' });
 
       const { query: dbQuery } = await import('../db.js');
       dbQuery(
@@ -153,7 +153,7 @@ describe('demo user AI key guards', () => {
 
   describe('POST /api/ai/test', () => {
     it('blocks demo user with 403 DEMO_RESTRICTION', async () => {
-      const { token } = await createTestUser(app, { username: 'demo' });
+      const { token } = await createTestUser(app, { email: 'demo@openbin.local' });
 
       const res = await request(app)
         .post('/api/ai/test')

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -32,19 +32,19 @@ function extractAccessToken(res: request.Response): string {
   throw new Error('openbin-access cookie not found in response');
 }
 
-export async function createTestUser(app: Express, overrides?: { username?: string; password?: string; email?: string }) {
+export async function createTestUser(app: Express, overrides?: { email?: string; password?: string; displayName?: string }) {
   userCounter++;
-  const username = overrides?.username ?? `testuser${userCounter}_${Date.now()}`;
+  const email = overrides?.email ?? `testuser${userCounter}_${Date.now()}@test.local`;
   const password = overrides?.password ?? 'TestPass123!';
-  const email = overrides?.email ?? `${username}@test.local`;
+  const displayName = overrides?.displayName ?? `Test User ${userCounter}`;
 
   const res = await request(app)
     .post('/api/auth/register')
-    .send({ username, password, email });
+    .send({ email, password, displayName });
 
   return {
     token: extractAccessToken(res),
-    user: res.body.user as { id: string; username: string; displayName: string },
+    user: res.body.user as { id: string; displayName: string; email: string },
     password,
   };
 }

--- a/server/src/__tests__/oauth.test.ts
+++ b/server/src/__tests__/oauth.test.ts
@@ -1,9 +1,9 @@
 import type { Express } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { generateUuid, query } from '../db.js';
+import { query } from '../db.js';
 import { createApp } from '../index.js';
-import { findOrCreateOAuthUser, generateUsername } from '../lib/oauth.js';
+import { findOrCreateOAuthUser } from '../lib/oauth.js';
 import { signToken } from '../middleware/auth.js';
 import { createTestUser } from './helpers.js';
 
@@ -11,45 +11,6 @@ let app: Express;
 
 beforeEach(() => {
   app = createApp();
-});
-
-describe('generateUsername', () => {
-  it('extracts prefix from email', async () => {
-    const name = await generateUsername('jane.doe@gmail.com');
-    expect(name).toBe('janedoe');
-  });
-
-  it('strips non-alphanumeric/underscore chars', async () => {
-    const name = await generateUsername('j+a.n-e@example.com');
-    expect(name).toBe('jane');
-  });
-
-  it('truncates to 50 chars', async () => {
-    const long = `${'a'.repeat(60)}@example.com`;
-    const name = await generateUsername(long);
-    expect(name.length).toBeLessThanOrEqual(50);
-  });
-
-  it('appends numeric suffix on conflict', async () => {
-    await createTestUser(app, { username: 'testconflict' });
-    const name = await generateUsername('testconflict@example.com');
-    expect(name).toBe('testconflict2');
-  });
-
-  it('increments suffix until unique', async () => {
-    await createTestUser(app, { username: 'dupuser' });
-    await query(
-      "INSERT INTO users (id, username, password_hash, display_name, plan, sub_status) VALUES ($1, $2, $3, $4, 1, 1)",
-      [generateUuid(), 'dupuser2', 'hash', 'dup']
-    );
-    const name = await generateUsername('dupuser@example.com');
-    expect(name).toBe('dupuser3');
-  });
-
-  it('falls back to "user" for empty prefix', async () => {
-    const name = await generateUsername('@example.com');
-    expect(name).toBe('user');
-  });
 });
 
 describe('findOrCreateOAuthUser', () => {
@@ -60,7 +21,7 @@ describe('findOrCreateOAuthUser', () => {
       email: 'newuser@example.com',
       displayName: 'New User',
     });
-    expect(result.user.username).toBeTruthy();
+    expect(result.user.email).toBe('newuser@example.com');
     expect(result.created).toBe(true);
   });
 
@@ -81,17 +42,16 @@ describe('findOrCreateOAuthUser', () => {
     expect(second.created).toBe(false);
   });
 
-  it('does not auto-link when email matches existing password user', async () => {
-    const { user } = await createTestUser(app, { email: 'link@example.com' });
-    const result = await findOrCreateOAuthUser({
-      provider: 'google',
-      providerUserId: 'google-sub-789',
-      email: 'link@example.com',
-      displayName: 'Linked',
-    });
-    // Should create a NEW user, not hijack the existing one
-    expect(result.user.id).not.toBe(user.id);
-    expect(result.created).toBe(true);
+  it('throws ForbiddenError when email matches existing password user', async () => {
+    await createTestUser(app, { email: 'link@example.com' });
+    await expect(
+      findOrCreateOAuthUser({
+        provider: 'google',
+        providerUserId: 'google-sub-789',
+        email: 'link@example.com',
+        displayName: 'Linked',
+      })
+    ).rejects.toThrow('An account with this email already exists');
   });
 
   it('rejects suspended user', async () => {
@@ -167,7 +127,7 @@ describe('OAuth routes', () => {
     });
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ username: user.username, password: 'anything' });
+      .send({ email: user.email, password: 'anything' });
     expect(res.status).toBe(401);
     expect(res.body.error).toBe('NO_PASSWORD');
   });

--- a/server/src/__tests__/passwordReset.test.ts
+++ b/server/src/__tests__/passwordReset.test.ts
@@ -104,7 +104,7 @@ describe('Password Reset', () => {
       // Login with new password
       const loginRes = await request(app)
         .post('/api/auth/login')
-        .send({ username: member.user.username, password: newPassword });
+        .send({ email: member.user.email, password: newPassword });
 
       expect(loginRes.status).toBe(200);
     });
@@ -164,7 +164,7 @@ describe('Password Reset', () => {
 
       const loginRes = await request(app)
         .post('/api/auth/login')
-        .send({ username: member.user.username, password: member.password });
+        .send({ email: member.user.email, password: member.password });
 
       expect(loginRes.status).toBe(401);
     });

--- a/server/src/__tests__/requirePlan.test.ts
+++ b/server/src/__tests__/requirePlan.test.ts
@@ -26,7 +26,7 @@ import { requirePro, requireWriteApi } from '../middleware/requirePlan.js';
 // ---- Helpers ----
 
 function makeReq(userId = 'user-123'): Partial<Request> {
-  return { user: { id: userId, username: 'testuser' } };
+  return { user: { id: userId, email: 'testuser@test.local' } };
 }
 
 function makeRes(): Partial<Response> {

--- a/server/src/db/__tests__/pg-concurrency.integration.test.ts
+++ b/server/src/db/__tests__/pg-concurrency.integration.test.ts
@@ -26,9 +26,9 @@ async function seedUserAndLocation() {
   const userId = crypto.randomUUID();
   const locationId = crypto.randomUUID();
   await pool.query(
-    `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+    `INSERT INTO users (id, email, password_hash, display_name, is_admin)
      VALUES ($1, $2, 'hash', 'Test', FALSE)`,
-    [userId, `u_${userId.slice(0, 8)}`],
+    [userId, `u_${userId.slice(0, 8)}@test.local`],
   );
   await pool.query(
     `INSERT INTO locations (id, name, created_by, invite_code)
@@ -58,12 +58,12 @@ describe('pg-concurrency: parallel writes', () => {
   });
 
   it('two concurrent INSERTs with same unique key — one gets 23505', async () => {
-    const username = `dup_${crypto.randomUUID().slice(0, 8)}`;
+    const email = `dup_${crypto.randomUUID().slice(0, 8)}@test.local`;
     const insert = (id: string) =>
       pool.query(
-        `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+        `INSERT INTO users (id, email, password_hash, display_name, is_admin)
          VALUES ($1, $2, 'hash', 'Dup', FALSE)`,
-        [id, username],
+        [id, email],
       );
 
     const results = await Promise.allSettled([
@@ -78,17 +78,17 @@ describe('pg-concurrency: parallel writes', () => {
   });
 
   it('isUniqueViolation() identifies 23505 from real PG constraint violation', async () => {
-    const username = `uniq_${crypto.randomUUID().slice(0, 8)}`;
+    const email = `uniq_${crypto.randomUUID().slice(0, 8)}@test.local`;
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, 'hash', 'U1', FALSE)`,
-      [crypto.randomUUID(), username],
+      [crypto.randomUUID(), email],
     );
     try {
       await pool.query(
-        `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+        `INSERT INTO users (id, email, password_hash, display_name, is_admin)
          VALUES ($1, $2, 'hash', 'U2', FALSE)`,
-        [crypto.randomUUID(), username],
+        [crypto.randomUUID(), email],
       );
       expect.fail('Should have thrown');
     } catch (err) {

--- a/server/src/db/__tests__/pg-engine.integration.test.ts
+++ b/server/src/db/__tests__/pg-engine.integration.test.ts
@@ -26,9 +26,9 @@ async function seedUserAndLocation() {
   const userId = crypto.randomUUID();
   const locationId = crypto.randomUUID();
   await pool.query(
-    `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+    `INSERT INTO users (id, email, password_hash, display_name, is_admin)
      VALUES ($1, $2, 'hash', 'Test', FALSE)`,
-    [userId, `u_${userId.slice(0, 8)}`],
+    [userId, `u_${userId.slice(0, 8)}@test.local`],
   );
   await pool.query(
     `INSERT INTO locations (id, name, created_by, invite_code)
@@ -42,51 +42,51 @@ describe('pg-engine: query execution', () => {
   it('INSERT and SELECT round-trip', async () => {
     const id = crypto.randomUUID();
     await engine.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-       VALUES ($1, 'roundtrip', 'hash', 'RT User', FALSE)`,
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+       VALUES ($1, 'roundtrip@test.local', 'hash', 'RT User', FALSE)`,
       [id],
     );
-    const result = await engine.query<{ username: string }>('SELECT username FROM users WHERE id = $1', [id]);
+    const result = await engine.query<{ email: string }>('SELECT email FROM users WHERE id = $1', [id]);
     expect(result.rows).toHaveLength(1);
-    expect(result.rows[0].username).toBe('roundtrip');
+    expect(result.rows[0].email).toBe('roundtrip@test.local');
   });
 
   it('parameterized query with $1, $2 binds correctly', async () => {
     const id = crypto.randomUUID();
     await engine.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, 'hash', 'Param', FALSE)`,
-      [id, 'param_user'],
+      [id, 'param_user@test.local'],
     );
     const result = await engine.query<{ id: string }>(
-      'SELECT id FROM users WHERE username = $1 AND display_name = $2',
-      ['param_user', 'Param'],
+      'SELECT id FROM users WHERE email = $1 AND display_name = $2',
+      ['param_user@test.local', 'Param'],
     );
     expect(result.rows[0].id).toBe(id);
   });
 
   it('INSERT with RETURNING returns inserted row', async () => {
     const id = crypto.randomUUID();
-    const result = await engine.query<{ id: string; username: string }>(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-       VALUES ($1, 'ret_user', 'hash', 'Ret', FALSE)
-       RETURNING id, username`,
+    const result = await engine.query<{ id: string; email: string }>(
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+       VALUES ($1, 'ret_user@test.local', 'hash', 'Ret', FALSE)
+       RETURNING id, email`,
       [id],
     );
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].id).toBe(id);
-    expect(result.rows[0].username).toBe('ret_user');
+    expect(result.rows[0].email).toBe('ret_user@test.local');
   });
 
   it('COUNT(*) returns JavaScript Number (bigint parser)', async () => {
     await engine.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-       VALUES ($1, 'cnt1', 'hash', 'C1', FALSE)`,
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+       VALUES ($1, 'cnt1@test.local', 'hash', 'C1', FALSE)`,
       [crypto.randomUUID()],
     );
     await engine.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-       VALUES ($1, 'cnt2', 'hash', 'C2', FALSE)`,
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+       VALUES ($1, 'cnt2@test.local', 'hash', 'C2', FALSE)`,
       [crypto.randomUUID()],
     );
     const result = await engine.query<{ count: number }>('SELECT COUNT(*) AS count FROM users');
@@ -132,20 +132,21 @@ describe('pg-engine: parameter serialization', () => {
 
   it('null param stores NULL, not string "null"', async () => {
     const id = crypto.randomUUID();
+    // Insert with a valid email but test that a nullable column (avatar_path) accepts null
     await engine.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin, email)
-       VALUES ($1, 'null_test', 'hash', 'Null', FALSE, $2)`,
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin, avatar_path)
+       VALUES ($1, 'null_test@test.local', 'hash', 'Null', FALSE, $2)`,
       [id, null],
     );
-    const result = await engine.query<{ email: string | null }>('SELECT email FROM users WHERE id = $1', [id]);
-    expect(result.rows[0].email).toBeNull();
+    const result = await engine.query<{ avatar_path: string | null }>('SELECT avatar_path FROM users WHERE id = $1', [id]);
+    expect(result.rows[0].avatar_path).toBeNull();
   });
 
   it('boolean true stored and returned as native true', async () => {
     const id = crypto.randomUUID();
     await engine.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-       VALUES ($1, 'bool_test', 'hash', 'Bool', $2)`,
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+       VALUES ($1, 'bool_test@test.local', 'hash', 'Bool', $2)`,
       [id, true],
     );
     const result = await engine.query<{ is_admin: boolean }>('SELECT is_admin FROM users WHERE id = $1', [id]);
@@ -159,13 +160,13 @@ describe('pg-engine: transactions', () => {
     const id2 = crypto.randomUUID();
     await engine.withTransaction(async (txQuery) => {
       await txQuery(
-        `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-         VALUES ($1, 'tx1', 'hash', 'TX1', FALSE)`,
+        `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+         VALUES ($1, 'tx1@test.local', 'hash', 'TX1', FALSE)`,
         [id1],
       );
       await txQuery(
-        `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-         VALUES ($1, 'tx2', 'hash', 'TX2', FALSE)`,
+        `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+         VALUES ($1, 'tx2@test.local', 'hash', 'TX2', FALSE)`,
         [id2],
       );
     });
@@ -179,8 +180,8 @@ describe('pg-engine: transactions', () => {
     await expect(
       engine.withTransaction(async (txQuery) => {
         await txQuery(
-          `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-           VALUES ($1, 'rb1', 'hash', 'RB1', FALSE)`,
+          `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+           VALUES ($1, 'rb1@test.local', 'hash', 'RB1', FALSE)`,
           [id1],
         );
         // Force an error
@@ -196,15 +197,15 @@ describe('pg-engine: transactions', () => {
     await Promise.all([
       engine.withTransaction(async (txQuery) => {
         await txQuery(
-          `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-           VALUES ($1, 'conc1', 'hash', 'C1', FALSE)`,
+          `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+           VALUES ($1, 'conc1@test.local', 'hash', 'C1', FALSE)`,
           [id1],
         );
       }),
       engine.withTransaction(async (txQuery) => {
         await txQuery(
-          `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-           VALUES ($1, 'conc2', 'hash', 'C2', FALSE)`,
+          `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+           VALUES ($1, 'conc2@test.local', 'hash', 'C2', FALSE)`,
           [id2],
         );
       }),
@@ -218,19 +219,19 @@ describe('pg-engine: transactions', () => {
     await expect(
       engine.withTransaction(async (txQuery) => {
         await txQuery(
-          `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-           VALUES ($1, 'midway', 'hash', 'MW', FALSE)`,
+          `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+           VALUES ($1, 'midway@test.local', 'hash', 'MW', FALSE)`,
           [userId],
         );
-        // violate unique constraint by inserting duplicate username
+        // violate unique constraint by inserting duplicate email
         await txQuery(
-          `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-           VALUES ($1, 'midway', 'hash', 'MW2', FALSE)`,
+          `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+           VALUES ($1, 'midway@test.local', 'hash', 'MW2', FALSE)`,
           [crypto.randomUUID()],
         );
       }),
     ).rejects.toThrow();
-    const result = await engine.query('SELECT id FROM users WHERE username = $1', ['midway']);
+    const result = await engine.query('SELECT id FROM users WHERE email = $1', ['midway@test.local']);
     expect(result.rows).toHaveLength(0);
   });
 

--- a/server/src/db/__tests__/pg-init.integration.test.ts
+++ b/server/src/db/__tests__/pg-init.integration.test.ts
@@ -90,10 +90,10 @@ describe('pg-init: schema loading', () => {
   it('admin user exists with correct attributes', async () => {
     await runInitialize();
     const { rows } = await pool.query(
-      `SELECT username, is_admin, plan, sub_status FROM users WHERE username = 'admin'`,
+      `SELECT email, is_admin, plan, sub_status FROM users WHERE email = 'admin@openbin.local'`,
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].username).toBe('admin');
+    expect(rows[0].email).toBe('admin@openbin.local');
     expect(rows[0].is_admin).toBe(true);
     expect(rows[0].plan).toBe(1);
     expect(rows[0].sub_status).toBe(1);
@@ -167,14 +167,14 @@ describe('pg-init: unique indexes', () => {
     const id1 = crypto.randomUUID();
     const id2 = crypto.randomUUID();
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin, email)
-       VALUES ($1, 'emailtest1', 'hash', 'E1', FALSE, 'Test@Example.com')`,
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+       VALUES ($1, 'Test@Example.com', 'hash', 'E1', FALSE)`,
       [id1],
     );
     await expect(
       pool.query(
-        `INSERT INTO users (id, username, password_hash, display_name, is_admin, email)
-         VALUES ($1, 'emailtest2', 'hash', 'E2', FALSE, 'test@example.com')`,
+        `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+         VALUES ($1, 'test@example.com', 'hash', 'E2', FALSE)`,
         [id2],
       ),
     ).rejects.toThrow();
@@ -188,7 +188,7 @@ describe('pg-init: admin seed', () => {
     const { initialize } = await import('../init.js');
     await initialize();
     const { rows } = await pool.query(
-      `SELECT COUNT(*) AS count FROM users WHERE username = 'admin'`,
+      `SELECT COUNT(*) AS count FROM users WHERE email = 'admin@openbin.local'`,
     );
     expect(Number(rows[0].count)).toBe(1);
   });

--- a/server/src/db/__tests__/pg-queries.integration.test.ts
+++ b/server/src/db/__tests__/pg-queries.integration.test.ts
@@ -23,8 +23,8 @@ beforeAll(async () => {
   userId = crypto.randomUUID();
   locationId = crypto.randomUUID();
   await pool.query(
-    `INSERT INTO users (id, username, password_hash, display_name, is_admin)
-     VALUES ($1, 'queryuser', 'hash', 'Query User', FALSE)`,
+    `INSERT INTO users (id, email, password_hash, display_name, is_admin)
+     VALUES ($1, 'queryuser@test.local', 'hash', 'Query User', FALSE)`,
     [userId],
   );
   await pool.query(

--- a/server/src/db/__tests__/pg-types.integration.test.ts
+++ b/server/src/db/__tests__/pg-types.integration.test.ts
@@ -22,9 +22,9 @@ async function seedUserAndLocation(p: pg.Pool) {
   const userId = crypto.randomUUID();
   const locationId = crypto.randomUUID();
   await p.query(
-    `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+    `INSERT INTO users (id, email, password_hash, display_name, is_admin)
      VALUES ($1, $2, 'hash', 'Test User', FALSE)`,
-    [userId, `user_${userId.slice(0, 8)}`],
+    [userId, `user_${userId.slice(0, 8)}@test.local`],
   );
   await p.query(
     `INSERT INTO locations (id, name, created_by, invite_code)
@@ -159,9 +159,9 @@ describe('pg-types: Boolean behavior', () => {
   it('users.is_admin TRUE returns JS true', async () => {
     const userId = crypto.randomUUID();
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, 'hash', 'Admin', TRUE)`,
-      [userId, `admin_${userId.slice(0, 8)}`],
+      [userId, `admin_${userId.slice(0, 8)}@test.local`],
     );
     const { rows } = await pool.query('SELECT is_admin FROM users WHERE id = $1', [userId]);
     expect(rows[0].is_admin).toBe(true);
@@ -171,9 +171,9 @@ describe('pg-types: Boolean behavior', () => {
   it('users.is_admin FALSE returns JS false', async () => {
     const userId = crypto.randomUUID();
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, 'hash', 'User', FALSE)`,
-      [userId, `user_${userId.slice(0, 8)}`],
+      [userId, `user_${userId.slice(0, 8)}@test.local`],
     );
     const { rows } = await pool.query('SELECT is_admin FROM users WHERE id = $1', [userId]);
     expect(rows[0].is_admin).toBe(false);
@@ -200,14 +200,14 @@ describe('pg-types: Boolean behavior', () => {
     const adminId = crypto.randomUUID();
     const userId = crypto.randomUUID();
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, 'hash', 'Admin', TRUE)`,
-      [adminId, `admin_${adminId.slice(0, 8)}`],
+      [adminId, `admin_${adminId.slice(0, 8)}@test.local`],
     );
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin)
        VALUES ($1, $2, 'hash', 'User', FALSE)`,
-      [userId, `user_${userId.slice(0, 8)}`],
+      [userId, `user_${userId.slice(0, 8)}@test.local`],
     );
     const { rows } = await pool.query('SELECT id FROM users WHERE is_admin = TRUE');
     expect(rows).toHaveLength(1);
@@ -217,9 +217,9 @@ describe('pg-types: Boolean behavior', () => {
   it('users.plan and sub_status remain INTEGER', async () => {
     const userId = crypto.randomUUID();
     await pool.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin, plan, sub_status)
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin, plan, sub_status)
        VALUES ($1, $2, 'hash', 'User', FALSE, 1, 1)`,
-      [userId, `user_${userId.slice(0, 8)}`],
+      [userId, `user_${userId.slice(0, 8)}@test.local`],
     );
     const { rows } = await pool.query('SELECT plan, sub_status FROM users WHERE id = $1', [userId]);
     expect(rows[0].plan).toBe(1);

--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -24,20 +24,21 @@ let engine: DatabaseEngine | null = null;
 const ADMIN_ACTIVE_UNTIL_MS = 1000 * 365 * 24 * 60 * 60 * 1000;
 
 async function seedAdminUser(eng: DatabaseEngine): Promise<void> {
-  const { rows } = await eng.query("SELECT 1 FROM users WHERE username = 'admin'");
+  const adminEmail = config.adminEmail || 'admin@openbin.local';
+  const { rows } = await eng.query('SELECT 1 FROM users WHERE email = $1', [adminEmail]);
   if (rows.length === 0) {
     const plaintext = config.adminPassword || crypto.randomBytes(12).toString('base64url');
     const hash = await bcrypt.hash(plaintext, config.bcryptRounds);
 
     await eng.query(
-      `INSERT INTO users (id, username, password_hash, display_name, is_admin, plan, sub_status, active_until)
-       VALUES ($1, 'admin', $2, 'Admin', TRUE, 1, 1, $3)`,
-      [crypto.randomUUID(), hash, new Date(Date.now() + ADMIN_ACTIVE_UNTIL_MS).toISOString()],
+      `INSERT INTO users (id, email, password_hash, display_name, is_admin, plan, sub_status, active_until)
+       VALUES ($1, $2, $3, 'Admin', TRUE, 1, 1, $4)`,
+      [crypto.randomUUID(), adminEmail, hash, new Date(Date.now() + ADMIN_ACTIVE_UNTIL_MS).toISOString()],
     );
 
     console.log('========================================');
     console.log('  Initial admin credentials:');
-    console.log('    Username: admin');
+    console.log(`    Email: ${adminEmail}`);
     console.log(`    Password: ${plaintext}`);
     console.log('========================================');
   }

--- a/server/src/ee/__tests__/inactivityChecker.test.ts
+++ b/server/src/ee/__tests__/inactivityChecker.test.ts
@@ -39,15 +39,14 @@ async function insertUser(opts: {
 }): Promise<string> {
   const id = `ic-user-${++uid}`;
   await query(
-    `INSERT INTO users (id, username, display_name, password_hash, sub_status, last_active_at, email, is_admin, deleted_at, suspended_at, created_at)
-     VALUES ($1, $2, $3, 'hash', $4, $5, $6, $7, $8, $9, $10)`,
+    `INSERT INTO users (id, email, display_name, password_hash, sub_status, last_active_at, is_admin, deleted_at, suspended_at, created_at)
+     VALUES ($1, $2, $3, 'hash', $4, $5, $6, $7, $8, $9)`,
     [
       id,
-      `user_${id}`,
+      (opts.email !== undefined && opts.email !== null) ? opts.email : `user_${id}@test.local`,
       'Test User',
       opts.subStatus,
       opts.lastActiveAt ?? null,
-      opts.email !== undefined ? opts.email : 'test@example.com',
       opts.isAdmin ? 1 : 0,
       opts.deletedAt ?? null,
       opts.suspendedAt ?? null,
@@ -86,20 +85,21 @@ describe('inactivityChecker', () => {
     expect(result.rows[0].deleted_at).not.toBeNull();
   });
 
-  // --- Skips email for users without email ---
-  it('skips warning email for user without email but still deletes at 365+', async () => {
-    const id = await insertUser({ subStatus: SubStatus.INACTIVE, lastActiveAt: daysAgoIso(370), email: null });
+  // --- Deletion at 365+ days does not trigger warning emails ---
+  it('soft-deletes user at 365+ days and does not send warning emails', async () => {
+    const id = await insertUser({ subStatus: SubStatus.INACTIVE, lastActiveAt: daysAgoIso(370), email: 'nodelete@example.com' });
     await checkInactiveUsers();
+    // Deletion path runs — no warning emails sent
     expect(mockFireInactivityWarning30d).not.toHaveBeenCalled();
     expect(mockFireInactivityWarning7d).not.toHaveBeenCalled();
     const result = await query<{ deleted_at: string | null }>('SELECT deleted_at FROM users WHERE id = $1', [id]);
     expect(result.rows[0].deleted_at).not.toBeNull();
   });
 
-  it('skips warning email for user without email at 340 days', async () => {
-    const id = await insertUser({ subStatus: SubStatus.INACTIVE, lastActiveAt: daysAgoIso(340), email: null });
+  it('sends 30d warning for user inactive exactly 340 days with email', async () => {
+    const id = await insertUser({ subStatus: SubStatus.INACTIVE, lastActiveAt: daysAgoIso(340), email: 'warn30@example.com' });
     await checkInactiveUsers();
-    expect(mockFireInactivityWarning30d).not.toHaveBeenCalled();
+    expect(mockFireInactivityWarning30d).toHaveBeenCalledTimes(1);
     const result = await query<{ deleted_at: string | null }>('SELECT deleted_at FROM users WHERE id = $1', [id]);
     expect(result.rows[0].deleted_at).toBeNull();
   });

--- a/server/src/ee/__tests__/trialChecker.test.ts
+++ b/server/src/ee/__tests__/trialChecker.test.ts
@@ -31,15 +31,14 @@ async function insertUser(opts: {
 }): Promise<string> {
   const id = `tc-user-${++uid}`;
   await query(
-    `INSERT INTO users (id, username, display_name, password_hash, sub_status, active_until, email, created_at)
-     VALUES ($1, $2, $3, 'hash', $4, $5, $6, $7)`,
+    `INSERT INTO users (id, email, display_name, password_hash, sub_status, active_until, created_at)
+     VALUES ($1, $2, $3, 'hash', $4, $5, $6)`,
     [
       id,
-      `user_${id}`,
+      (opts.email !== undefined && opts.email !== null) ? opts.email : `user_${id}@test.local`,
       'Test User',
       opts.subStatus,
       opts.activeUntil ?? null,
-      opts.email ?? null,
       opts.createdAt ?? new Date().toISOString(),
     ],
   );
@@ -166,10 +165,10 @@ describe('trialChecker queries', () => {
     expect(result.rows.map((r) => r.id)).toContain(id);
   });
 
-  // --- Queries exclude users without email ---
+  // --- Email is always present (NOT NULL) — verify query still works ---
 
-  it('trial expiring query excludes users without email', async () => {
-    const id = await insertUser({ subStatus: SubStatus.TRIAL, activeUntil: daysFromNow(2), email: null });
+  it('trial expiring query includes users with email (email is always present)', async () => {
+    const id = await insertUser({ subStatus: SubStatus.TRIAL, activeUntil: daysFromNow(2), email: 'trialtest@example.com' });
     const result = await query<{ id: string }>(
       `SELECT id FROM users
        WHERE sub_status = $1 AND active_until IS NOT NULL
@@ -177,6 +176,6 @@ describe('trialChecker queries', () => {
        AND email IS NOT NULL`,
       [SubStatus.TRIAL],
     );
-    expect(result.rows.map((r) => r.id)).not.toContain(id);
+    expect(result.rows.map((r) => r.id)).toContain(id);
   });
 });

--- a/server/src/ee/inactivityChecker.ts
+++ b/server/src/ee/inactivityChecker.ts
@@ -15,8 +15,7 @@ const WARNING_7D_DAYS = INACTIVITY_DAYS - 7;   // 358
 
 interface InactiveUser {
   id: string;
-  email: string | null;
-  username: string;
+  email: string;
   display_name: string;
   last_active_at: string | null;
   created_at: string;
@@ -26,7 +25,7 @@ export async function checkInactiveUsers(): Promise<void> {
   if (!(await acquireJobLock('inactivity_checker', 7200))) return;
   try {
     const candidates = await query<InactiveUser>(
-      `SELECT id, email, username, display_name, last_active_at, created_at
+      `SELECT id, email, display_name, last_active_at, created_at
        FROM users
        WHERE sub_status = $1
          AND deleted_at IS NULL

--- a/server/src/ee/managerWebhook.ts
+++ b/server/src/ee/managerWebhook.ts
@@ -17,7 +17,6 @@ function sendManagerRequest(endpoint: string, payload: Record<string, unknown>, 
 interface NewUserPayload {
   userId: string;
   email: string | null;
-  username: string;
   activeUntil: string;
   status: string;
 }
@@ -26,7 +25,6 @@ export function notifyManagerNewUser(user: NewUserPayload): void {
   sendManagerRequest('/api/v1/users', {
     userId: user.userId,
     email: user.email,
-    username: user.username,
     activeUntil: user.activeUntil,
     status: user.status,
     action: 'create_user',

--- a/server/src/ee/metrics.ts
+++ b/server/src/ee/metrics.ts
@@ -20,10 +20,10 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache: { data: CloudMetrics; fetchedAt: number } | null = null;
 
 function demoExclusion(): { clause: string; params: string[] } {
-  const names = [...config.demoUsernames];
-  if (names.length === 0) return { clause: '', params: [] };
-  const placeholders = names.map((_, i) => `$${i + 1}`).join(', ');
-  return { clause: `AND u.username NOT IN (${placeholders})`, params: names };
+  const emails = [...config.demoEmails];
+  if (emails.length === 0) return { clause: '', params: [] };
+  const placeholders = emails.map((_, i) => `$${i + 1}`).join(', ');
+  return { clause: `AND u.email NOT IN (${placeholders})`, params: emails };
 }
 
 async function queryPlanDistribution(demo: { clause: string; params: string[] }) {

--- a/server/src/lib/__tests__/emailSender.test.ts
+++ b/server/src/lib/__tests__/emailSender.test.ts
@@ -31,9 +31,9 @@ const EMAIL = 'test@example.com';
 
 async function insertUser(id: string): Promise<void> {
   await query(
-    `INSERT INTO users (id, username, display_name, password_hash)
+    `INSERT INTO users (id, email, display_name, password_hash)
      VALUES ($1, $2, $3, $4)`,
-    [id, `user_${id}`, 'Test User', 'hash'],
+    [id, `user_${id}@test.local`, 'Test User', 'hash'],
   );
 }
 

--- a/server/src/lib/__tests__/importTransaction.test.ts
+++ b/server/src/lib/__tests__/importTransaction.test.ts
@@ -11,10 +11,10 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function createUser(id: string, username: string) {
+async function createUser(id: string, displayName: string) {
   await query(
-    'INSERT INTO users (id, username, password_hash, display_name) VALUES ($1, $2, $3, $4)',
-    [id, username, 'hash', username],
+    'INSERT INTO users (id, email, password_hash, display_name) VALUES ($1, $2, $3, $4)',
+    [id, `${id}@test.local`, 'hash', displayName],
   );
 }
 

--- a/server/src/lib/__tests__/validation.test.ts
+++ b/server/src/lib/__tests__/validation.test.ts
@@ -4,33 +4,29 @@ import {
   validateBinName,
   validateDisplayName,
   validateEmail,
+  validateLoginEmail,
   validatePassword,
   validateRequiredString,
   validateRetentionDays,
-  validateUsername,
 } from '../validation.js';
 
-describe('validateUsername', () => {
-  it('accepts a valid username', () => {
-    expect(validateUsername('alice_42')).toBe('alice_42');
+describe('validateLoginEmail', () => {
+  it('accepts a valid email', () => {
+    expect(validateLoginEmail('alice@example.com')).toBe('alice@example.com');
   });
 
-  it('rejects too-short usernames', () => {
-    expect(() => validateUsername('ab')).toThrow();
+  it('lowercases and trims the email', () => {
+    expect(validateLoginEmail('  Alice@Example.COM  ')).toBe('alice@example.com');
   });
 
-  it('rejects too-long usernames', () => {
-    expect(() => validateUsername('a'.repeat(51))).toThrow();
-  });
-
-  it('rejects special characters', () => {
-    expect(() => validateUsername('alice!')).toThrow();
+  it('rejects invalid email format', () => {
+    expect(() => validateLoginEmail('notanemail')).toThrow();
   });
 
   it('rejects empty / null / non-string', () => {
-    expect(() => validateUsername('')).toThrow();
-    expect(() => validateUsername(null)).toThrow();
-    expect(() => validateUsername(123)).toThrow();
+    expect(() => validateLoginEmail('')).toThrow();
+    expect(() => validateLoginEmail(null)).toThrow();
+    expect(() => validateLoginEmail(123)).toThrow();
   });
 });
 

--- a/server/src/lib/adminHelpers.ts
+++ b/server/src/lib/adminHelpers.ts
@@ -6,9 +6,9 @@ export async function getAdminCount(): Promise<number> {
   return result.rows[0].cnt;
 }
 
-export async function assertUserExists(userId: string): Promise<{ id: string; username: string }> {
-  const result = await query<{ id: string; username: string }>(
-    'SELECT id, username FROM users WHERE id = $1',
+export async function assertUserExists(userId: string): Promise<{ id: string; email: string }> {
+  const result = await query<{ id: string; email: string }>(
+    'SELECT id, email FROM users WHERE id = $1',
     [userId],
   );
   if (result.rows.length === 0) throw new NotFoundError('User not found');

--- a/server/src/lib/binQueries.ts
+++ b/server/src/lib/binQueries.ts
@@ -2,7 +2,7 @@ import { d, getDialect, query } from '../db.js';
 
 /** Shared SELECT columns for bin queries (requires b alias for bins, a alias for areas). */
 export function BIN_SELECT_COLS(): string {
-  return `b.id, b.short_code, b.location_id, b.name, b.area_id, COALESCE(a.name, '') AS area_name, COALESCE((SELECT ${d.jsonGroupArray(d.jsonObject("'id'", 'bi.id', "'name'", 'bi.name', "'quantity'", 'bi.quantity'))} FROM (SELECT id, name, quantity FROM bin_items bi WHERE bi.bin_id = b.id ORDER BY bi.position) bi), '[]') AS items, b.notes, b.tags, b.icon, b.color, b.card_style, b.created_by, COALESCE((SELECT COALESCE(u.display_name, u.username) FROM users u WHERE u.id = b.created_by), '') AS created_by_name, b.visibility, b.created_at, b.updated_at, COALESCE((SELECT ${d.jsonGroupObject('bcfv.field_id', 'bcfv.value')} FROM bin_custom_field_values bcfv WHERE bcfv.bin_id = b.id), '{}') AS custom_fields`;
+  return `b.id, b.short_code, b.location_id, b.name, b.area_id, COALESCE(a.name, '') AS area_name, COALESCE((SELECT ${d.jsonGroupArray(d.jsonObject("'id'", 'bi.id', "'name'", 'bi.name', "'quantity'", 'bi.quantity'))} FROM (SELECT id, name, quantity FROM bin_items bi WHERE bi.bin_id = b.id ORDER BY bi.position) bi), '[]') AS items, b.notes, b.tags, b.icon, b.color, b.card_style, b.created_by, COALESCE((SELECT u.display_name FROM users u WHERE u.id = b.created_by), '') AS created_by_name, b.visibility, b.created_at, b.updated_at, COALESCE((SELECT ${d.jsonGroupObject('bcfv.field_id', 'bcfv.value')} FROM bin_custom_field_values bcfv WHERE bcfv.bin_id = b.id), '{}') AS custom_fields`;
 }
 
 /**

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -58,6 +58,7 @@ export const config = Object.freeze({
 
   // Auth
   adminPassword: process.env.ADMIN_PASSWORD || null,
+  adminEmail: process.env.ADMIN_EMAIL || null,
   jwtSecret: resolveJwtSecret(),
   accessTokenExpiresIn: '15m',
   refreshTokenMaxDays: 7,
@@ -131,7 +132,7 @@ export const config = Object.freeze({
   demoMode: parseBool(process.env.DEMO_MODE, false),
   demoSeedPath: null as string | null,
   aiMock: parseBool(process.env.AI_MOCK, false),
-  demoUsernames: new Set<string>(),
+  demoEmails: new Set<string>(),
 
   // ClamAV malware scanning (opt-in for cloud deployments)
   clamavHost: process.env.CLAMAV_HOST || null,
@@ -290,8 +291,8 @@ export function isGroupEnvLocked(group: AiTaskGroup): boolean {
   return !!(o.provider || o.apiKey || o.model || o.endpointUrl);
 }
 
-/** Returns true if the request user is in the DEMO_USERNAMES list. */
-export function isDemoUser(req: { user?: { username: string } }): boolean {
+/** Returns true if the request user is a demo account. */
+export function isDemoUser(req: { user?: { email: string } }): boolean {
   if (!req.user) return false;
-  return config.demoUsernames.has(req.user.username.toLowerCase());
+  return config.demoEmails.has(req.user.email.toLowerCase());
 }

--- a/server/src/lib/demoSeed.ts
+++ b/server/src/lib/demoSeed.ts
@@ -30,7 +30,7 @@ import { generateShortCode } from './shortCode.js';
 const log = createLogger('demoSeed');
 
 interface ExternalDemoData {
-  users: Record<string, string>;
+  users: Record<string, { email: string; displayName: string }>;
   locations: { home: string; storage: string };
   homeAreas: string[];
   nestedAreas: Record<string, string[]>;
@@ -94,11 +94,13 @@ async function createLocation(tx: TxQueryFn, userId: string, name: string): Prom
   return locationId;
 }
 
-async function cleanupExistingDemoUsers(tx: TxQueryFn, usernames: string[]): Promise<void> {
-  for (const username of usernames) {
+async function cleanupExistingDemoUsers(tx: TxQueryFn, members: DemoMember[], users: Record<DemoMember, { email: string; displayName: string }>): Promise<void> {
+  for (const member of members) {
+    const info = users[member];
+    if (!info) continue;
     const existing = await tx<{ id: string }>(
-      'SELECT id FROM users WHERE username = $1',
-      [username],
+      'SELECT id FROM users WHERE email = $1',
+      [info.email],
     );
     if (existing.rows.length > 0) {
       await tx('DELETE FROM locations WHERE created_by = $1', [existing.rows[0].id]);
@@ -107,14 +109,14 @@ async function cleanupExistingDemoUsers(tx: TxQueryFn, usernames: string[]): Pro
   }
 }
 
-async function createDemoUsers(tx: TxQueryFn, passwordHash: string, users: Record<string, string>): Promise<Map<DemoMember, string>> {
+async function createDemoUsers(tx: TxQueryFn, passwordHash: string, users: Record<DemoMember, { email: string; displayName: string }>): Promise<Map<DemoMember, string>> {
   const userIdMap = new Map<DemoMember, string>();
-  for (const [username, displayName] of Object.entries(users)) {
+  for (const [member, info] of Object.entries(users) as [DemoMember, { email: string; displayName: string }][]) {
     const id = generateUuid();
-    userIdMap.set(username as DemoMember, id);
+    userIdMap.set(member, id);
     await tx(
-      'INSERT INTO users (id, username, password_hash, display_name) VALUES ($1, $2, $3, $4)',
-      [id, username, passwordHash, displayName],
+      'INSERT INTO users (id, email, password_hash, display_name) VALUES ($1, $2, $3, $4)',
+      [id, info.email, passwordHash, info.displayName],
     );
   }
   return userIdMap;
@@ -379,8 +381,8 @@ async function seedScanHistory(tx: TxQueryFn, userIdMap: Map<DemoMember, string>
 }
 
 async function seedOnboardingPrefs(tx: TxQueryFn, userIdMap: Map<DemoMember, string>): Promise<void> {
-  for (const [username, id] of userIdMap.entries()) {
-    const prefs = username === 'demo'
+  for (const [member, id] of userIdMap.entries()) {
+    const prefs = member === 'demo'
       ? { onboarding_completed: false, onboarding_step: 0 }
       : { onboarding_completed: true };
     await tx(
@@ -450,7 +452,7 @@ export async function seedDemoData(): Promise<void> {
 
   const external = loadExternalDemoData();
   const users = external?.users ?? DEMO_USERS;
-  const usernames = Object.keys(users);
+  const members = Object.keys(users) as DemoMember[];
   const locationNames = external?.locations ?? { home: 'Our House', storage: 'Self Storage Unit' };
   const homeAreaNames = external?.homeAreas ?? HOME_AREAS;
   const nestedAreaDefs = external?.nestedAreas ?? NESTED_AREAS;
@@ -474,11 +476,11 @@ export async function seedDemoData(): Promise<void> {
 
   try {
     await withTransaction(async (tx) => {
-      await cleanupExistingDemoUsers(tx, usernames);
+      await cleanupExistingDemoUsers(tx, members, users as Record<DemoMember, { email: string; displayName: string }>);
 
       const randomPassword = crypto.randomBytes(32).toString('hex');
       const passwordHash = bcrypt.hashSync(randomPassword, 10);
-      const userIdMap = await createDemoUsers(tx, passwordHash, users);
+      const userIdMap = await createDemoUsers(tx, passwordHash, users as Record<DemoMember, { email: string; displayName: string }>);
       const userId = userIdMap.get('demo')!;
 
       const { homeLocationId, storageLocationId } = await setupLocations(tx, userId, locationNames);
@@ -500,7 +502,7 @@ export async function seedDemoData(): Promise<void> {
     const homeBins = bins.filter((b) => b.location === 'home').length;
     const storageBins = bins.filter((b) => b.location === 'storage').length;
     const totalAreas = homeAreaNames.length + Object.values(nestedAreaDefs).flat().length + storageAreaNames.length;
-    const message = `Demo data seeded in ${elapsed}ms (${usernames.length} users, ${homeBins} + ${storageBins} bins, ${trashedBinsList.length} trashed, ${totalAreas} areas, ${cfDefs.length} custom fields, ${activityEntries.length} activity log entries across 2 locations)`;
+    const message = `Demo data seeded in ${elapsed}ms (${members.length} users, ${homeBins} + ${storageBins} bins, ${trashedBinsList.length} trashed, ${totalAreas} areas, ${cfDefs.length} custom fields, ${activityEntries.length} activity log entries across 2 locations)`;
     log.info(message);
     pushLog({ level: 'info', message });
   } catch (err) {

--- a/server/src/lib/demoSeedData.ts
+++ b/server/src/lib/demoSeedData.ts
@@ -16,15 +16,15 @@ export interface DemoBin {
   visibility?: 'location' | 'private';
 }
 
-export const DEMO_USERS: Record<DemoMember, string> = {
-  demo: 'Darrin DeYoung',
-  sarah: 'Sarah DeYoung',
-  alex: 'Alex DeYoung',
-  jordan: 'Jordan DeYoung',
-  pat: 'Pat DeYoung',
+export const DEMO_USERS: Record<DemoMember, { email: string; displayName: string }> = {
+  demo: { email: 'demo@openbin.local', displayName: 'Darrin DeYoung' },
+  sarah: { email: 'sarah@openbin.local', displayName: 'Sarah DeYoung' },
+  alex: { email: 'alex@openbin.local', displayName: 'Alex DeYoung' },
+  jordan: { email: 'jordan@openbin.local', displayName: 'Jordan DeYoung' },
+  pat: { email: 'pat@openbin.local', displayName: 'Pat DeYoung' },
 };
 
-export const DEMO_USERNAMES = Object.keys(DEMO_USERS) as DemoMember[];
+export const DEMO_MEMBERS = Object.keys(DEMO_USERS) as DemoMember[];
 
 export const HOME_AREAS = ['Garage', 'Kitchen', "Kids' Room", 'Basement', 'Closet', 'Office'];
 

--- a/server/src/lib/eeHooks.ts
+++ b/server/src/lib/eeHooks.ts
@@ -1,7 +1,6 @@
 export interface NewUserPayload {
   userId: string;
   email: string | null;
-  username: string;
   activeUntil: string;
   status: string;
 }

--- a/server/src/lib/exportHelpers.ts
+++ b/server/src/lib/exportHelpers.ts
@@ -85,7 +85,7 @@ export interface ExportSavedView {
 
 export interface ExportMember {
   userId: string;
-  username: string;
+  email: string;
   role: 'admin' | 'member' | 'viewer';
   joinedAt: string;
 }
@@ -510,16 +510,16 @@ export async function fetchLocationSavedViews(locationId: string, userId?: strin
   }));
 }
 
-/** Fetch location members with usernames for export. */
+/** Fetch location members with emails for export. */
 export async function fetchLocationMembers(locationId: string): Promise<ExportMember[]> {
-  const result = await query<{ user_id: string; username: string; role: 'admin' | 'member' | 'viewer'; joined_at: string }>(
-    `SELECT lm.user_id, u.username, lm.role, lm.joined_at
+  const result = await query<{ user_id: string; email: string; role: 'admin' | 'member' | 'viewer'; joined_at: string }>(
+    `SELECT lm.user_id, u.email, lm.role, lm.joined_at
      FROM location_members lm JOIN users u ON u.id = lm.user_id
      WHERE lm.location_id = $1
      ORDER BY lm.joined_at`,
     [locationId]
   );
-  return result.rows.map(r => ({ userId: r.user_id, username: r.username, role: r.role, joinedAt: r.joined_at }));
+  return result.rows.map(r => ({ userId: r.user_id, email: r.email, role: r.role, joinedAt: r.joined_at }));
 }
 
 /** Apply exported location settings. */

--- a/server/src/lib/oauth.ts
+++ b/server/src/lib/oauth.ts
@@ -95,29 +95,6 @@ export async function generateAppleClientSecret(): Promise<string> {
     .sign(key);
 }
 
-// -- Username generation --
-
-export async function generateUsername(email: string): Promise<string> {
-  const prefix = email.split('@')[0].replace(/[^a-zA-Z0-9_]/g, '').toLowerCase().slice(0, 50);
-  const base = prefix || 'user';
-
-  // Single query to find all taken usernames matching base or base+N
-  const taken = await query<{ username: string }>(
-    "SELECT username FROM users WHERE username = $1 OR username LIKE $1 || '%'",
-    [base]
-  );
-  const takenSet = new Set(taken.rows.map((r) => r.username));
-
-  if (!takenSet.has(base)) return base;
-
-  for (let i = 2; i < 1000; i++) {
-    const candidate = `${base}${i}`.slice(0, 50);
-    if (!takenSet.has(candidate)) return candidate;
-  }
-
-  return `${base}_${crypto.randomBytes(4).toString('hex')}`;
-}
-
 // -- Find or create OAuth user --
 
 interface OAuthUserInput {
@@ -128,7 +105,7 @@ interface OAuthUserInput {
 }
 
 interface OAuthUserResult {
-  user: { id: string; username: string; token_version: number };
+  user: { id: string; email: string; token_version: number };
   created: boolean;
 }
 
@@ -143,14 +120,14 @@ export async function findOrCreateOAuthUser(input: OAuthUserInput): Promise<OAut
 
   if (linkResult.rows.length > 0) {
     const userId = linkResult.rows[0].user_id;
-    const userResult = await query<{ id: string; username: string; token_version: number; deleted_at: string | null; suspended_at: string | null }>(
-      'SELECT id, username, token_version, deleted_at, suspended_at FROM users WHERE id = $1',
+    const userResult = await query<{ id: string; email: string; token_version: number; deleted_at: string | null; suspended_at: string | null }>(
+      'SELECT id, email, token_version, deleted_at, suspended_at FROM users WHERE id = $1',
       [userId]
     );
     const user = userResult.rows[0];
     if (user && !user.deleted_at) {
       if (user.suspended_at) throw new ForbiddenError('This account has been suspended');
-      return { user: { id: user.id, username: user.username, token_version: user.token_version }, created: false };
+      return { user: { id: user.id, email: user.email, token_version: user.token_version }, created: false };
     }
     // User deleted or missing — remove stale link so a fresh account can be created
     await query('DELETE FROM user_oauth_links WHERE provider = $1 AND provider_user_id = $2', [provider, providerUserId]);
@@ -169,22 +146,17 @@ export async function findOrCreateOAuthUser(input: OAuthUserInput): Promise<OAut
     throw new ForbiddenError('Registration requires an invite code');
   }
 
-  // 4. Create new user. If the email is already taken, retry without email to avoid
-  //    hijacking the existing account. Handled atomically via unique constraint.
-  const username = await generateUsername(email);
+  // 4. Create new user. Email is UNIQUE NOT NULL — if it's already taken, throw.
   const userId = generateUuid();
-
-  let emailUsed: string | null = email;
 
   await withTransaction(async (txQuery) => {
     try {
       await txQuery(
-        `INSERT INTO users (id, username, password_hash, display_name, email, plan, sub_status, active_until)
-         VALUES ($1, $2, NULL, $3, $4, $5, $6, $7)`,
+        `INSERT INTO users (id, password_hash, display_name, email, plan, sub_status, active_until)
+         VALUES ($1, NULL, $2, $3, $4, $5, $6)`,
         [
           userId,
-          username,
-          displayName || username,
+          displayName || email.split('@')[0],
           email,
           Plan.PLUS,
           SubStatus.TRIAL,
@@ -193,33 +165,20 @@ export async function findOrCreateOAuthUser(input: OAuthUserInput): Promise<OAut
       );
     } catch (err: unknown) {
       if (isUniqueViolation(err, 'idx_users_email_unique')) {
-        log.warn(`OAuth ${provider} login: email "${email}" already in use — creating account without email`);
-        emailUsed = null;
-        await txQuery(
-          `INSERT INTO users (id, username, password_hash, display_name, email, plan, sub_status, active_until)
-           VALUES ($1, $2, NULL, $3, NULL, $4, $5, $6)`,
-          [
-            userId,
-            username,
-            displayName || username,
-            Plan.PLUS,
-            SubStatus.TRIAL,
-            new Date(Date.now() + config.trialPeriodDays * 24 * 60 * 60 * 1000).toISOString(),
-          ]
-        );
-      } else {
-        throw err;
+        log.warn(`OAuth ${provider} login: email "${email}" already in use — cannot create account`);
+        throw new ForbiddenError('An account with this email already exists. Please link this provider from account settings.');
       }
+      throw err;
     }
 
     await txQuery(
       'INSERT INTO user_oauth_links (id, user_id, provider, provider_user_id, email) VALUES ($1, $2, $3, $4, $5)',
-      [generateUuid(), userId, provider, providerUserId, emailUsed]
+      [generateUuid(), userId, provider, providerUserId, email]
     );
   });
 
-  log.info(`Created new user "${username}" via ${provider} OAuth`);
-  return { user: { id: userId, username, token_version: 0 }, created: true };
+  log.info(`Created new user "${email}" via ${provider} OAuth`);
+  return { user: { id: userId, email, token_version: 0 }, created: true };
 }
 
 // -- Finalize OAuth login (issue tokens, record history, redirect) --
@@ -227,10 +186,10 @@ export async function findOrCreateOAuthUser(input: OAuthUserInput): Promise<OAut
 export async function finalizeOAuthLogin(
   req: import('express').Request,
   res: Response,
-  user: { id: string; username: string; token_version: number },
+  user: { id: string; email: string; token_version: number },
   provider: string,
 ): Promise<void> {
-  const accessToken = await signToken({ id: user.id, username: user.username }, user.token_version);
+  const accessToken = await signToken({ id: user.id, email: user.email }, user.token_version);
   const refresh = await createRefreshToken(user.id);
   setAccessTokenCookie(res, accessToken);
   setRefreshTokenCookie(res, refresh.rawToken);
@@ -240,7 +199,7 @@ export async function finalizeOAuthLogin(
   query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 1)',
     [generateUuid(), user.id, ip, ua, provider]).catch(() => {});
 
-  log.info(`User "${user.username}" logged in via ${provider} OAuth`);
+  log.info(`User "${user.email}" logged in via ${provider} OAuth`);
   res.redirect('/?oauth=success');
 }
 

--- a/server/src/lib/oauth.ts
+++ b/server/src/lib/oauth.ts
@@ -164,7 +164,7 @@ export async function findOrCreateOAuthUser(input: OAuthUserInput): Promise<OAut
         ]
       );
     } catch (err: unknown) {
-      if (isUniqueViolation(err, 'idx_users_email_unique')) {
+      if (isUniqueViolation(err, 'idx_users_email_unique') || isUniqueViolation(err)) {
         log.warn(`OAuth ${provider} login: email "${email}" already in use — cannot create account`);
         throw new ForbiddenError('An account with this email already exists. Please link this provider from account settings.');
       }

--- a/server/src/lib/routeHelpers.ts
+++ b/server/src/lib/routeHelpers.ts
@@ -10,7 +10,7 @@ export function logRouteActivity(req: Request, opts: RouteActivityOptions): void
   logActivity({
     ...opts,
     userId: req.user!.id,
-    userName: req.user!.username,
+    userName: req.user!.email,
     authMethod: req.authMethod,
     apiKeyId: req.apiKeyId,
   });

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -13,9 +13,7 @@ export function validateLoginEmail(email: unknown): string {
     throw new ValidationError('Email is required');
   }
   const trimmed = email.trim().toLowerCase();
-  if (!EMAIL_REGEX.test(trimmed) || trimmed.length > 255) {
-    throw new ValidationError('Invalid email address');
-  }
+  validateEmail(trimmed);
   return trimmed;
 }
 

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -1,6 +1,5 @@
 import { ValidationError } from './httpErrors.js';
 
-const USERNAME_REGEX = /^[a-zA-Z0-9_]{3,50}$/;
 const EMAIL_REGEX = /^[^\s@+]+@[^\s@]+\.[^\s@]+$/;
 export const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
@@ -9,11 +8,15 @@ export function stripUnicodeControl(text: string): string {
   return text.replace(/[\u200B-\u200F\u2028-\u202F\u2060-\u206F\uFEFF\u00AD]/g, '');
 }
 
-export function validateUsername(username: unknown): string {
-  if (!username || typeof username !== 'string' || !USERNAME_REGEX.test(username)) {
-    throw new ValidationError('Username must be 3-50 characters (alphanumeric and underscores only)');
+export function validateLoginEmail(email: unknown): string {
+  if (!email || typeof email !== 'string' || !email.trim()) {
+    throw new ValidationError('Email is required');
   }
-  return username;
+  const trimmed = email.trim().toLowerCase();
+  if (!EMAIL_REGEX.test(trimmed) || trimmed.length > 255) {
+    throw new ValidationError('Invalid email address');
+  }
+  return trimmed;
 }
 
 export function isStrongPassword(password: string): boolean {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -9,7 +9,7 @@ const JWT_SECRET_KEY = new TextEncoder().encode(config.jwtSecret);
 
 export interface AuthUser {
   id: string;
-  username: string;
+  email: string;
 }
 
 declare global {
@@ -31,7 +31,7 @@ function extractToken(req: Request): string | undefined {
 
 interface JwtPayload {
   id: string;
-  username: string;
+  email: string;
   tv?: number; // token_version
 }
 
@@ -39,7 +39,7 @@ async function verifyJwt(token: string): Promise<(AuthUser & { tokenVersion: num
   try {
     const { payload } = await jose.jwtVerify(token, JWT_SECRET_KEY, { algorithms: ['HS256'] });
     const p = payload as unknown as JwtPayload;
-    return { id: p.id, username: p.username, tokenVersion: p.tv ?? 0 };
+    return { id: p.id, email: p.email, tokenVersion: p.tv ?? 0 };
   } catch {
     return null;
   }
@@ -160,7 +160,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
   if (token.startsWith('sk_openbin_')) {
     const keyHash = crypto.createHash('sha256').update(token).digest('hex');
     query(
-      `SELECT ak.id AS key_id, u.id, u.username, u.deleted_at, u.suspended_at, u.plan
+      `SELECT ak.id AS key_id, u.id, u.email, u.deleted_at, u.suspended_at, u.plan
        FROM api_keys ak
        JOIN users u ON u.id = ak.user_id
        WHERE ak.key_hash = $1 AND ak.revoked_at IS NULL`,
@@ -170,7 +170,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
         res.status(401).json({ error: 'UNAUTHORIZED', message: 'Invalid API key' });
         return;
       }
-      const row = result.rows[0] as { key_id: string; id: string; username: string; deleted_at: string | null; suspended_at: string | null; plan: number };
+      const row = result.rows[0] as { key_id: string; id: string; email: string; deleted_at: string | null; suspended_at: string | null; plan: number };
       if (row.deleted_at) {
         res.status(401).json({ error: 'ACCOUNT_DELETED', message: 'This account has been deleted' });
         return;
@@ -183,7 +183,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
         res.status(403).json({ error: 'PLAN_RESTRICTED', message: 'API key access requires a Pro plan' });
         return;
       }
-      req.user = { id: row.id, username: row.username };
+      req.user = { id: row.id, email: row.email };
       req.authMethod = 'api_key';
       req.apiKeyId = row.key_id;
       maybeUpdateLastActive(row.id);
@@ -207,7 +207,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
           res.status(401).json({ error: 'SESSION_REVOKED', message: 'Session has been revoked. Please log in again.' });
           return;
         }
-        req.user = { id: user.id, username: user.username };
+        req.user = { id: user.id, email: user.email };
         req.authMethod = 'jwt';
         maybeUpdateLastActive(user.id);
         next();
@@ -219,7 +219,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction): v
 }
 
 export async function signToken(user: AuthUser, tokenVersion = 0): Promise<string> {
-  return new jose.SignJWT({ id: user.id, username: user.username, tv: tokenVersion })
+  return new jose.SignJWT({ id: user.id, email: user.email, tv: tokenVersion })
     .setProtectedHeader({ alg: 'HS256' })
     .setExpirationTime(config.accessTokenExpiresIn)
     .sign(JWT_SECRET_KEY);

--- a/server/src/middleware/demoConnectionLimiter.ts
+++ b/server/src/middleware/demoConnectionLimiter.ts
@@ -1,7 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import { config } from '../lib/config.js';
-import type { DemoMember } from '../lib/demoSeedData.js';
-import { DEMO_USERNAMES } from '../lib/demoSeedData.js';
+import { DEMO_MEMBERS, DEMO_USERS } from '../lib/demoSeedData.js';
 
 const PER_USER_MAX = 2;
 const TOTAL_DEMO_MAX = 6;
@@ -11,7 +10,7 @@ let totalDemoCount = 0;
 
 /** Check whether the authenticated user is a demo account. */
 export function isDemoUser(req: Request): boolean {
-  return config.demoMode && !!req.user && DEMO_USERNAMES.includes(req.user.username as DemoMember);
+  return config.demoMode && !!req.user && DEMO_MEMBERS.some((m) => DEMO_USERS[m].email === req.user!.email);
 }
 
 /**

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -16,7 +16,7 @@ import { createLogger } from '../lib/logger.js';
 import { createPasswordResetToken } from '../lib/passwordReset.js';
 import { getFeatureMap, invalidateOverLimitCache, isSelfHosted, Plan, type PlanTier, planLabel, SubStatus, type SubStatusType, subStatusLabel, validatePlanTransition } from '../lib/planGate.js';
 import { restoreBackup } from '../lib/restore.js';
-import { validateDisplayName, validateEmail, validateLoginEmail, validatePassword } from '../lib/validation.js';
+import { validateDisplayName, validateLoginEmail, validatePassword } from '../lib/validation.js';
 import { authenticate, invalidateDeletedCache } from '../middleware/auth.js';
 import { requireAdmin } from '../middleware/requireAdmin.js';
 
@@ -293,7 +293,7 @@ router.put('/users/:id', asyncHandler(async (req, res) => {
     }
   }
 
-  if (email !== undefined && email !== '') validateEmail(email);
+  const normalizedEmail = (email !== undefined && email !== '') ? validateLoginEmail(email) : undefined;
   if (displayName !== undefined) validateDisplayName(displayName);
   if (password !== undefined) validatePassword(password);
 
@@ -316,7 +316,7 @@ router.put('/users/:id', asyncHandler(async (req, res) => {
   }
   if (email !== undefined) {
     updates.push(`email = ${nextParam()}`);
-    updateParams.push(email === '' ? null : email);
+    updateParams.push(email === '' ? null : normalizedEmail ?? null);
   }
   if (displayName !== undefined) {
     updates.push(`display_name = ${nextParam()}`);

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -16,7 +16,7 @@ import { createLogger } from '../lib/logger.js';
 import { createPasswordResetToken } from '../lib/passwordReset.js';
 import { getFeatureMap, invalidateOverLimitCache, isSelfHosted, Plan, type PlanTier, planLabel, SubStatus, type SubStatusType, subStatusLabel, validatePlanTransition } from '../lib/planGate.js';
 import { restoreBackup } from '../lib/restore.js';
-import { validateDisplayName, validateEmail, validatePassword, validateUsername } from '../lib/validation.js';
+import { validateDisplayName, validateEmail, validateLoginEmail, validatePassword } from '../lib/validation.js';
 import { authenticate, invalidateDeletedCache } from '../middleware/auth.js';
 import { requireAdmin } from '../middleware/requireAdmin.js';
 
@@ -36,7 +36,7 @@ router.get('/users', asyncHandler(async (req, res) => {
   let whereClause = '';
   const params: unknown[] = [];
   if (q) {
-    whereClause = 'WHERE (LOWER(u.username) LIKE $1 OR LOWER(u.email) LIKE $1 OR LOWER(u.display_name) LIKE $1)';
+    whereClause = 'WHERE (LOWER(u.email) LIKE $1 OR LOWER(u.display_name) LIKE $1)';
     params.push(`%${q.toLowerCase()}%`);
   }
 
@@ -50,7 +50,6 @@ router.get('/users', asyncHandler(async (req, res) => {
   const field = desc ? sortField.slice(1) : sortField;
 
   const sortMap: Record<string, string> = {
-    username: 'u.username',
     email: 'u.email',
     plan: 'u.plan',
     status: 'u.sub_status',
@@ -74,7 +73,7 @@ router.get('/users', asyncHandler(async (req, res) => {
   const orderDir = desc ? 'DESC' : 'ASC';
 
   const usersResult = await query(
-    `SELECT u.id, u.username, u.display_name, u.email, u.is_admin, u.plan, u.sub_status,
+    `SELECT u.id, u.email, u.display_name, u.is_admin, u.plan, u.sub_status,
        u.active_until, u.deleted_at, u.suspended_at, u.created_at, u.last_active_at,
        u.ai_credits_used, u.ai_credits_reset_at,
        (SELECT COUNT(*) FROM bins b JOIN location_members lm ON b.location_id = lm.location_id WHERE lm.user_id = u.id AND b.deleted_at IS NULL) AS bin_count,
@@ -96,9 +95,8 @@ router.get('/users', asyncHandler(async (req, res) => {
     const features = getFeatureMap(u.plan as PlanTier);
     return {
       id: u.id,
-      username: u.username,
-      displayName: u.display_name,
       email: u.email || null,
+      displayName: u.display_name,
       isAdmin: !!u.is_admin,
       plan: planLabel(u.plan),
       status: subStatusLabel(u.sub_status),
@@ -128,12 +126,11 @@ router.get('/users', asyncHandler(async (req, res) => {
 
 // POST /api/admin/users — create a new user (admin only)
 router.post('/users', asyncHandler(async (req, res) => {
-  const { username, password, displayName, email, isAdmin } = req.body;
+  const { email, password, displayName, isAdmin } = req.body;
 
-  validateUsername(username);
+  const trimmedEmail = validateLoginEmail(email);
   validatePassword(password);
   if (displayName !== undefined) validateDisplayName(displayName);
-  if (email !== undefined && email !== '') validateEmail(email);
 
   const passwordHash = await bcrypt.hash(password, config.bcryptRounds);
   const userId = generateUuid();
@@ -141,15 +138,14 @@ router.post('/users', asyncHandler(async (req, res) => {
   let result: import('../db.js').QueryResult<Record<string, unknown>>;
   try {
     result = await query(
-      `INSERT INTO users (id, username, password_hash, display_name, email, is_admin, plan, sub_status, active_until)
-       VALUES ($1, $2, $3, $4, $5, ${isAdmin ? 'TRUE' : 'FALSE'}, $6, $7, $8)
-       RETURNING id, username, display_name, email, is_admin, plan, sub_status, created_at`,
+      `INSERT INTO users (id, password_hash, display_name, email, is_admin, plan, sub_status, active_until)
+       VALUES ($1, $2, $3, $4, ${isAdmin ? 'TRUE' : 'FALSE'}, $5, $6, $7)
+       RETURNING id, email, display_name, is_admin, plan, sub_status, created_at`,
       [
         userId,
-        username.toLowerCase(),
         passwordHash,
-        displayName || username,
-        email || null,
+        displayName || trimmedEmail.split('@')[0],
+        trimmedEmail,
         Plan.PLUS,
         isSelfHosted() ? SubStatus.ACTIVE : SubStatus.TRIAL,
         isSelfHosted()
@@ -159,23 +155,22 @@ router.post('/users', asyncHandler(async (req, res) => {
     );
   } catch (err: unknown) {
     if (isUniqueViolation(err)) {
-      throw new ConflictError('Username already taken');
+      throw new ConflictError('Email already taken');
     }
     throw err;
   }
 
   const user = result.rows[0] as {
-    id: string; username: string; display_name: string; email: string | null;
+    id: string; email: string; display_name: string;
     is_admin: number; plan: PlanTier; sub_status: SubStatusType; created_at: string;
   };
 
-  log.info(`User ${req.user!.username} created user ${username}`);
+  log.info(`User ${req.user!.email} created user ${trimmedEmail}`);
 
   res.status(201).json({
     id: user.id,
-    username: user.username,
-    displayName: user.display_name,
     email: user.email,
+    displayName: user.display_name,
     isAdmin: !!user.is_admin,
     plan: planLabel(user.plan),
     status: subStatusLabel(user.sub_status),
@@ -188,13 +183,13 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
   const userId = req.params.id;
 
   const userResult = await query<{
-    id: string; username: string; display_name: string; email: string | null;
+    id: string; email: string; display_name: string;
     is_admin: number; plan: PlanTier; sub_status: SubStatusType;
     active_until: string | null; deleted_at: string | null; suspended_at: string | null;
     created_at: string; updated_at: string;
     last_active_at: string | null; ai_credits_used: number | null; ai_credits_reset_at: string | null;
   }>(
-    'SELECT id, username, display_name, email, is_admin, plan, sub_status, active_until, deleted_at, suspended_at, force_password_change, created_at, updated_at, last_active_at, ai_credits_used, ai_credits_reset_at FROM users WHERE id = $1',
+    'SELECT id, email, display_name, is_admin, plan, sub_status, active_until, deleted_at, suspended_at, force_password_change, created_at, updated_at, last_active_at, ai_credits_used, ai_credits_reset_at FROM users WHERE id = $1',
     [userId],
   );
 
@@ -218,9 +213,8 @@ router.get('/users/:id', asyncHandler(async (req, res) => {
 
   res.json({
     id: row.id,
-    username: row.username,
-    displayName: row.display_name,
     email: row.email,
+    displayName: row.display_name,
     isAdmin: !!row.is_admin,
     plan: planLabel(row.plan),
     status: subStatusLabel(row.sub_status),
@@ -260,8 +254,8 @@ router.put('/users/:id', asyncHandler(async (req, res) => {
     throw new ValidationError('Nothing to update');
   }
 
-  const targetResult = await query<{ id: string; username: string; is_admin: number; sub_status: number; plan: number }>(
-    'SELECT id, username, is_admin, sub_status, plan FROM users WHERE id = $1',
+  const targetResult = await query<{ id: string; email: string; is_admin: number; sub_status: number; plan: number }>(
+    'SELECT id, email, is_admin, sub_status, plan FROM users WHERE id = $1',
     [targetId],
   );
   const target = targetResult.rows[0];
@@ -403,7 +397,7 @@ router.put('/users/:id', asyncHandler(async (req, res) => {
   }
 
   const { password: _, ...safeBody } = req.body;
-  log.info(`User ${req.user!.username} updated user ${target.username}: ${JSON.stringify(safeBody)}`);
+  log.info(`User ${req.user!.email} updated user ${target.email}: ${JSON.stringify(safeBody)}`);
 
   res.json({ message: 'User updated' });
 }));
@@ -416,8 +410,8 @@ router.delete('/users/:id', asyncHandler(async (req, res) => {
     throw new ForbiddenError('Cannot delete your own account via admin');
   }
 
-  const targetResult = await query<{ id: string; username: string; is_admin: number }>(
-    'SELECT id, username, is_admin FROM users WHERE id = $1',
+  const targetResult = await query<{ id: string; email: string; is_admin: number }>(
+    'SELECT id, email, is_admin FROM users WHERE id = $1',
     [targetId],
   );
   const target = targetResult.rows[0];
@@ -437,7 +431,7 @@ router.delete('/users/:id', asyncHandler(async (req, res) => {
 
   getEeHooks().onUserUpdate?.({ userId: targetId, action: 'delete_user' });
 
-  log.info(`User ${req.user!.username} soft-deleted user ${target.username}`);
+  log.info(`User ${req.user!.email} soft-deleted user ${target.email}`);
 
   res.json({ message: 'User marked for deletion' });
 }));
@@ -446,8 +440,8 @@ router.delete('/users/:id', asyncHandler(async (req, res) => {
 router.post('/users/:id/regenerate-api-key', asyncHandler(async (req, res) => {
   const targetId = req.params.id;
 
-  const targetResult = await query<{ id: string; username: string }>(
-    'SELECT id, username FROM users WHERE id = $1',
+  const targetResult = await query<{ id: string; email: string }>(
+    'SELECT id, email FROM users WHERE id = $1',
     [targetId],
   );
   const target = targetResult.rows[0];
@@ -470,7 +464,7 @@ router.post('/users/:id/regenerate-api-key', asyncHandler(async (req, res) => {
     [id, targetId, keyHash, keyPrefix, 'Admin-generated key'],
   );
 
-  log.info(`User ${req.user!.username} regenerated API key for user ${target.username}`);
+  log.info(`User ${req.user!.email} regenerated API key for user ${target.email}`);
 
   res.json({ keyPrefix, name: 'Admin-generated key', createdAt: new Date().toISOString() });
 }));
@@ -479,20 +473,19 @@ router.post('/users/:id/regenerate-api-key', asyncHandler(async (req, res) => {
 router.post('/users/:id/send-password-reset', asyncHandler(async (req, res) => {
   const targetId = req.params.id;
 
-  const targetResult = await query<{ id: string; username: string; email: string | null; display_name: string }>(
-    'SELECT id, username, email, display_name FROM users WHERE id = $1',
+  const targetResult = await query<{ id: string; email: string; display_name: string }>(
+    'SELECT id, email, display_name FROM users WHERE id = $1',
     [targetId],
   );
   const target = targetResult.rows[0];
   if (!target) throw new NotFoundError('User not found');
-  if (!target.email) throw new ValidationError('User does not have an email address');
 
   const { rawToken } = await createPasswordResetToken(targetId, req.user!.id);
   const resetUrl = `${config.baseUrl}/reset-password?token=${encodeURIComponent(rawToken)}`;
 
   firePasswordResetEmail(targetId, target.email, target.display_name, resetUrl);
 
-  log.info(`User ${req.user!.username} sent password reset for user ${target.username}`);
+  log.info(`User ${req.user!.email} sent password reset for user ${target.email}`);
 
   res.json({ message: 'Password reset email sent' });
 }));
@@ -515,7 +508,7 @@ router.patch('/registration', asyncHandler(async (req, res) => {
     [mode],
   );
 
-  log.info(`User ${req.user!.username} changed registration mode to ${mode}`);
+  log.info(`User ${req.user!.email} changed registration mode to ${mode}`);
 
   res.json({ mode });
 }));
@@ -542,7 +535,7 @@ export async function getRegistrationMode(): Promise<string> {
 // POST /api/admin/backup — trigger on-demand backup
 router.post('/backup', asyncHandler(async (req, res) => {
   const zipPath = await runBackup();
-  log.info(`On-demand backup created by ${req.user!.username}`);
+  log.info(`On-demand backup created by ${req.user!.email}`);
   res.json({ message: 'Backup created', filename: path.basename(zipPath) });
 }));
 
@@ -572,7 +565,7 @@ router.post('/restore', restoreUpload, asyncHandler(async (req, res) => {
     throw new HttpError(500, 'RESTORE_FAILED', result.error || 'Unknown restore error');
   }
 
-  log.info(`Backup restored by ${req.user!.username}`);
+  log.info(`Backup restored by ${req.user!.email}`);
   res.json({ message: 'Backup restored successfully' });
 }));
 

--- a/server/src/routes/adminOverrides.ts
+++ b/server/src/routes/adminOverrides.ts
@@ -87,11 +87,11 @@ router.put('/overrides/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'update_overrides',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
     details: { maxBins, maxLocations, maxPhotoStorageMb, maxMembersPerLocation, activityRetentionDays, aiCreditsPerMonth, aiEnabled },
   });
 
@@ -112,11 +112,11 @@ router.delete('/overrides/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'clear_overrides',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
   });
 
   res.json({ message: 'Overrides cleared' });
@@ -142,11 +142,11 @@ router.post('/ai-credits/grant/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'grant_ai_credits',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
     details: { amount },
   });
 
@@ -170,11 +170,11 @@ router.post('/ai-credits/reset/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'reset_ai_credits',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
   });
 
   res.json({ message: 'AI credits reset' });
@@ -192,8 +192,8 @@ router.post('/extend-trial/:userId', asyncHandler(async (req, res) => {
     throw new ValidationError('days must be an integer between 1 and 90');
   }
 
-  const userResult = await query<{ id: string; username: string; sub_status: number; active_until: string | null }>(
-    'SELECT id, username, sub_status, active_until FROM users WHERE id = $1',
+  const userResult = await query<{ id: string; email: string; sub_status: number; active_until: string | null }>(
+    'SELECT id, email, sub_status, active_until FROM users WHERE id = $1',
     [userId],
   );
   const target = userResult.rows[0];
@@ -216,11 +216,11 @@ router.post('/extend-trial/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'extend_trial',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
     details: { days, newActiveUntil },
   });
 
@@ -254,11 +254,11 @@ router.post('/grant-comp/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'grant_comp_plan',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
     details: { plan: planLabel(plan as PlanTier), days, activeUntil },
   });
 
@@ -293,11 +293,11 @@ router.post('/force-downgrade/:userId', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'force_downgrade',
     targetType: 'user',
     targetId: userId,
-    targetName: target.username,
+    targetName: target.email,
     details: { from: planLabel(oldPlan), to: planLabel(plan as PlanTier) },
   });
 

--- a/server/src/routes/adminSecurity.ts
+++ b/server/src/routes/adminSecurity.ts
@@ -19,8 +19,8 @@ router.post('/suspend/:id', asyncHandler(async (req, res) => {
     throw new ForbiddenError('Cannot suspend yourself');
   }
 
-  const targetResult = await query<{ id: string; username: string; is_admin: number; suspended_at: string | null }>(
-    'SELECT id, username, is_admin, suspended_at FROM users WHERE id = $1',
+  const targetResult = await query<{ id: string; email: string; is_admin: number; suspended_at: string | null }>(
+    'SELECT id, email, is_admin, suspended_at FROM users WHERE id = $1',
     [targetId],
   );
   const target = targetResult.rows[0];
@@ -39,11 +39,11 @@ router.post('/suspend/:id', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'suspend_user',
     targetType: 'user',
     targetId,
-    targetName: target.username,
+    targetName: target.email,
     details: { reason: reason || null },
   });
 
@@ -54,8 +54,8 @@ router.post('/suspend/:id', asyncHandler(async (req, res) => {
 router.post('/reactivate/:id', asyncHandler(async (req, res) => {
   const targetId = req.params.id;
 
-  const targetResult = await query<{ id: string; username: string; suspended_at: string | null }>(
-    'SELECT id, username, suspended_at FROM users WHERE id = $1',
+  const targetResult = await query<{ id: string; email: string; suspended_at: string | null }>(
+    'SELECT id, email, suspended_at FROM users WHERE id = $1',
     [targetId],
   );
   const target = targetResult.rows[0];
@@ -74,11 +74,11 @@ router.post('/reactivate/:id', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'reactivate_user',
     targetType: 'user',
     targetId,
-    targetName: target.username,
+    targetName: target.email,
   });
 
   res.json({ message: 'User reactivated' });
@@ -104,11 +104,11 @@ router.post('/revoke-sessions/:id', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'revoke_sessions',
     targetType: 'user',
     targetId,
-    targetName: target.username,
+    targetName: target.email,
   });
 
   res.json({ message: 'All sessions revoked' });
@@ -127,11 +127,11 @@ router.post('/revoke-all-api-keys/:id', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'revoke_all_api_keys',
     targetType: 'user',
     targetId,
-    targetName: target.username,
+    targetName: target.email,
     details: { count: revokedCount },
   });
 
@@ -190,11 +190,11 @@ router.post('/force-password-change/:id', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'force_password_change',
     targetType: 'user',
     targetId,
-    targetName: target.username,
+    targetName: target.email,
     details: { enabled },
   });
 
@@ -210,7 +210,7 @@ router.post('/force-logout-all', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'force_logout_all',
     targetType: 'system',
   });

--- a/server/src/routes/adminSystem.ts
+++ b/server/src/routes/adminSystem.ts
@@ -50,7 +50,7 @@ router.post('/maintenance', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'toggle_maintenance',
     targetType: 'system',
     details: { enabled, message: message ?? '' },
@@ -121,7 +121,7 @@ router.post('/announcements', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'create_announcement',
     targetType: 'announcement',
     targetId: id,
@@ -155,7 +155,7 @@ router.delete('/announcements/:id', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'delete_announcement',
     targetType: 'announcement',
     targetId: id,
@@ -304,11 +304,11 @@ router.get('/locations', asyncHandler(async (req, res) => {
       params,
     ),
     query<{
-    id: string; name: string; owner_username: string | null; owner_display_name: string | null;
+    id: string; name: string; owner_email: string | null; owner_display_name: string | null;
     member_count: number; bin_count: number; area_count: number; created_at: string;
   }>(
     `SELECT l.id, l.name,
-       u.username AS owner_username,
+       u.email AS owner_email,
        u.display_name AS owner_display_name,
        (SELECT COUNT(*) FROM location_members lm WHERE lm.location_id = l.id) AS member_count,
        (SELECT COUNT(*) FROM bins b WHERE b.location_id = l.id AND b.deleted_at IS NULL) AS bin_count,
@@ -326,7 +326,7 @@ router.get('/locations', asyncHandler(async (req, res) => {
   const results = dataResult.rows.map((row) => ({
     id: row.id,
     name: row.name,
-    ownerUsername: row.owner_username ?? null,
+    ownerEmail: row.owner_email ?? null,
     ownerDisplayName: row.owner_display_name ?? null,
     memberCount: row.member_count ?? 0,
     binCount: row.bin_count ?? 0,
@@ -370,7 +370,7 @@ router.post('/locations/:id/force-join', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'force_join_location',
     targetType: 'location',
     targetId: locationId,
@@ -396,7 +396,7 @@ router.delete('/locations/:locationId/members/:userId', asyncHandler(async (req,
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'remove_member',
     targetType: 'location_member',
     targetId: userId,
@@ -426,7 +426,7 @@ router.put('/locations/:locationId/members/:userId/role', asyncHandler(async (re
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'change_member_role',
     targetType: 'location_member',
     targetId: userId,
@@ -461,11 +461,11 @@ router.get('/bins', asyncHandler(async (req, res) => {
 
   const dataResult = await query<{
     id: string; name: string; short_code: string; location_name: string;
-    owner_username: string | null; created_at: string; updated_at: string;
+    owner_email: string | null; created_at: string; updated_at: string;
   }>(
     `SELECT b.id, b.name, b.short_code,
        l.name AS location_name,
-       u.username AS owner_username,
+       u.email AS owner_email,
        b.created_at, b.updated_at
      FROM bins b
      JOIN locations l ON b.location_id = l.id
@@ -481,7 +481,7 @@ router.get('/bins', asyncHandler(async (req, res) => {
     name: row.name,
     shortCode: row.short_code,
     locationName: row.location_name,
-    ownerUsername: row.owner_username ?? null,
+    ownerEmail: row.owner_email ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }));
@@ -498,9 +498,9 @@ router.get('/bins/:id', asyncHandler(async (req, res) => {
     area_id: string | null; notes: string; tags: string; icon: string;
     color: string; card_style: string; visibility: string;
     created_by: string | null; created_at: string; updated_at: string;
-    deleted_at: string | null; location_name: string; owner_username: string | null;
+    deleted_at: string | null; location_name: string; owner_email: string | null;
   }>(
-    `SELECT b.*, l.name AS location_name, u.username AS owner_username
+    `SELECT b.*, l.name AS location_name, u.email AS owner_email
      FROM bins b
      JOIN locations l ON b.location_id = l.id
      LEFT JOIN users u ON b.created_by = u.id
@@ -536,7 +536,7 @@ router.get('/bins/:id', asyncHandler(async (req, res) => {
     color: bin.color,
     cardStyle: bin.card_style,
     visibility: bin.visibility,
-    ownerUsername: bin.owner_username ?? null,
+    ownerEmail: bin.owner_email ?? null,
     createdBy: bin.created_by ?? null,
     createdAt: bin.created_at,
     updatedAt: bin.updated_at,
@@ -568,7 +568,7 @@ router.post('/locations/:id/regen-invite', asyncHandler(async (req, res) => {
 
   logAdminAction({
     actorId: req.user!.id,
-    actorName: req.user!.username,
+    actorName: req.user!.email,
     action: 'regen_invite_code',
     targetType: 'location',
     targetId: locationId,

--- a/server/src/routes/apiKeys.ts
+++ b/server/src/routes/apiKeys.ts
@@ -51,7 +51,7 @@ router.post('/', requirePro(), asyncHandler(async (req, res) => {
     [id, req.user!.id, keyHash, keyPrefix, (name || '').trim().slice(0, 255)]
   );
 
-  log.info(`API key created: ${keyPrefix} by user ${req.user!.username}`);
+  log.info(`API key created: ${keyPrefix} by user ${req.user!.email}`);
 
   res.status(201).json({
     id,
@@ -76,7 +76,7 @@ router.delete('/:id', requirePro(), asyncHandler(async (req, res) => {
     throw new NotFoundError('API key not found');
   }
 
-  log.info(`API key revoked: ${id} by user ${req.user!.username}`);
+  log.info(`API key revoked: ${id} by user ${req.user!.email}`);
   res.json({ message: 'API key revoked' });
 }));
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -27,7 +27,7 @@ import { consumeResetToken, createPasswordResetToken } from '../lib/passwordRese
 import { safePath } from '../lib/pathSafety.js';
 import { isSelfHosted, Plan, planLabel, SubStatus, subStatusLabel } from '../lib/planGate.js';
 import { createRefreshToken, revokeAllUserTokens, revokeSingleToken, rotateRefreshToken } from '../lib/refreshTokens.js';
-import { validateDisplayName, validateEmail, validatePassword, validateUsername } from '../lib/validation.js';
+import { validateDisplayName, validateEmail, validateLoginEmail, validatePassword } from '../lib/validation.js';
 import { authenticate, invalidateUserStatusCache, signToken } from '../middleware/auth.js';
 import { getMaintenanceMessage, isMaintenanceMode } from '../middleware/maintenance.js';
 
@@ -75,8 +75,8 @@ router.post('/demo-login', asyncHandler(async (_req, res) => {
   }
 
   const result = await query(
-    'SELECT id, username, display_name, email, avatar_path, active_location_id FROM users WHERE username = $1',
-    ['demo'],
+    'SELECT id, display_name, email, avatar_path, active_location_id FROM users WHERE email = $1',
+    ['demo@openbin.local'],
   );
 
   if (result.rows.length === 0) {
@@ -95,7 +95,7 @@ router.post('/demo-login', asyncHandler(async (_req, res) => {
     await query('INSERT INTO user_preferences (id, user_id, settings) VALUES ($1, $2, $3)', [generateUuid(), user.id, resetSettings]);
   }
 
-  const token = await signToken({ id: user.id, username: user.username });
+  const token = await signToken({ id: user.id, email: user.email });
   const refresh = await createRefreshToken(user.id);
 
   setAccessTokenCookie(res, token);
@@ -104,9 +104,8 @@ router.post('/demo-login', asyncHandler(async (_req, res) => {
   res.json({
     user: {
       id: user.id,
-      username: user.username,
       displayName: user.display_name,
-      email: user.email || null,
+      email: user.email,
       avatarUrl: user.avatar_path ? `/api/auth/avatar/${user.id}` : null,
     },
     activeLocationId: user.active_location_id || null,
@@ -146,7 +145,7 @@ router.post('/register', asyncHandler(async (req, res) => {
     throw new ForbiddenError('Registration is currently disabled');
   }
 
-  const { username, password, displayName, email, inviteCode } = req.body;
+  const { email, password, displayName, inviteCode } = req.body;
 
   // In invite mode, invite code is required
   if (regMode === 'invite' && !inviteCode) {
@@ -166,28 +165,22 @@ router.post('/register', asyncHandler(async (req, res) => {
     locationToJoin = locResult.rows[0] as { id: string; default_join_role: string };
   }
 
-  validateUsername(username);
+  const trimmedEmail = validateLoginEmail(email);
   validatePassword(password);
-  if (displayName !== undefined) validateDisplayName(displayName);
-  const trimmedEmail = (typeof email === 'string' && email.trim()) || null;
-  if (!isSelfHosted() && !trimmedEmail) {
-    throw new ValidationError('Email is required');
-  }
-  if (trimmedEmail) validateEmail(trimmedEmail);
+  validateDisplayName(displayName);
 
   const passwordHash = await bcrypt.hash(password, config.bcryptRounds);
   const userId = generateUuid();
   let result: import('../db.js').QueryResult<Record<string, unknown>>;
   try {
     result = await query(
-      `INSERT INTO users (id, username, password_hash, display_name, email, plan, sub_status, active_until)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-       RETURNING id, username, display_name, email, created_at, active_until`,
+      `INSERT INTO users (id, password_hash, display_name, email, plan, sub_status, active_until)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, display_name, email, created_at, active_until`,
       [
         userId,
-        username.toLowerCase(),
         passwordHash,
-        displayName || username,
+        displayName.trim(),
         trimmedEmail,
         Plan.PLUS,
         isSelfHosted() ? SubStatus.ACTIVE : SubStatus.TRIAL,
@@ -206,7 +199,7 @@ router.post('/register', asyncHandler(async (req, res) => {
     throw err;
   }
 
-  const user = result.rows[0] as { id: string; username: string; display_name: string; email: string | null; created_at: string; active_until: string };
+  const user = result.rows[0] as { id: string; display_name: string; email: string; created_at: string; active_until: string };
 
   // Auto-join location if invite code was valid
   if (locationToJoin) {
@@ -217,20 +210,19 @@ router.post('/register', asyncHandler(async (req, res) => {
     await query('UPDATE users SET active_location_id = $1 WHERE id = $2', [locationToJoin.id, user.id]);
   }
 
-  const token = await signToken({ id: user.id, username: user.username });
+  const token = await signToken({ id: user.id, email: user.email });
   const refresh = await createRefreshToken(user.id);
 
   setAccessTokenCookie(res, token);
   setRefreshTokenCookie(res, refresh.rawToken);
 
-  log.info(`New user registered: ${user.username}`);
+  log.info(`New user registered: ${user.email}`);
 
   res.status(201).json({
     user: {
       id: user.id,
-      username: user.username,
       displayName: user.display_name,
-      email: user.email || null,
+      email: user.email,
       avatarUrl: null,
       createdAt: user.created_at,
     },
@@ -240,7 +232,6 @@ router.post('/register', asyncHandler(async (req, res) => {
   getEeHooks().onNewUser?.({
     userId: user.id,
     email: user.email,
-    username: user.username,
     activeUntil: user.active_until,
     status: 'trial',
   });
@@ -254,32 +245,32 @@ router.post('/register', asyncHandler(async (req, res) => {
 
 // POST /api/auth/login
 router.post('/login', asyncHandler(async (req, res) => {
-  const { username, password } = req.body;
+  const { email, password } = req.body;
 
-  if (!username || !password) {
-    throw new ValidationError('Username and password required');
+  if (!email || !password) {
+    throw new ValidationError('Email and password required');
   }
 
   const result = await query(
-    'SELECT id, username, password_hash, display_name, email, avatar_path, active_location_id, deleted_at, suspended_at, token_version, force_password_change, is_admin FROM users WHERE username = $1',
-    [username.toLowerCase()]
+    'SELECT id, password_hash, display_name, email, avatar_path, active_location_id, deleted_at, suspended_at, token_version, force_password_change, is_admin FROM users WHERE email = $1',
+    [email.toLowerCase().trim()]
   );
 
   const ip = req.ip || req.socket.remoteAddress || null;
   const ua = req.headers['user-agent'] || null;
 
   if (result.rows.length === 0) {
-    // Constant-time rejection — prevent timing-based username enumeration
+    // Constant-time rejection — prevent timing-based email enumeration
     await bcrypt.compare(password, '$2b$12$000000000000000000000uVjKPCGJcotDu8bMahKn7VoPxpL0Wi');
-    log.warn(`Login failed: unknown user "${username}"`);
-    throw new UnauthorizedError('Invalid username or password');
+    log.warn(`Login failed: unknown email "${email}"`);
+    throw new UnauthorizedError('Invalid email or password');
   }
 
   const user = result.rows[0];
 
   // Social-only users have no password
   if (!user.password_hash) {
-    log.warn(`Login failed: no password set for "${username}" (social-only account)`);
+    log.warn(`Login failed: no password set for "${email}" (social-only account)`);
     query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 0)',
       [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
     res.status(401).json({ error: 'NO_PASSWORD', message: 'This account uses social login. Sign in with Google or Apple, or set a password from account settings.' });
@@ -288,22 +279,22 @@ router.post('/login', asyncHandler(async (req, res) => {
 
   const valid = await bcrypt.compare(password, user.password_hash);
   if (!valid) {
-    log.warn(`Login failed: bad password for user "${username}"`);
+    log.warn(`Login failed: bad password for email "${email}"`);
     // Record failed login
     query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 0)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
-    throw new UnauthorizedError('Invalid username or password');
+    throw new UnauthorizedError('Invalid email or password');
   }
   if (user.deleted_at) {
-    log.warn(`Login failed: deleted user "${username}"`);
-    throw new UnauthorizedError('Invalid username or password');
+    log.warn(`Login failed: deleted user "${email}"`);
+    throw new UnauthorizedError('Invalid email or password');
   }
   if (user.suspended_at) {
-    log.warn(`Login failed: suspended user "${username}"`);
+    log.warn(`Login failed: suspended user "${email}"`);
     query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 0)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
     throw new ForbiddenError('This account has been suspended');
   }
   if (user.force_password_change) {
-    log.info(`Login blocked: force password change required for "${username}"`);
+    log.info(`Login blocked: force password change required for "${email}"`);
     query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 0)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
     res.status(403).json({ error: 'FORCE_PASSWORD_CHANGE', message: 'You must change your password before logging in. Please use the password reset flow.' });
     return;
@@ -312,7 +303,7 @@ router.post('/login', asyncHandler(async (req, res) => {
   // Record successful login
   query('INSERT INTO login_history (id, user_id, ip_address, user_agent, method, success) VALUES ($1, $2, $3, $4, $5, 1)', [generateUuid(), user.id, ip, ua, 'password']).catch(() => {});
 
-  const token = await signToken({ id: user.id, username: user.username }, user.token_version ?? 0);
+  const token = await signToken({ id: user.id, email: user.email }, user.token_version ?? 0);
   const refresh = await createRefreshToken(user.id);
 
   setAccessTokenCookie(res, token);
@@ -345,14 +336,13 @@ router.post('/login', asyncHandler(async (req, res) => {
     }
   }
 
-  log.info(`User "${user.username}" logged in`);
+  log.info(`User "${user.email}" logged in`);
 
   res.json({
     user: {
       id: user.id,
-      username: user.username,
       displayName: user.display_name,
-      email: user.email || null,
+      email: user.email,
       avatarUrl: user.avatar_path ? `/api/auth/avatar/${user.id}` : null,
       isAdmin: !!user.is_admin,
     },
@@ -376,8 +366,8 @@ router.post('/refresh', asyncHandler(async (req, res) => {
   }
 
   // Look up user for new access token (reject soft-deleted/suspended users)
-  const userResult = await query<{ id: string; username: string; deleted_at: string | null; suspended_at: string | null; token_version: number }>(
-    'SELECT id, username, deleted_at, suspended_at, token_version FROM users WHERE id = $1',
+  const userResult = await query<{ id: string; email: string; deleted_at: string | null; suspended_at: string | null; token_version: number }>(
+    'SELECT id, email, deleted_at, suspended_at, token_version FROM users WHERE id = $1',
     [rotated.userId],
   );
   if (userResult.rows.length === 0 || userResult.rows[0].deleted_at !== null) {
@@ -390,7 +380,7 @@ router.post('/refresh', asyncHandler(async (req, res) => {
   }
 
   const user = userResult.rows[0];
-  const accessToken = await signToken({ id: user.id, username: user.username }, user.token_version ?? 0);
+  const accessToken = await signToken({ id: user.id, email: user.email }, user.token_version ?? 0);
 
   setAccessTokenCookie(res, accessToken);
   setRefreshTokenCookie(res, rotated.rawToken);
@@ -418,7 +408,7 @@ router.post('/logout-all', authenticate, asyncHandler(async (req, res) => {
 // GET /api/auth/me
 router.get('/me', authenticate, asyncHandler(async (req, res) => {
   const result = await query(
-    'SELECT id, username, display_name, email, avatar_path, active_location_id, created_at, updated_at, plan, sub_status, active_until, is_admin, password_hash FROM users WHERE id = $1',
+    'SELECT id, display_name, email, avatar_path, active_location_id, created_at, updated_at, plan, sub_status, active_until, is_admin, password_hash FROM users WHERE id = $1',
     [req.user!.id]
   );
 
@@ -443,9 +433,8 @@ router.get('/me', authenticate, asyncHandler(async (req, res) => {
 
   res.json({
     id: user.id,
-    username: user.username,
     displayName: user.display_name,
-    email: user.email || null,
+    email: user.email,
     avatarUrl: user.avatar_path ? `/api/auth/avatar/${user.id}` : null,
     activeLocationId,
     demoMode: config.demoMode,
@@ -498,7 +487,7 @@ router.put('/profile', authenticate, asyncHandler(async (req, res) => {
   let result: import('../db.js').QueryResult<Record<string, unknown>>;
   try {
     result = await query(
-      `UPDATE users SET ${updates.join(', ')} WHERE id = $${idx} RETURNING id, username, display_name, email, avatar_path, created_at, updated_at`,
+      `UPDATE users SET ${updates.join(', ')} WHERE id = $${idx} RETURNING id, display_name, email, avatar_path, created_at, updated_at`,
       values
     );
   } catch (err: unknown) {
@@ -508,10 +497,9 @@ router.put('/profile', authenticate, asyncHandler(async (req, res) => {
     throw err;
   }
 
-  const user = result.rows[0] as { id: string; username: string; display_name: string; email: string | null; avatar_path: string | null; created_at: string; updated_at: string };
+  const user = result.rows[0] as { id: string; display_name: string; email: string | null; avatar_path: string | null; created_at: string; updated_at: string };
   res.json({
     id: user.id,
-    username: user.username,
     displayName: user.display_name,
     email: user.email || null,
     avatarUrl: user.avatar_path ? `/api/auth/avatar/${user.id}` : null,
@@ -590,7 +578,7 @@ router.put('/password', authenticate, asyncHandler(async (req, res) => {
   invalidateUserStatusCache(req.user!.id);
   clearAuthCookies(res);
 
-  log.info(`User ${req.user!.username} changed password`);
+  log.info(`User ${req.user!.email} changed password`);
   res.json({ message: 'Password updated successfully' });
 }));
 
@@ -675,7 +663,7 @@ router.delete('/account', authenticate, asyncHandler(async (req, res) => {
 
   clearAuthCookies(res);
 
-  log.info(`User ${req.user!.username} deleted their account`);
+  log.info(`User ${req.user!.email} deleted their account`);
 
   res.json({ message: 'Account deleted' });
 }));
@@ -942,7 +930,7 @@ router.delete('/oauth/link/:provider', authenticate, asyncHandler(async (req, re
     throw new NotFoundError('Provider not linked');
   }
 
-  log.info(`User "${req.user!.username}" unlinked ${provider}`);
+  log.info(`User "${req.user!.email}" unlinked ${provider}`);
   res.json({ success: true });
 }));
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -190,9 +190,6 @@ router.post('/register', asyncHandler(async (req, res) => {
       ]
     );
   } catch (err: unknown) {
-    if (isUniqueViolation(err, 'idx_users_email_unique')) {
-      throw new ConflictError('Registration failed — please try different credentials');
-    }
     if (isUniqueViolation(err)) {
       throw new ConflictError('Registration failed — please try different credentials');
     }
@@ -456,8 +453,9 @@ router.put('/profile', authenticate, asyncHandler(async (req, res) => {
     validateDisplayName(displayName);
   }
 
+  let normalizedEmail: string | undefined;
   if (email !== undefined && email !== null && email !== '') {
-    validateEmail(email);
+    normalizedEmail = validateLoginEmail(email);
   }
 
   // Check if user currently has no email (for welcome email trigger)
@@ -474,7 +472,7 @@ router.put('/profile', authenticate, asyncHandler(async (req, res) => {
   }
   if (email !== undefined) {
     updates.push(`email = $${idx++}`);
-    values.push(email === '' ? null : email);
+    values.push(email === '' ? null : normalizedEmail ?? null);
   }
 
   if (updates.length === 0) {

--- a/server/src/routes/batch.ts
+++ b/server/src/routes/batch.ts
@@ -367,7 +367,7 @@ router.post('/batch', authenticate, batchLimiter, requireLocationMember(), async
     }
   }
 
-  const result = await executeActions(actions, locationId, req.user!.id, req.user!.username, req.authMethod, req.apiKeyId);
+  const result = await executeActions(actions, locationId, req.user!.id, req.user!.email, req.authMethod, req.apiKeyId);
 
   res.json({
     results: result.executed,

--- a/server/src/routes/locations.ts
+++ b/server/src/routes/locations.ts
@@ -354,7 +354,7 @@ router.post('/join', asyncHandler(async (req, res) => {
     locationId: location.id,
     action: 'join',
     entityType: 'member',
-    entityName: req.user!.username,
+    entityName: req.user!.email,
   });
 
   // Get area count for the joined location
@@ -429,8 +429,8 @@ router.get('/:id/members', asyncHandler(async (req, res) => {
 
   const result = await query(
     `SELECT lm.id, lm.location_id, lm.user_id, lm.role, lm.joined_at,
-            COALESCE(u.display_name, u.username) AS display_name,
-            u.username
+            COALESCE(u.display_name, u.email) AS display_name,
+            u.email
      FROM location_members lm
      LEFT JOIN users u ON u.id = lm.user_id
      WHERE lm.location_id = $1
@@ -488,9 +488,9 @@ router.delete('/:id/members/:userId', asyncHandler(async (req, res) => {
     }
   }
 
-  // Get username for activity log
-  const userResult = await query('SELECT username FROM users WHERE id = $1', [userId]);
-  const removedUsername = userResult.rows[0]?.username ?? 'unknown';
+  // Get email for activity log
+  const userResult = await query('SELECT email FROM users WHERE id = $1', [userId]);
+  const removedEmail = userResult.rows[0]?.email ?? 'unknown';
 
   const result = await query(
     'DELETE FROM location_members WHERE location_id = $1 AND user_id = $2 RETURNING id',
@@ -509,7 +509,7 @@ router.delete('/:id/members/:userId', asyncHandler(async (req, res) => {
     locationId: id,
     action,
     entityType: 'member',
-    entityName: removedUsername,
+    entityName: removedEmail,
   });
 
   res.json({ message: 'Member removed' });
@@ -556,15 +556,15 @@ router.put('/:id/members/:userId/role', asyncHandler(async (req, res) => {
     [role, id, userId]
   );
 
-  // Get username for activity log
-  const userResult = await query('SELECT username FROM users WHERE id = $1', [userId]);
-  const targetUsername = userResult.rows[0]?.username ?? 'unknown';
+  // Get email for activity log
+  const userResult = await query('SELECT email FROM users WHERE id = $1', [userId]);
+  const targetEmail = userResult.rows[0]?.email ?? 'unknown';
 
   logRouteActivity(req, {
     locationId: id,
     action: 'change_role',
     entityType: 'member',
-    entityName: targetUsername,
+    entityName: targetEmail,
     changes: { role: { old: targetRole, new: role } },
   });
 
@@ -593,16 +593,16 @@ router.post('/:id/members/:userId/reset-password', asyncHandler(async (req, res)
 
   const { rawToken, expiresAt } = await createPasswordResetToken(userId, req.user!.id);
 
-  // Get username for activity log
-  const userResult = await query('SELECT username FROM users WHERE id = $1', [userId]);
-  const targetUsername = userResult.rows[0]?.username ?? 'unknown';
+  // Get email for activity log
+  const userResult = await query('SELECT email FROM users WHERE id = $1', [userId]);
+  const targetEmail = userResult.rows[0]?.email ?? 'unknown';
 
   logRouteActivity(req, {
     locationId: id,
     action: 'reset_password',
     entityType: 'member',
     entityId: userId,
-    entityName: targetUsername,
+    entityName: targetEmail,
   });
 
   if (isSelfHosted()) {

--- a/src/features/activity/ActivityFilterBar.tsx
+++ b/src/features/activity/ActivityFilterBar.tsx
@@ -56,7 +56,7 @@ export function ActivityFilterBar({
         <option value="">All users</option>
         {members.map((m) => (
           <option key={m.user_id} value={m.user_id}>
-            {m.display_name || m.username}
+            {m.display_name || m.email}
           </option>
         ))}
       </select>

--- a/src/features/admin/AdminUserDetailPage.tsx
+++ b/src/features/admin/AdminUserDetailPage.tsx
@@ -129,7 +129,7 @@ export function AdminUserDetailPage() {
     if (!detail) return;
     try {
       await deleteUser(detail.id);
-      showToast({ message: `User ${detail.username} deleted`, variant: 'success' });
+      showToast({ message: `User ${detail.email} deleted`, variant: 'success' });
       navigate('/admin/users');
     } catch (err) {
       showToast({ message: getErrorMessage(err, 'Failed to delete user'), variant: 'error' });
@@ -228,7 +228,7 @@ export function AdminUserDetailPage() {
     if (!detail) return;
     try {
       await suspendUser(detail.id);
-      showToast({ message: `User ${detail.username} suspended`, variant: 'success' });
+      showToast({ message: `User ${detail.email} suspended`, variant: 'success' });
       refresh();
       setSuspendOpen(false);
     } catch (err) {
@@ -240,7 +240,7 @@ export function AdminUserDetailPage() {
     if (!detail) return;
     try {
       await reactivateUser(detail.id);
-      showToast({ message: `User ${detail.username} reactivated`, variant: 'success' });
+      showToast({ message: `User ${detail.email} reactivated`, variant: 'success' });
       refresh();
     } catch (err) {
       showToast({ message: getErrorMessage(err, 'Failed to reactivate user'), variant: 'error' });
@@ -368,7 +368,7 @@ export function AdminUserDetailPage() {
   return (
     <div className="page-content">
       <PageHeader
-        title={detail.displayName || detail.username}
+        title={detail.displayName || detail.email || ''}
         back
         backTo="/admin/users"
       />
@@ -388,16 +388,12 @@ export function AdminUserDetailPage() {
         <CardContent>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <span className="text-[12px] text-[var(--text-tertiary)] uppercase tracking-wide">Username</span>
-              <p className="text-[15px] text-[var(--text-primary)]">@{detail.username}</p>
+              <span className="text-[12px] text-[var(--text-tertiary)] uppercase tracking-wide">Email</span>
+              <p className="text-[15px] text-[var(--text-primary)]">{detail.email || '—'}</p>
             </div>
             <div>
               <span className="text-[12px] text-[var(--text-tertiary)] uppercase tracking-wide">Display Name</span>
               <p className="text-[15px] text-[var(--text-primary)]">{detail.displayName || '—'}</p>
-            </div>
-            <div>
-              <span className="text-[12px] text-[var(--text-tertiary)] uppercase tracking-wide">Email</span>
-              <p className="text-[15px] text-[var(--text-primary)]">{detail.email || '—'}</p>
             </div>
             {__EE__ && !planInfo.selfHosted && (
               <div>
@@ -695,7 +691,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Suspend User</DialogTitle>
             <DialogDescription>
-              Suspend <strong>{detail.username}</strong>? They will be immediately logged out and unable to access the app.
+              Suspend <strong>{detail.email}</strong>? They will be immediately logged out and unable to access the app.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -711,7 +707,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Revoke All Sessions</DialogTitle>
             <DialogDescription>
-              This will log <strong>{detail.username}</strong> out of all devices immediately.
+              This will log <strong>{detail.email}</strong> out of all devices immediately.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -727,7 +723,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Revoke All API Keys</DialogTitle>
             <DialogDescription>
-              This will immediately invalidate all API keys for <strong>{detail.username}</strong>. Any integrations using these keys will stop working.
+              This will immediately invalidate all API keys for <strong>{detail.email}</strong>. Any integrations using these keys will stop working.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -743,7 +739,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Delete User</DialogTitle>
             <DialogDescription>
-              Permanently delete <strong>{detail.username}</strong>? This cannot be undone. All their data will be removed.
+              Permanently delete <strong>{detail.email}</strong>? This cannot be undone. All their data will be removed.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -759,7 +755,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Regenerate API Key</DialogTitle>
             <DialogDescription>
-              This will revoke all existing API keys for <strong>{detail.username}</strong> and create a new one.
+              This will revoke all existing API keys for <strong>{detail.email}</strong> and create a new one.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -775,7 +771,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Change Plan</DialogTitle>
             <DialogDescription>
-              Change <strong>{detail.username}</strong>&apos;s plan from {capitalize(detail.plan)} to {pendingPlan ? capitalize(pendingPlan) : ''}?
+              Change <strong>{detail.email}</strong>&apos;s plan from {capitalize(detail.plan)} to {pendingPlan ? capitalize(pendingPlan) : ''}?
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -791,7 +787,7 @@ export function AdminUserDetailPage() {
           <DialogHeader>
             <DialogTitle>Change Subscription Status</DialogTitle>
             <DialogDescription>
-              Change <strong>{detail.username}</strong>&apos;s status from {capitalize(detail.status)} to {pendingStatus ? capitalize(pendingStatus) : ''}?
+              Change <strong>{detail.email}</strong>&apos;s status from {capitalize(detail.status)} to {pendingStatus ? capitalize(pendingStatus) : ''}?
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/features/admin/AdminUsersPage.tsx
+++ b/src/features/admin/AdminUsersPage.tsx
@@ -51,7 +51,7 @@ export function AdminUsersPage() {
   const { visibility, toggleField, isVisible } = useAdminColumnVisibility();
   const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
-  const [createForm, setCreateForm] = useState({ username: '', password: '', displayName: '', email: '', isAdmin: false });
+  const [createForm, setCreateForm] = useState({ email: '', password: '', displayName: '', isAdmin: false });
   const [createLoading, setCreateLoading] = useState(false);
 
   const sortParam = `${sortDirection === 'desc' ? '-' : ''}${sortColumn}`;
@@ -68,7 +68,7 @@ export function AdminUsersPage() {
     if (!deleteTarget) return;
     try {
       await deleteUser(deleteTarget.id);
-      showToast({ message: `User ${deleteTarget.username} deleted`, variant: 'success' });
+      showToast({ message: `User ${deleteTarget.email} deleted`, variant: 'success' });
       setDeleteTarget(null);
     } catch (err) {
       showToast({ message: getErrorMessage(err, 'Failed to delete user'), variant: 'error' });
@@ -88,15 +88,14 @@ export function AdminUsersPage() {
     setCreateLoading(true);
     try {
       await createUser({
-        username: createForm.username,
+        email: createForm.email,
         password: createForm.password,
         displayName: createForm.displayName || undefined,
-        email: createForm.email || undefined,
         isAdmin: createForm.isAdmin,
       });
-      showToast({ message: `User ${createForm.username} created`, variant: 'success' });
+      showToast({ message: `User ${createForm.email} created`, variant: 'success' });
       setCreateOpen(false);
-      setCreateForm({ username: '', password: '', displayName: '', email: '', isAdmin: false });
+      setCreateForm({ email: '', password: '', displayName: '', isAdmin: false });
     } catch (err) {
       showToast({ message: getErrorMessage(err, 'Failed to create user'), variant: 'error' });
     } finally {
@@ -268,7 +267,7 @@ export function AdminUsersPage() {
           <DialogHeader>
             <DialogTitle>Delete User</DialogTitle>
             <DialogDescription>
-              Permanently delete <strong>{deleteTarget?.username}</strong>? This cannot be undone. All their data will be removed.
+              Permanently delete <strong>{deleteTarget?.email}</strong>? This cannot be undone. All their data will be removed.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -282,7 +281,7 @@ export function AdminUsersPage() {
       <Dialog open={createOpen} onOpenChange={(open) => {
         if (!open) {
           setCreateOpen(false);
-          setCreateForm({ username: '', password: '', displayName: '', email: '', isAdmin: false });
+          setCreateForm({ email: '', password: '', displayName: '', isAdmin: false });
         }
       }}>
         <DialogContent>
@@ -291,13 +290,14 @@ export function AdminUsersPage() {
             <DialogDescription>Create a new user account.</DialogDescription>
           </DialogHeader>
           <form onSubmit={(e) => { e.preventDefault(); handleCreate(); }} className="space-y-5">
-            <FormField label="Username" htmlFor="create-username">
+            <FormField label="Email" htmlFor="create-email">
               <Input
-                id="create-username"
-                value={createForm.username}
-                onChange={(e) => setCreateForm((f) => ({ ...f, username: e.target.value }))}
-                placeholder="Username"
-                autoComplete="off"
+                id="create-email"
+                type="email"
+                value={createForm.email}
+                onChange={(e) => setCreateForm((f) => ({ ...f, email: e.target.value }))}
+                placeholder="Email"
+                autoComplete="email"
               />
             </FormField>
             <FormField label="Password" htmlFor="create-password" hint="8+ characters, mixed case, one digit">
@@ -318,15 +318,6 @@ export function AdminUsersPage() {
                 placeholder="Optional"
               />
             </FormField>
-            <FormField label="Email" htmlFor="create-email">
-              <Input
-                id="create-email"
-                type="email"
-                value={createForm.email}
-                onChange={(e) => setCreateForm((f) => ({ ...f, email: e.target.value }))}
-                placeholder="Optional"
-              />
-            </FormField>
             <div className="flex items-center gap-2">
               <Switch
                 checked={createForm.isAdmin}
@@ -336,7 +327,7 @@ export function AdminUsersPage() {
             </div>
             <DialogFooter>
               <Button variant="outline" type="button" onClick={() => setCreateOpen(false)}>Cancel</Button>
-              <Button type="submit" disabled={!createForm.username || !createForm.password || createLoading}>
+              <Button type="submit" disabled={!createForm.email || !createForm.password || createLoading}>
                 {createLoading ? 'Creating...' : 'Create'}
               </Button>
             </DialogFooter>

--- a/src/features/admin/AdminUsersTable.tsx
+++ b/src/features/admin/AdminUsersTable.tsx
@@ -38,7 +38,7 @@ export function AdminUsersTable({
     <Table>
       <TableHeader>
         <div className="flex-1 min-w-0">
-          <SortHeader label="User" column="username" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
+          <SortHeader label="User" column="email" currentColumn={sortColumn} currentDirection={sortDirection} onSort={onSort} />
         </div>
         {isVisible('email') && (
           <div className="hidden lg:block w-40">
@@ -153,8 +153,8 @@ export function AdminUsersTable({
             className={cn((u.deletedAt || u.suspendedAt) && 'opacity-50')}
           >
             <div className="flex-1 min-w-0">
-              <div className="font-medium text-[14px] text-[var(--text-primary)] truncate">{u.displayName || u.username}</div>
-              <div className="text-[12px] text-[var(--text-tertiary)] truncate">@{u.username}</div>
+              <div className="font-medium text-[14px] text-[var(--text-primary)] truncate">{u.displayName || u.email}</div>
+              <div className="text-[12px] text-[var(--text-tertiary)] truncate">{u.email}</div>
             </div>
             {isVisible('email') && (
               <div className="hidden lg:block w-40 text-[14px] text-[var(--text-secondary)] truncate">{u.email || '—'}</div>
@@ -237,7 +237,7 @@ export function AdminUsersTable({
                 size="icon-sm"
                 onClick={(e) => { e.stopPropagation(); onDelete(u); }}
                 disabled={isSelf}
-                aria-label={`Delete ${u.username}`}
+                aria-label={`Delete ${u.email}`}
                 className="text-[var(--destructive)] hover:text-[var(--destructive)]"
               >
                 <Trash2 className="h-3.5 w-3.5" />

--- a/src/features/admin/__tests__/useAdminUsers.test.ts
+++ b/src/features/admin/__tests__/useAdminUsers.test.ts
@@ -54,7 +54,7 @@ describe('capitalize', () => {
 
 describe('fetchUser', () => {
   it('calls correct endpoint', async () => {
-    const mockDetail = { id: 'u1', username: 'admin', stats: {} };
+    const mockDetail = { id: 'u1', email: 'admin@example.com', stats: {} };
     mockApiFetch.mockResolvedValue(mockDetail);
 
     const result = await fetchUser('u1');

--- a/src/features/admin/useAdminColumnVisibility.ts
+++ b/src/features/admin/useAdminColumnVisibility.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo, useState } from 'react';
 import { STORAGE_KEYS } from '@/lib/storageKeys';
 
 export type AdminFieldKey =
-  | 'username' | 'email' | 'role' | 'plan' | 'status'
+  | 'email' | 'role' | 'plan' | 'status'
   | 'bins' | 'locations' | 'storage' | 'created'
   | 'lastActive' | 'items' | 'photos' | 'scans30d'
   | 'aiCredits' | 'apiKeys' | 'apiRequests7d'
   | 'binPct' | 'storagePct' | 'binsCreated7d' | 'accountAge';
 
 const DEFAULT_VISIBILITY: Record<AdminFieldKey, boolean> = {
-  username: true, email: true, role: true, plan: true, status: true,
+  email: true, role: true, plan: true, status: true,
   bins: true, locations: true, storage: true, created: true,
   lastActive: false, items: false, photos: false, scans30d: false,
   aiCredits: false, apiKeys: false, apiRequests7d: false,
@@ -17,7 +17,7 @@ const DEFAULT_VISIBILITY: Record<AdminFieldKey, boolean> = {
 };
 
 export const ADMIN_FIELD_LABELS: Record<AdminFieldKey, string> = {
-  username: 'User', email: 'Email', role: 'Role', plan: 'Plan', status: 'Status',
+  email: 'Email', role: 'Role', plan: 'Plan', status: 'Status',
   bins: 'Bins', locations: 'Locations', storage: 'Storage', created: 'Created',
   lastActive: 'Last Active', items: 'Items', photos: 'Photos', scans30d: 'Scans (30d)',
   aiCredits: 'AI Credits', apiKeys: 'API Keys', apiRequests7d: 'API Reqs (7d)',

--- a/src/features/admin/useAdminUsers.ts
+++ b/src/features/admin/useAdminUsers.ts
@@ -3,7 +3,6 @@ import { apiFetch } from '@/lib/api';
 
 export interface AdminUser {
   id: string;
-  username: string;
   displayName: string;
   email: string | null;
   isAdmin: boolean;
@@ -87,7 +86,7 @@ export function useAdminUsers(query = '', page = 1, sort = '-created') {
   }, []);
 
   const createUser = useCallback(async (data: {
-    username: string; password: string; displayName?: string; email?: string; isAdmin?: boolean;
+    email: string; password: string; displayName?: string; isAdmin?: boolean;
   }) => {
     const result = await apiFetch<AdminUser>('/api/admin/users', { method: 'POST', body: data });
     await fetchUsers();
@@ -99,7 +98,6 @@ export function useAdminUsers(query = '', page = 1, sort = '-created') {
 
 export interface AdminUserDetail {
   id: string;
-  username: string;
   displayName: string;
   email: string | null;
   isAdmin: boolean;

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -23,7 +23,7 @@ export function LoginPage() {
   const { settings } = useAppSettings();
   const { preference, setThemePreference } = useTheme();
   const ThemeIcon = preference === 'light' ? Sun : preference === 'dark' ? Moon : Monitor;
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [registrationEnabled, setRegistrationEnabled] = useState(true);
@@ -31,7 +31,7 @@ export function LoginPage() {
   const [demoLoading, setDemoLoading] = useState(false);
   const [formError, setFormError] = useState('');
   const [oauthProviders, setOAuthProviders] = useState<string[]>([]);
-  const usernameRef = useRef<HTMLInputElement>(null);
+  const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
 
   useOAuthReturn();
@@ -74,8 +74,8 @@ export function LoginPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setFormError('');
-    if (!username.trim()) {
-      usernameRef.current?.focus();
+    if (!email.trim()) {
+      emailRef.current?.focus();
       return;
     }
     if (!password) {
@@ -84,11 +84,11 @@ export function LoginPage() {
     }
     setLoading(true);
     try {
-      await login(username.trim(), password);
+      await login(email.trim(), password);
       navigate('/');
     } catch (err) {
-      setFormError(getErrorMessage(err, 'Invalid username or password'));
-      usernameRef.current?.focus();
+      setFormError(getErrorMessage(err, 'Invalid email or password'));
+      emailRef.current?.focus();
     } finally {
       setLoading(false);
     }
@@ -136,15 +136,15 @@ export function LoginPage() {
                     </p>
                   )}
                   <div className="space-y-2">
-                    <Label htmlFor="login-username">Username</Label>
+                    <Label htmlFor="login-email">Email</Label>
                     <Input
-                      ref={usernameRef}
-                      id="login-username"
-                      value={username}
-                      onChange={(e) => { setUsername(e.target.value); if (formError) setFormError(''); }}
-                      placeholder="Enter username"
-                      autoComplete="username"
-                      autoCapitalize="none"
+                      ref={emailRef}
+                      id="login-email"
+                      type="email"
+                      value={email}
+                      onChange={(e) => { setEmail(e.target.value); if (formError) setFormError(''); }}
+                      placeholder="Enter email"
+                      autoComplete="email"
                       autoFocus
                       required
                       enterKeyHint="next"
@@ -170,7 +170,7 @@ export function LoginPage() {
                   </div>
                   <Button
                     type="submit"
-                    disabled={!username.trim() || !password || loading}
+                    disabled={!email.trim() || !password || loading}
                     fullWidth
                   >
                     <LogIn className="h-4 w-4 mr-2" />

--- a/src/features/auth/RegisterPage.tsx
+++ b/src/features/auth/RegisterPage.tsx
@@ -16,8 +16,6 @@ import { cycleThemePreference, useTheme } from '@/lib/theme';
 import { cn, EMAIL_REGEX, focusRing, getErrorMessage } from '@/lib/utils';
 import { SocialButtons, SocialDivider } from './SocialButtons';
 
-const USERNAME_REGEX = /^[a-zA-Z0-9_]{3,50}$/;
-
 export function RegisterPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -26,14 +24,12 @@ export function RegisterPage() {
   const { settings } = useAppSettings();
   const { preference, setThemePreference } = useTheme();
   const ThemeIcon = preference === 'light' ? Sun : preference === 'dark' ? Moon : Monitor;
-  const [username, setUsername] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [inviteCode, setInviteCode] = useState(searchParams.get('invite') ?? '');
   const [registrationMode, setRegistrationMode] = useState<'open' | 'invite'>('open');
-  const [selfHosted, setSelfHosted] = useState(true);
   const [oauthProviders, setOAuthProviders] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [statusLoaded, setStatusLoaded] = useState(false);
@@ -42,7 +38,6 @@ export function RegisterPage() {
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const markTouched = useCallback((field: string) => setTouched((t) => ({ ...t, [field]: true })), []);
 
-  const usernameRef = useRef<HTMLInputElement>(null);
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const confirmRef = useRef<HTMLInputElement>(null);
@@ -57,7 +52,6 @@ export function RegisterPage() {
           navigate('/login');
         }
         setRegistrationMode(data.registrationMode ?? 'open');
-        if (data.selfHosted === false) setSelfHosted(false);
         if (Array.isArray(data.oauthProviders)) setOAuthProviders(data.oauthProviders);
       })
       .catch(() => {})
@@ -102,13 +96,13 @@ export function RegisterPage() {
 
   const fieldErrors = useMemo(() => {
     const errors: Record<string, string | undefined> = {};
-    if (username && !USERNAME_REGEX.test(username)) {
-      errors.username = 'Must be 3\u201350 characters (letters, numbers, underscores)';
-    }
-    if (!selfHosted && touched.email && !email.trim()) {
+    if (touched.email && !email.trim()) {
       errors.email = 'Email is required';
     } else if (email && !EMAIL_REGEX.test(email)) {
       errors.email = 'Enter a valid email address';
+    }
+    if (!displayName.trim() && touched.displayName) {
+      errors.displayName = 'Display name is required';
     }
     if (confirmPassword && password !== confirmPassword) {
       errors.confirmPassword = 'Passwords do not match';
@@ -117,20 +111,19 @@ export function RegisterPage() {
       errors.inviteCode = 'An invite code is required to register';
     }
     return errors;
-  }, [username, email, password, confirmPassword, inviteCode, registrationMode, selfHosted, touched.email, touched.inviteCode]);
+  }, [email, displayName, password, confirmPassword, inviteCode, registrationMode, touched.email, touched.displayName, touched.inviteCode]);
 
   function validate(): string | null {
-    if (!USERNAME_REGEX.test(username)) {
-      usernameRef.current?.focus();
-      return 'Username must be 3\u201350 characters (letters, numbers, underscores)';
-    }
-    if (!selfHosted && !email.trim()) {
+    if (!email.trim()) {
       emailRef.current?.focus();
       return 'Email is required';
     }
-    if (email && !EMAIL_REGEX.test(email)) {
+    if (!EMAIL_REGEX.test(email)) {
       emailRef.current?.focus();
       return 'Please enter a valid email address';
+    }
+    if (!displayName.trim()) {
+      return 'Display name is required';
     }
     if (!allChecksPassing(passwordChecks)) {
       passwordRef.current?.focus();
@@ -151,13 +144,13 @@ export function RegisterPage() {
     e.preventDefault();
     const error = validate();
     if (error) {
-      setTouched({ username: true, email: true, confirmPassword: true, inviteCode: true });
+      setTouched({ email: true, displayName: true, confirmPassword: true, inviteCode: true });
       showToast({ message: error, variant: 'error' });
       return;
     }
     setLoading(true);
     try {
-      await register(username.trim(), password, displayName.trim() || username.trim(), email.trim() || undefined, inviteCode.trim() || undefined);
+      await register(email.trim(), password, displayName.trim(), inviteCode.trim() || undefined);
       navigate('/');
     } catch (err) {
       showToast({
@@ -168,8 +161,6 @@ export function RegisterPage() {
       setLoading(false);
     }
   }
-
-  const optionalHint = <span className="font-normal normal-case tracking-normal text-[var(--text-tertiary)]">(optional)</span>;
 
   return (
     <div className="auth-pattern min-h-dvh flex flex-col items-center justify-center px-6 py-8 bg-[var(--bg-base)]">
@@ -237,44 +228,7 @@ export function RegisterPage() {
                   <fieldset className="space-y-4">
                     <legend className="sr-only">Account details</legend>
                     <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <Label htmlFor="reg-username">Username</Label>
-                        {username.length > 0 && (
-                          <span className="text-[11px] text-[var(--text-tertiary)] tabular-nums">{username.length}/50</span>
-                        )}
-                      </div>
-                      <Input
-                        ref={usernameRef}
-                        id="reg-username"
-                        value={username}
-                        onChange={(e) => setUsername(e.target.value)}
-                        onBlur={() => markTouched('username')}
-                        placeholder="Letters, numbers, underscores"
-                        autoComplete="username"
-                        autoCapitalize="none"
-                        autoFocus
-                        required
-                        enterKeyHint="next"
-                        aria-invalid={touched.username && !!fieldErrors.username}
-                        aria-describedby={touched.username && fieldErrors.username ? 'reg-username-error' : undefined}
-                      />
-                      {touched.username && fieldErrors.username && (
-                        <p id="reg-username-error" role="alert" className="text-[13px] text-[var(--destructive)]">{fieldErrors.username}</p>
-                      )}
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="reg-display-name">Display Name {optionalHint}</Label>
-                      <Input
-                        id="reg-display-name"
-                        value={displayName}
-                        onChange={(e) => setDisplayName(e.target.value)}
-                        placeholder="How you appear to others"
-                        autoComplete="name"
-                        enterKeyHint="next"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="reg-email">Email{selfHosted && <> {optionalHint}</>}</Label>
+                      <Label htmlFor="reg-email">Email</Label>
                       <Input
                         ref={emailRef}
                         id="reg-email"
@@ -282,15 +236,33 @@ export function RegisterPage() {
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         onBlur={() => markTouched('email')}
-                        placeholder={selfHosted ? 'For password recovery' : 'Required for account recovery'}
+                        placeholder="Enter your email"
                         autoComplete="email"
-                        required={!selfHosted}
+                        autoFocus
+                        required
                         enterKeyHint="next"
                         aria-invalid={touched.email && !!fieldErrors.email}
                         aria-describedby={touched.email && fieldErrors.email ? 'reg-email-error' : undefined}
                       />
                       {touched.email && fieldErrors.email && (
                         <p id="reg-email-error" role="alert" className="text-[13px] text-[var(--destructive)]">{fieldErrors.email}</p>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="reg-display-name">Display Name</Label>
+                      <Input
+                        id="reg-display-name"
+                        value={displayName}
+                        onChange={(e) => setDisplayName(e.target.value)}
+                        onBlur={() => markTouched('displayName')}
+                        placeholder="How you appear to others"
+                        autoComplete="name"
+                        enterKeyHint="next"
+                        aria-invalid={touched.displayName && !!fieldErrors.displayName}
+                        aria-describedby={touched.displayName && fieldErrors.displayName ? 'reg-display-name-error' : undefined}
+                      />
+                      {touched.displayName && fieldErrors.displayName && (
+                        <p id="reg-display-name-error" role="alert" className="text-[13px] text-[var(--destructive)]">{fieldErrors.displayName}</p>
                       )}
                     </div>
                   </fieldset>
@@ -351,7 +323,7 @@ export function RegisterPage() {
                     <legend className="sr-only">Invitation</legend>
                     <div className="space-y-2">
                       <Label htmlFor="reg-invite">
-                        Invite Code{registrationMode !== 'invite' && <> {optionalHint}</>}
+                        Invite Code{registrationMode !== 'invite' && <> <span className="font-normal normal-case tracking-normal text-[var(--text-tertiary)]">(optional)</span></>}
                       </Label>
                       <Input
                         ref={inviteRef}
@@ -374,7 +346,7 @@ export function RegisterPage() {
                   <div className="mt-6 space-y-4">
                     <Button
                       type="submit"
-                      disabled={!username.trim() || !password || !confirmPassword || loading}
+                      disabled={!email.trim() || !displayName.trim() || !password || !confirmPassword || loading}
                       fullWidth
                     >
                       <UserPlus className="h-4 w-4 mr-2" />

--- a/src/features/auth/__tests__/AuthGuard.test.tsx
+++ b/src/features/auth/__tests__/AuthGuard.test.tsx
@@ -47,7 +47,7 @@ describe('AuthGuard', () => {
 
   it('renders children when authenticated', () => {
     mockedUseAuth.mockReturnValue({
-      user: { id: '1', username: 'test' },
+      user: { id: '1', email: 'test@example.com' },
       loading: false,
     } as ReturnType<typeof useAuth>);
     renderWithRouter();
@@ -56,7 +56,7 @@ describe('AuthGuard', () => {
 
   it('does not show spinner when authenticated', () => {
     mockedUseAuth.mockReturnValue({
-      user: { id: '1', username: 'test' },
+      user: { id: '1', email: 'test@example.com' },
       loading: false,
     } as ReturnType<typeof useAuth>);
     renderWithRouter();

--- a/src/features/layout/Sidebar.tsx
+++ b/src/features/layout/Sidebar.tsx
@@ -196,7 +196,7 @@ export function SidebarContent({ locations, activeLocationId, onLocationChange, 
             <button
               type="button"
               onClick={() => { navigate('/settings/account'); onItemClick?.(); }}
-              aria-label={user.displayName || user.username}
+              aria-label={user.displayName || user.email}
               aria-current={location.pathname === '/settings/account' ? 'page' : undefined}
               className={cn(
                 'flex items-center gap-3 px-2 py-2.5 rounded-[var(--radius-sm)] text-[15px] font-medium w-full overflow-hidden whitespace-nowrap text-left border',
@@ -207,11 +207,11 @@ export function SidebarContent({ locations, activeLocationId, onLocationChange, 
             >
               <UserAvatar
                 avatarUrl={user.avatarUrl ? getAvatarUrl(user.avatarUrl) : null}
-                displayName={user.displayName || user.username}
+                displayName={user.displayName || user.email}
                 size="xs"
               />
               <span className={cn('flex-1 truncate', collapsed && 'w-0 opacity-0')} aria-hidden={collapsed || undefined}>
-                {user.displayName || user.username}
+                {user.displayName || user.email}
               </span>
             </button>
           )}

--- a/src/features/locations/LocationMembersDialog.tsx
+++ b/src/features/locations/LocationMembersDialog.tsx
@@ -50,7 +50,7 @@ export function LocationMembersDialog({ locationId, open, onOpenChange }: Locati
     const q = memberSearch.toLowerCase();
     return members.filter((m) =>
       (m.display_name || '').toLowerCase().includes(q) ||
-      (m.username || '').toLowerCase().includes(q),
+      (m.email || '').toLowerCase().includes(q),
     );
   }, [members, memberSearch]);
 
@@ -206,7 +206,7 @@ export function LocationMembersDialog({ locationId, open, onOpenChange }: Locati
             {filteredMembers.map((member) => {
               const isSelf = member.user_id === user?.id;
               const displayName = member.display_name || member.user_id.slice(0, 8);
-              const showUsername = member.username && member.username !== member.display_name;
+              const showEmail = member.email && member.email !== member.display_name;
               return (
                 <div
                   key={member.id}
@@ -220,9 +220,9 @@ export function LocationMembersDialog({ locationId, open, onOpenChange }: Locati
                     <span className="text-[14px] text-[var(--text-primary)] truncate block">
                       {isSelf ? 'You' : displayName}
                     </span>
-                    {showUsername && (
+                    {showEmail && (
                       <span className="text-[12px] text-[var(--text-tertiary)] truncate block">
-                        @{member.username}
+                        {member.email}
                       </span>
                     )}
                   </div>
@@ -300,7 +300,7 @@ export function LocationMembersDialog({ locationId, open, onOpenChange }: Locati
           <DialogHeader>
             <DialogTitle>Remove member</DialogTitle>
             <DialogDescription>
-              Remove {memberToRemove?.display_name || memberToRemove?.username || 'this member'} from {location?.name ?? 'this location'}? They will lose access to all bins in this location.
+              Remove {memberToRemove?.display_name || memberToRemove?.email || 'this member'} from {location?.name ?? 'this location'}? They will lose access to all bins in this location.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/features/onboarding/__tests__/useOnboarding.test.ts
+++ b/src/features/onboarding/__tests__/useOnboarding.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/lib/auth', () => ({
   useAuth: vi.fn(() => ({
-    user: { id: 'user-1', username: 'testuser', displayName: 'Test', email: null, avatarUrl: null, createdAt: '', updatedAt: '' },
+    user: { id: 'user-1', displayName: 'Test', email: 'testuser@example.com', avatarUrl: null, createdAt: '', updatedAt: '' },
   })),
 }));
 
@@ -27,7 +27,7 @@ function wrapper({ children }: { children: React.ReactNode }) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseAuth.mockReturnValue({
-    user: { id: 'user-1', username: 'testuser', displayName: 'Test', email: null, avatarUrl: null, createdAt: '', updatedAt: '' },
+    user: { id: 'user-1', displayName: 'Test', email: 'testuser@example.com', avatarUrl: null, createdAt: '', updatedAt: '' },
   } as ReturnType<typeof useAuth>);
   mockApiFetch.mockResolvedValue(null);
 });

--- a/src/features/settings/__tests__/AccountSection.test.tsx
+++ b/src/features/settings/__tests__/AccountSection.test.tsx
@@ -37,7 +37,6 @@ vi.mock('../useApiKeys', () => ({
 
 const baseUser = {
   id: '1',
-  username: 'testuser',
   displayName: 'Test User',
   email: 'test@example.com',
   avatarUrl: null,

--- a/src/features/settings/__tests__/SettingsLayout.test.tsx
+++ b/src/features/settings/__tests__/SettingsLayout.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsLayout } from '../SettingsLayout';
 
 vi.mock('@/lib/auth', () => ({
-  useAuth: vi.fn(() => ({ user: { id: '1', username: 'test', isAdmin: false }, activeLocationId: 'loc-1', token: 't' })),
+  useAuth: vi.fn(() => ({ user: { id: '1', email: 'test@example.com', isAdmin: false }, activeLocationId: 'loc-1', token: 't' })),
 }));
 
 vi.mock('@/lib/usePermissions', () => ({

--- a/src/features/settings/sections/AccountSection.tsx
+++ b/src/features/settings/sections/AccountSection.tsx
@@ -302,7 +302,7 @@ export function AccountSection() {
             >
               <UserAvatar
                 avatarUrl={avatarSrc}
-                displayName={user.displayName || user.username}
+                displayName={user.displayName || user.email}
                 size="lg"
               />
               <div
@@ -316,8 +316,8 @@ export function AccountSection() {
             </button>
           </div>
           <div className="min-w-0">
-            <p className="text-[15px] font-semibold text-[var(--text-primary)] truncate">{user.displayName || user.username}</p>
-            <p className="text-[13px] text-[var(--text-tertiary)]">@{user.username}</p>
+            <p className="text-[15px] font-semibold text-[var(--text-primary)] truncate">{user.displayName || user.email}</p>
+            <p className="text-[13px] text-[var(--text-tertiary)]">{user.email}</p>
             <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1 text-[12px] text-[var(--text-tertiary)]">
               <span className="inline-flex items-center gap-1">
                 <Calendar className="h-3 w-3" />

--- a/src/lib/__tests__/auth.test.tsx
+++ b/src/lib/__tests__/auth.test.tsx
@@ -23,9 +23,8 @@ const mockApiFetch = vi.mocked(apiFetch);
 function makeUser(overrides: Partial<User> = {}): User {
   return {
     id: 'user-1',
-    username: 'testuser',
     displayName: 'Test User',
-    email: null,
+    email: 'testuser@example.com',
     avatarUrl: null,
     createdAt: '2025-01-01T00:00:00Z',
     updatedAt: '2025-01-01T00:00:00Z',
@@ -135,12 +134,12 @@ describe('useAuth', () => {
       });
 
       await act(async () => {
-        await result.current.login('testuser', 'password');
+        await result.current.login('testuser@example.com', 'password');
       });
 
       expect(mockApiFetch).toHaveBeenCalledWith('/api/auth/login', {
         method: 'POST',
-        body: { username: 'testuser', password: 'password' },
+        body: { email: 'testuser@example.com', password: 'password' },
       });
       expect(localStorage.getItem(STORAGE_KEYS.ACTIVE_LOCATION)).toBe('loc-1');
       expect(result.current.user).toEqual(user);
@@ -163,7 +162,7 @@ describe('useAuth', () => {
       });
 
       await act(async () => {
-        await result.current.login('testuser', 'password');
+        await result.current.login('testuser@example.com', 'password');
       });
 
       expect(result.current.activeLocationId).toBe('existing-loc');
@@ -188,12 +187,12 @@ describe('useAuth', () => {
       });
 
       await act(async () => {
-        await result.current.register('newuser', 'password', 'New User');
+        await result.current.register('newuser@example.com', 'password', 'New User');
       });
 
       expect(mockApiFetch).toHaveBeenCalledWith('/api/auth/register', {
         method: 'POST',
-        body: { username: 'newuser', password: 'password', displayName: 'New User' },
+        body: { email: 'newuser@example.com', password: 'password', displayName: 'New User' },
       });
       expect(localStorage.getItem(STORAGE_KEYS.ACTIVE_LOCATION)).toBeNull();
       expect(result.current.user).toEqual(user);

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -12,8 +12,8 @@ interface AuthState {
 }
 
 interface AuthContextValue extends AuthState {
-  login: (username: string, password: string) => Promise<void>;
-  register: (username: string, password: string, displayName: string, email?: string, inviteCode?: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, displayName: string, inviteCode?: string) => Promise<void>;
   logout: () => Promise<void>;
   refreshSession: () => Promise<void>;
   setActiveLocationId: (id: string | null) => void;
@@ -114,10 +114,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener('openbin-auth-expired', handler);
   }, []);
 
-  const login = useCallback(async (username: string, password: string) => {
+  const login = useCallback(async (email: string, password: string) => {
     const data = await apiFetch<{ token: string; user: User; activeLocationId?: string }>('/api/auth/login', {
       method: 'POST',
-      body: { username, password },
+      body: { email, password },
     });
     if (data.activeLocationId) {
       localStorage.setItem(STORAGE_KEYS.ACTIVE_LOCATION, data.activeLocationId);
@@ -130,9 +130,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }));
   }, []);
 
-  const register = useCallback(async (username: string, password: string, displayName: string, email?: string, inviteCode?: string) => {
-    const body: Record<string, string> = { username, password, displayName };
-    if (email) body.email = email;
+  const register = useCallback(async (email: string, password: string, displayName: string, inviteCode?: string) => {
+    const body: Record<string, string> = { email, password, displayName };
     if (inviteCode) body.inviteCode = inviteCode;
     const data = await apiFetch<{ token: string; user: User; activeLocationId?: string }>('/api/auth/register', {
       method: 'POST',

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,8 @@ export type SubscriptionStatus = 'inactive' | 'active' | 'trial';
 
 export interface User {
   id: string;
-  username: string;
   displayName: string;
-  email: string | null;
+  email: string;
   avatarUrl: string | null;
   createdAt: string;
   updatedAt: string;
@@ -44,7 +43,7 @@ export interface LocationMember {
   role: 'admin' | 'member' | 'viewer';
   joined_at: string;
   display_name?: string;
-  username?: string;
+  email?: string;
 }
 
 export interface ActivityLogEntry {
@@ -222,7 +221,7 @@ export interface ExportDataV2 {
   customFieldDefinitions?: Array<{ name: string; position: number }>;
   pinnedBins?: Array<{ userId: string; binId: string; position: number }>;
   savedViews?: Array<{ userId: string; name: string; searchQuery: string; sort: string; filters: string }>;
-  members?: Array<{ userId: string; username: string; role: string; joinedAt: string }>;
+  members?: Array<{ userId: string; email: string; role: string; joinedAt: string }>;
   photos?: ExportedPhoto[];
 }
 


### PR DESCRIPTION
## Summary
- Remove the `username` column from the schema entirely; email becomes the sole login identifier
- Rewrite all auth routes, OAuth flow, middleware, and validation to use email
- Update all server routes (admin, locations, export, API keys, demo seed) to reference email instead of username
- Update client UI — login/register forms, sidebar, member lists, admin pages, settings
- Normalize email case on profile/admin update for consistency

## Test plan
- [ ] Register a new account with email — no username field should appear
- [ ] Login with email + password
- [ ] OAuth login creates account using email directly
- [ ] Admin user list shows email instead of username
- [ ] Member list in location settings shows email
- [ ] All existing tests pass (`npx vitest run` for client, `cd server && npx vitest run` for server)
- [ ] Verify migration works on existing DB (username column ignored/dropped)