### PR TITLE
feat: bin usage tracking with activity heatmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Bin-centric inventory with intelligence. Multi-user web app for organizing physi
 - **Icons**: `lucide-react` — import named icons (e.g. `import { Plus } from 'lucide-react'`).
 - **Responsive**: mobile-first. Breakpoint `lg` (1024px).
 - **Server error handling**: Routes use `throw new ValidationError(...)` etc. from `server/src/lib/httpErrors.ts`, wrapped in `asyncHandler()` to forward to the global error handler.
-- **Event bus**: `notify()` and `useRefreshOn()` from `lib/eventBus.ts`. 9 event types: `BINS`, `LOCATIONS`, `PHOTOS`, `PINS`, `AREAS`, `TAG_COLORS`, `SCAN_HISTORY`, `CUSTOM_FIELDS`, `PLAN`.
+- **Event bus**: `notify()` and `useRefreshOn()` from `lib/eventBus.ts`. 11 event types: `BINS`, `LOCATIONS`, `PHOTOS`, `PINS`, `AREAS`, `TAG_COLORS`, `SCAN_HISTORY`, `CUSTOM_FIELDS`, `PLAN`, `CHECKOUTS`, `BIN_USAGE`.
 
 ## API Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Bin-centric inventory with intelligence. Multi-user web app for organizing physical storage bins with QR codes and photo recognition. Data persists in SQLite via Express API. Flat material design system.
+Bin-centric inventory with intelligence. Multi-user web app for organizing physical storage bins with QR codes and photo recognition. Data persists in SQLite via Express API.
 
 **Data model**: Location → Area → **Bin** → Items. The bin is the core entity — not individual items. Items exist only inside a bin (name + optional quantity, no independent identity). Custom fields, photos, tags, and QR codes all attach to bins. This is a "what's in this container" tool, not an asset tracker.
 
@@ -25,10 +25,6 @@ Bin-centric inventory with intelligence. Multi-user web app for organizing physi
 - **Key utilities**: `apiFetch()` in `lib/api.ts`, `useAuth()` in `lib/auth.tsx`, `useAppSettings()` in `lib/appSettings.ts`, `LocationProvider` in `features/locations/useLocations.tsx`, `usePermissions()` in `lib/usePermissions.ts`, `cn()` in `lib/utils.ts`. Read the source for signatures.
 - **Soft deletes**: `DELETE /api/bins/:id` sets `deleted_at`. All bin queries filter `WHERE deleted_at IS NULL`.
 - **API response envelopes**: Lists return `{ results: T[], count }`. Errors return `{ error: "CODE", message }`. See `server/openapi.yaml` for details.
-- **CSS**: use `var(--token)` design tokens, not raw colors. Surface classes `flat-card`, `flat-nav`, `flat-heavy`, `flat-popover` provide opaque backgrounds with solid borders — no blur, no shadow. Use `cn()` from `lib/utils.ts` (clsx + tailwind-merge) for className composition. **Do not** add `backdrop-blur-*`, `shadow-*`, or `rounded-full` (except pills/avatars) — the design is deliberately flat.
-- **Border tokens**: `--border-flat` for structural/container borders (cards, inputs, pickers, panels). `--border-subtle` for internal separators (dividers between list items, section breaks within a card).
-- **Radius tokens**: `--radius-xs` (4px) through `--radius-xl` (12px), `--radius-full` (9999px). Use `var(--radius-*)` instead of hardcoded values or Tailwind `rounded-*`.
-- **Shared class constants** in `lib/utils.ts`: `inputBase` (form controls), `flatCard`, `focusRing`, `focusRingInset`, `categoryHeader`, `iconButton`, `rowAction`, `overlayBackdrop`, `disclosureSectionLabel`. Use these instead of hand-rolling the same patterns.
 - **Icons**: `lucide-react` — import named icons (e.g. `import { Plus } from 'lucide-react'`).
 - **Responsive**: mobile-first. Breakpoint `lg` (1024px).
 - **Server error handling**: Routes use `throw new ValidationError(...)` etc. from `server/src/lib/httpErrors.ts`, wrapped in `asyncHandler()` to forward to the global error handler.

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -3735,6 +3735,94 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /bins/{id}/usage:
+    get:
+      summary: Get usage history for a bin
+      tags: [Bins]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Usage rows
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        date: { type: string, format: date }
+                        count: { type: integer }
+                  count: { type: integer }
+        '404': { description: Bin not found }
+    post:
+      summary: Record a usage dot for a bin
+      tags: [Bins]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [trigger]
+              properties:
+                trigger:
+                  type: string
+                  enum: [scan, manual]
+      responses:
+        '201':
+          description: Recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  recorded: { type: boolean }
+        '200':
+          description: Trigger disabled in user preferences; nothing recorded
+        '404': { description: Bin not found }
+        '422': { description: Invalid trigger value }
+
+  /locations/{id}/usage:
+    get:
+      summary: Get aggregate usage for a location
+      tags: [Locations]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Aggregated daily rows across all bins in the location
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        date: { type: string, format: date }
+                        binCount: { type: integer }
+                        totalCount: { type: integer }
+                  count: { type: integer }
+        '403': { description: Not a member of this location }
+
   # ════════════════════════════════════════════════════════
   # Photos
   # ════════════════════════════════════════════════════════

--- a/server/schema.pg.sql
+++ b/server/schema.pg.sql
@@ -471,3 +471,14 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
   name       TEXT PRIMARY KEY,
   applied_at TEXT NOT NULL DEFAULT (NOW())
 );
+
+CREATE TABLE IF NOT EXISTS bin_usage_days (
+  bin_id           TEXT NOT NULL REFERENCES bins(id) ON DELETE CASCADE,
+  date             TEXT NOT NULL,
+  count            INTEGER NOT NULL DEFAULT 1,
+  last_user_id     TEXT REFERENCES users(id) ON DELETE SET NULL,
+  last_recorded_at TEXT NOT NULL DEFAULT (NOW()::text),
+  PRIMARY KEY (bin_id, date)
+);
+CREATE INDEX IF NOT EXISTS idx_bin_usage_days_date ON bin_usage_days(date);
+CREATE INDEX IF NOT EXISTS idx_bin_usage_days_bin ON bin_usage_days(bin_id, date DESC);

--- a/server/schema.sqlite.sql
+++ b/server/schema.sqlite.sql
@@ -454,3 +454,14 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
   name       TEXT PRIMARY KEY,
   applied_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS bin_usage_days (
+  bin_id           TEXT NOT NULL REFERENCES bins(id) ON DELETE CASCADE,
+  date             TEXT NOT NULL,
+  count            INTEGER NOT NULL DEFAULT 1,
+  last_user_id     TEXT REFERENCES users(id) ON DELETE SET NULL,
+  last_recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (bin_id, date)
+);
+CREATE INDEX IF NOT EXISTS idx_bin_usage_days_date ON bin_usage_days(date);
+CREATE INDEX IF NOT EXISTS idx_bin_usage_days_bin ON bin_usage_days(bin_id, date DESC);

--- a/server/src/db/migrations/0003_bin_usage_days.ts
+++ b/server/src/db/migrations/0003_bin_usage_days.ts
@@ -1,0 +1,24 @@
+import type { Migration } from './types.js';
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS bin_usage_days (
+    bin_id           TEXT NOT NULL REFERENCES bins(id) ON DELETE CASCADE,
+    date             TEXT NOT NULL,
+    count            INTEGER NOT NULL DEFAULT 1,
+    last_user_id     TEXT REFERENCES users(id) ON DELETE SET NULL,
+    last_recorded_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+    PRIMARY KEY (bin_id, date)
+  );
+  CREATE INDEX IF NOT EXISTS idx_bin_usage_days_date ON bin_usage_days(date);
+  CREATE INDEX IF NOT EXISTS idx_bin_usage_days_bin ON bin_usage_days(bin_id, date DESC);
+`;
+
+export const binUsageDays: Migration = {
+  name: '0003_bin_usage_days',
+  sqlite(db) {
+    db.exec(SQL);
+  },
+  async postgres(pool) {
+    await pool.query(SQL);
+  },
+};

--- a/server/src/db/migrations/index.ts
+++ b/server/src/db/migrations/index.ts
@@ -1,5 +1,6 @@
 import { legacy } from './0001_legacy.js';
 import { shareExpires } from './0002_share_expires.js';
+import { binUsageDays } from './0003_bin_usage_days.js';
 import type { Migration } from './types.js';
 
 /**
@@ -9,4 +10,5 @@ import type { Migration } from './types.js';
 export const migrations: Migration[] = [
   legacy,
   shareExpires,
+  binUsageDays,
 ];

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import binItemsRoutes from './routes/binItems.js';
 import binPinsRoutes from './routes/binPins.js';
 import { binSharesRoutes } from './routes/binShares.js';
 import binsRoutes from './routes/bins.js';
+import binUsageRoutes from './routes/binUsage.js';
 import customFieldsRoutes from './routes/customFields.js';
 import exportRoutes from './routes/export.js';
 import itemCheckoutsRoutes, { locationCheckoutsRouter as locationCheckoutsRoutes } from './routes/itemCheckouts.js';
@@ -146,6 +147,7 @@ export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => voi
   app.use('/api/bins', binPinsRoutes);
   app.use('/api/bins', binSharesRoutes);
   app.use('/api/bins', binsRoutes);
+  app.use('/api/bins', binUsageRoutes);  // new — mounts GET/POST /:id/usage
   app.use('/api/bins', binItemsRoutes);
   app.use('/api/bins', itemCheckoutsRoutes);
   app.use('/api/photos', photosRoutes);

--- a/server/src/lib/__tests__/binQueries.test.ts
+++ b/server/src/lib/__tests__/binQueries.test.ts
@@ -1,0 +1,60 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { setDialect } from '../../db/dialect.js';
+
+beforeAll(() => {
+  setDialect('sqlite');
+});
+
+const { buildBinListQuery } = await import('../binQueries.js');
+
+describe('buildBinListQuery sort', () => {
+  const base = { locationId: 'loc-1', userId: 'user-1' };
+
+  it('defaults to updated_at DESC', () => {
+    const q = buildBinListQuery({ ...base });
+    expect(q.orderClause).toContain('b.updated_at');
+    expect(q.orderClause).toContain('DESC');
+  });
+
+  it('supports name sort with COLLATE NOCASE', () => {
+    const q = buildBinListQuery({ ...base, sort: 'name', sortDir: 'asc' });
+    expect(q.orderClause).toContain('b.name');
+    expect(q.orderClause).toContain('NOCASE');
+    expect(q.orderClause).toContain('ASC');
+  });
+
+  it('supports last_used sort with NULLs last (DESC)', () => {
+    const q = buildBinListQuery({ ...base, sort: 'last_used', sortDir: 'desc' });
+    expect(q.orderClause).toContain('SELECT MAX(date) FROM bin_usage_days');
+    expect(q.orderClause).toContain('IS NULL THEN 1 ELSE 0 END ASC');
+    expect(q.orderClause).toContain('DESC');
+  });
+
+  it('last_used sort ASC still sorts NULLs last', () => {
+    const q = buildBinListQuery({ ...base, sort: 'last_used', sortDir: 'asc' });
+    expect(q.orderClause).toMatch(/IS NULL THEN 1 ELSE 0 END ASC/);
+    expect(q.orderClause).toContain('ASC');
+  });
+});
+
+describe('buildBinListQuery unusedSince filter', () => {
+  const base = { locationId: 'loc-1', userId: 'user-1' };
+
+  it('adds WHERE clause with MAX(date) comparison', () => {
+    const q = buildBinListQuery({ ...base, unusedSince: '2026-01-12' });
+    expect(q.whereSQL).toContain('SELECT MAX(date) FROM bin_usage_days');
+    expect(q.params).toContain('2026-01-12');
+  });
+
+  it('includes bins with no usage rows via IS NULL branch', () => {
+    const q = buildBinListQuery({ ...base, unusedSince: '2026-01-12' });
+    expect(q.whereSQL).toContain('IS NULL OR');
+  });
+
+  it('ignores malformed date values', () => {
+    const q = buildBinListQuery({ ...base, unusedSince: 'notadate' });
+    expect(q.whereSQL).not.toContain('bin_usage_days');
+    expect(q.params).not.toContain('notadate');
+  });
+});

--- a/server/src/lib/__tests__/recordBinUsage.test.ts
+++ b/server/src/lib/__tests__/recordBinUsage.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+
+vi.mock('../../db.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  d: {
+    now: () => "datetime('now')",
+    today: () => "date('now')",
+  },
+}));
+
+const { recordBinUsage, getUserUsageTrackingPrefs } = await import('../recordBinUsage.js');
+
+describe('recordBinUsage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  });
+
+  it('inserts a row for (bin, today) with count=1', async () => {
+    await recordBinUsage('bin-1', 'user-1');
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('INSERT INTO bin_usage_days');
+    expect(sql).toContain('ON CONFLICT (bin_id, date) DO UPDATE');
+    expect(sql).toContain('count = bin_usage_days.count + 1');
+    expect(params).toEqual(['bin-1', today, 'user-1']);
+  });
+
+  it('accepts null userId (e.g. api-key calls where user context is thin)', async () => {
+    await recordBinUsage('bin-1', null);
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params).toEqual(['bin-1', today, null]);
+  });
+
+  it('swallows errors so callers never have to catch', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+    await expect(recordBinUsage('bin-1', 'user-1')).resolves.toBeUndefined();
+  });
+
+  it('uses UTC date (not local) when computing today', async () => {
+    vi.useFakeTimers();
+    try {
+      // Set wall clock to 2026-04-12T23:59:00Z — late evening UTC
+      vi.setSystemTime(new Date('2026-04-12T23:59:00Z'));
+      await recordBinUsage('bin-1', 'user-1');
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [, params] = mockQuery.mock.calls[0];
+      expect(params).toEqual(['bin-1', '2026-04-12', 'user-1']);
+
+      mockQuery.mockClear();
+
+      // Advance past UTC midnight
+      vi.setSystemTime(new Date('2026-04-13T00:01:00Z'));
+      await recordBinUsage('bin-1', 'user-1');
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [, params2] = mockQuery.mock.calls[0];
+      expect(params2).toEqual(['bin-1', '2026-04-13', 'user-1']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('getUserUsageTrackingPrefs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns defaults when user has no preferences row', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const prefs = await getUserUsageTrackingPrefs('user-1');
+    expect(prefs).toEqual({ scan: true, manual_lookup: true, view: false, modify: false });
+  });
+
+  it('parses existing preferences JSON', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ settings: JSON.stringify({ usage_tracking_scan: false, usage_tracking_view: true }) }],
+      rowCount: 1,
+    });
+    const prefs = await getUserUsageTrackingPrefs('user-1');
+    expect(prefs.scan).toBe(false);
+    expect(prefs.manual_lookup).toBe(true);  // default
+    expect(prefs.view).toBe(true);
+    expect(prefs.modify).toBe(false);  // default
+  });
+
+  it('handles settings stored as already-parsed object (pg JSONB)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ settings: { usage_tracking_scan: false } }],
+      rowCount: 1,
+    });
+    const prefs = await getUserUsageTrackingPrefs('user-1');
+    expect(prefs.scan).toBe(false);
+  });
+
+  it('returns defaults if settings JSON is malformed', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ settings: 'not json' }],
+      rowCount: 1,
+    });
+    const prefs = await getUserUsageTrackingPrefs('user-1');
+    expect(prefs).toEqual({ scan: true, manual_lookup: true, view: false, modify: false });
+  });
+});

--- a/server/src/lib/binQueries.ts
+++ b/server/src/lib/binQueries.ts
@@ -44,6 +44,7 @@ export interface BinListFilterParams {
   hasItems?: string;
   hasNotes?: string;
   needsOrganizing?: string;
+  unusedSince?: string;  // NEW — ISO 'YYYY-MM-DD'
   sort?: string;
   sortDir?: string;
 }
@@ -151,6 +152,17 @@ export function buildBinListQuery(filters: BinListFilterParams): BinListQuery {
     whereClauses.push(`${emptyTags} AND b.area_id IS NULL AND NOT EXISTS (SELECT 1 FROM bin_items bi WHERE bi.bin_id = b.id)`);
   }
 
+  // Unused-since filter: match bins whose most recent usage row is before the cutoff,
+  // OR bins that have no usage row at all.
+  if (filters.unusedSince && /^\d{4}-\d{2}-\d{2}$/.test(filters.unusedSince)) {
+    const p = `$${paramIdx}`;
+    whereClauses.push(
+      `((SELECT MAX(date) FROM bin_usage_days WHERE bin_id = b.id) IS NULL OR (SELECT MAX(date) FROM bin_usage_days WHERE bin_id = b.id) < ${p})`,
+    );
+    params.push(filters.unusedSince);
+    paramIdx++;
+  }
+
   const validSorts: Record<string, string> = {
     name: `b.name ${d.nocase()}`,
     created_at: 'b.created_at',
@@ -162,6 +174,10 @@ export function buildBinListQuery(filters: BinListFilterParams): BinListQuery {
   let orderClause: string;
   if (sortKey === 'area') {
     orderClause = `CASE WHEN a.name IS NULL OR a.name = '' THEN 1 ELSE 0 END ASC, a.name ${d.nocase()} ${dir}, b.name ${d.nocase()} ASC`;
+  } else if (sortKey === 'last_used') {
+    // Subquery-based to keep BIN_SELECT_COLS untouched; NULLs (never-used) always sort to the tail.
+    const lastUsedExpr = '(SELECT MAX(date) FROM bin_usage_days WHERE bin_id = b.id)';
+    orderClause = `CASE WHEN ${lastUsedExpr} IS NULL THEN 1 ELSE 0 END ASC, ${lastUsedExpr} ${dir}, b.name ${d.nocase()} ASC`;
   } else {
     const orderBy = validSorts[sortKey] || 'b.updated_at';
     orderClause = `${orderBy} ${dir}`;

--- a/server/src/lib/demoSeed.ts
+++ b/server/src/lib/demoSeed.ts
@@ -397,6 +397,87 @@ async function seedScanHistory(tx: TxQueryFn, userIdMap: Map<DemoMember, string>
   }
 }
 
+type UsageProfile = 'hot' | 'warm' | 'historical' | 'cold' | 'silent';
+
+function pickProfile(binName: string): UsageProfile {
+  const hash = (binName.charCodeAt(0) + (binName.charCodeAt(1) || 0)) % 10;
+  if (hash < 2) return 'hot';        // ~20%
+  if (hash < 5) return 'warm';       // ~30%
+  if (hash < 7) return 'historical'; // ~20%
+  if (hash < 9) return 'cold';       // ~20%
+  return 'silent';                   // ~10%
+}
+
+function generateDatesForProfile(
+  profile: UsageProfile,
+  binName: string,
+): Array<{ date: string; count: number }> {
+  const hash = binName.charCodeAt(0) + (binName.charCodeAt(1) || 0);
+  const now = Date.now();
+  const utcDate = (daysAgo: number): string =>
+    new Date(now - daysAgo * 86_400_000).toISOString().slice(0, 10);
+
+  const results: Array<{ date: string; count: number }> = [];
+
+  if (profile === 'hot') {
+    // Last 60 days, ~4 days/week
+    for (let i = 0; i < 60; i++) {
+      if ((hash + i) % 7 < 4) {
+        const count = ((hash + i) % 2) + 1; // 1 or 2
+        results.push({ date: utcDate(i), count });
+      }
+    }
+  } else if (profile === 'warm') {
+    // Last 180 days, ~1 day/week
+    for (let i = 0; i < 180; i++) {
+      if ((hash + i) % 7 === 0) {
+        results.push({ date: utcDate(i), count: 1 });
+      }
+    }
+  } else if (profile === 'historical') {
+    // 300–480 days ago, ~3 of 10 days
+    for (let i = 300; i < 480; i++) {
+      if ((hash + i) % 10 < 3) {
+        const count = ((hash + i) % 2) + 1; // 1 or 2
+        results.push({ date: utcDate(i), count });
+      }
+    }
+  } else if (profile === 'cold') {
+    // Just 3 scattered hits far in the past
+    for (const daysAgo of [400, 550, 730]) {
+      results.push({ date: utcDate(daysAgo), count: 1 });
+    }
+  }
+  // 'silent' returns []
+  return results;
+}
+
+async function seedBinUsageDays(
+  tx: TxQueryFn,
+  binIdMap: Map<string, string>,
+  userIdMap: Map<DemoMember, string>,
+): Promise<void> {
+  const userIds = [...userIdMap.values()];
+  let userIdx = 0;
+
+  for (const [binName, binId] of binIdMap.entries()) {
+    const profile = pickProfile(binName);
+    if (profile === 'silent') continue;
+
+    const dates = generateDatesForProfile(profile, binName);
+    for (const { date, count } of dates) {
+      const recordedAt = `${date}T00:00:00.000Z`;
+      const userId = userIds[userIdx % userIds.length];
+      userIdx++;
+      await tx(
+        `INSERT INTO bin_usage_days (bin_id, date, count, last_user_id, last_recorded_at)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [binId, date, count, userId, recordedAt],
+      );
+    }
+  }
+}
+
 async function seedOnboardingPrefs(tx: TxQueryFn, userIdMap: Map<DemoMember, string>): Promise<void> {
   for (const [member, id] of userIdMap.entries()) {
     const prefs = member === 'demo'
@@ -579,6 +660,7 @@ export async function seedDemoData(): Promise<void> {
       await seedPins(tx, userId, userIdMap.get('pat')!, binIdMap, pinnedNames, pinnedNamesPat);
       await seedSavedViews(tx, userId, userIdMap.get('sarah')!, areaMap);
       await seedScanHistory(tx, userIdMap, binIdMap, scannedNames);
+      await seedBinUsageDays(tx, binIdMap, userIdMap);
       await seedOnboardingPrefs(tx, userIdMap);
       await seedCustomFields(tx, homeLocationId, binIdMap, cfDefs, cfValues);
       await seedCheckouts(tx, homeLocationId, storageLocationId, userIdMap, binIdMap, bins, checkouts, returnedCheckoutsList);

--- a/server/src/lib/recordBinUsage.ts
+++ b/server/src/lib/recordBinUsage.ts
@@ -1,0 +1,76 @@
+import { d, query } from '../db.js';
+
+export interface UsageTrackingPrefs {
+  scan: boolean;
+  manual_lookup: boolean;
+  view: boolean;
+  modify: boolean;
+}
+
+const DEFAULT_PREFS: UsageTrackingPrefs = {
+  scan: true,
+  manual_lookup: true,
+  view: false,
+  modify: false,
+};
+
+/**
+ * Upsert today's usage row for a bin. One row per (bin, UTC date).
+ * Fire-and-forget from callers' perspective — errors are swallowed since
+ * usage tracking is observational and should never fail a request.
+ */
+export async function recordBinUsage(binId: string, userId: string | null): Promise<void> {
+  try {
+    const today = new Date().toISOString().slice(0, 10);  // 'YYYY-MM-DD' UTC
+    await query(
+      `INSERT INTO bin_usage_days (bin_id, date, count, last_user_id, last_recorded_at)
+       VALUES ($1, $2, 1, $3, ${d.now()})
+       ON CONFLICT (bin_id, date) DO UPDATE SET
+         count = bin_usage_days.count + 1,
+         last_user_id = EXCLUDED.last_user_id,
+         last_recorded_at = ${d.now()}`,
+      [binId, today, userId],
+    );
+  } catch {
+    // Swallow — usage tracking is non-critical. Callers should not have to handle errors.
+  }
+}
+
+interface SettingsRow {
+  settings: unknown;
+}
+
+function parseSettings(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+/**
+ * Read the caller's usage tracking preferences from the user_preferences JSON.
+ * Returns DEFAULT_PREFS if no row exists or JSON is malformed.
+ */
+export async function getUserUsageTrackingPrefs(userId: string): Promise<UsageTrackingPrefs> {
+  const result = await query<SettingsRow>(
+    'SELECT settings FROM user_preferences WHERE user_id = $1',
+    [userId],
+  );
+  if (result.rows.length === 0) return { ...DEFAULT_PREFS };
+
+  const settings = parseSettings(result.rows[0].settings);
+  return {
+    scan: typeof settings.usage_tracking_scan === 'boolean' ? settings.usage_tracking_scan : DEFAULT_PREFS.scan,
+    manual_lookup: typeof settings.usage_tracking_manual_lookup === 'boolean' ? settings.usage_tracking_manual_lookup : DEFAULT_PREFS.manual_lookup,
+    view: typeof settings.usage_tracking_view === 'boolean' ? settings.usage_tracking_view : DEFAULT_PREFS.view,
+    modify: typeof settings.usage_tracking_modify === 'boolean' ? settings.usage_tracking_modify : DEFAULT_PREFS.modify,
+  };
+}

--- a/server/src/routes/__tests__/binUsage.test.ts
+++ b/server/src/routes/__tests__/binUsage.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockVerifyBinAccess = vi.fn();
+const mockRecordBinUsage = vi.fn();
+const mockGetPrefs = vi.fn();
+
+vi.mock('../../db.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  d: { now: () => "datetime('now')", today: () => "date('now')" },
+  generateUuid: () => 'test-uuid',
+}));
+vi.mock('../../lib/config.js', () => ({
+  config: { selfHosted: true, disableRateLimit: true },
+}));
+vi.mock('../../lib/binAccess.js', () => ({
+  verifyBinAccess: (...args: unknown[]) => mockVerifyBinAccess(...args),
+}));
+vi.mock('../../lib/recordBinUsage.js', () => ({
+  recordBinUsage: (...args: unknown[]) => mockRecordBinUsage(...args),
+  getUserUsageTrackingPrefs: (...args: unknown[]) => mockGetPrefs(...args),
+}));
+
+const { default: router } = await import('../binUsage.js');
+
+function findHandler(method: 'get' | 'post', path: string) {
+  const layer = (router as any).stack.find(
+    (l: any) => l.route?.path === path && l.route?.methods?.[method],
+  );
+  if (!layer) throw new Error(`${method.toUpperCase()} ${path} not found`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+describe('GET /api/bins/:id/usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 for bins the user cannot access', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce(null);
+    const handler = findHandler('get', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, user: { id: 'user-1' } } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+    expect(next.mock.calls[0][0].statusCode).toBe(404);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('returns usage rows for accessible bins', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce({ locationId: 'loc-1', visibility: 'location', createdBy: 'user-1', name: 'Test' });
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { date: '2026-04-12', count: 3 },
+        { date: '2026-04-10', count: 1 },
+      ],
+      rowCount: 2,
+    });
+
+    const handler = findHandler('get', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, user: { id: 'user-1' } } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(res.json).toHaveBeenCalledWith({
+      results: [
+        { date: '2026-04-12', count: 3 },
+        { date: '2026-04-10', count: 1 },
+      ],
+      count: 2,
+    });
+  });
+});
+
+describe('GET /api/bins/:id/usage with empty data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty results envelope when bin has no usage rows', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce({ locationId: 'loc-1', visibility: 'location', createdBy: 'user-1', name: 'Test' });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const handler = findHandler('get', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, user: { id: 'user-1' } } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(res.json).toHaveBeenCalledWith({ results: [], count: 0 });
+  });
+});
+
+describe('POST /api/bins/:id/usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 422 if trigger is missing', async () => {
+    const handler = findHandler('post', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, body: {}, user: { id: 'user-1' } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+    expect(next.mock.calls[0][0].statusCode).toBe(422);
+  });
+
+  it('returns 422 for unknown trigger value', async () => {
+    const handler = findHandler('post', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, body: { trigger: 'random' }, user: { id: 'user-1' } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+    expect(next.mock.calls[0][0].statusCode).toBe(422);
+  });
+
+  it('returns 404 when bin is not accessible', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce(null);
+    const handler = findHandler('post', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, body: { trigger: 'scan' }, user: { id: 'user-1' } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+    expect(next.mock.calls[0][0].statusCode).toBe(404);
+  });
+
+  it('records usage when scan trigger is enabled in prefs', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce({ locationId: 'loc-1', visibility: 'location', createdBy: 'user-1', name: 'Test' });
+    mockGetPrefs.mockResolvedValueOnce({ scan: true, manual_lookup: true, view: false, modify: false });
+
+    const handler = findHandler('post', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, body: { trigger: 'scan' }, user: { id: 'user-1' } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(mockRecordBinUsage).toHaveBeenCalledWith('bin-1', 'user-1');
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ ok: true, recorded: true });
+  });
+
+  it('does not record when trigger is disabled in prefs', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce({ locationId: 'loc-1', visibility: 'location', createdBy: 'user-1', name: 'Test' });
+    mockGetPrefs.mockResolvedValueOnce({ scan: false, manual_lookup: true, view: false, modify: false });
+
+    const handler = findHandler('post', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, body: { trigger: 'scan' }, user: { id: 'user-1' } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(mockRecordBinUsage).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ ok: true, recorded: false });
+  });
+
+  it('checks manual_lookup pref for trigger=manual', async () => {
+    mockVerifyBinAccess.mockResolvedValueOnce({ locationId: 'loc-1', visibility: 'location', createdBy: 'user-1', name: 'Test' });
+    mockGetPrefs.mockResolvedValueOnce({ scan: true, manual_lookup: false, view: false, modify: false });
+
+    const handler = findHandler('post', '/:id/usage');
+    const req = { params: { id: 'bin-1' }, body: { trigger: 'manual' }, user: { id: 'user-1' } } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(mockRecordBinUsage).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ ok: true, recorded: false });
+  });
+});

--- a/server/src/routes/__tests__/locationUsage.test.ts
+++ b/server/src/routes/__tests__/locationUsage.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockVerifyLocationMembership = vi.fn();
+
+vi.mock('../../db.js', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  d: { now: () => "datetime('now')", today: () => "date('now')" },
+  generateUuid: () => 'test-uuid',
+}));
+vi.mock('../../lib/config.js', () => ({
+  config: { selfHosted: true, disableRateLimit: true },
+}));
+vi.mock('../../lib/binAccess.js', () => ({
+  verifyLocationMembership: (...args: unknown[]) => mockVerifyLocationMembership(...args),
+  requireMemberOrAbove: vi.fn(),
+  requireAdmin: vi.fn(),
+  getMemberRole: vi.fn(),
+  isLocationAdmin: vi.fn(),
+}));
+
+const { default: router } = await import('../locations.js');
+
+function findHandler(method: 'get', path: string) {
+  const layer = (router as any).stack.find(
+    (l: any) => l.route?.path === path && l.route?.methods?.[method],
+  );
+  if (!layer) throw new Error(`${method.toUpperCase()} ${path} not found`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+describe('GET /api/locations/:id/usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 when the user is not a member', async () => {
+    mockVerifyLocationMembership.mockResolvedValueOnce(false);
+    const handler = findHandler('get', '/:id/usage');
+    const req = { params: { id: 'loc-1' }, user: { id: 'user-1' } } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+    expect(next.mock.calls[0][0].statusCode).toBe(403);
+  });
+
+  it('returns aggregated daily counts for members', async () => {
+    mockVerifyLocationMembership.mockResolvedValueOnce(true);
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { date: '2026-04-12', bin_count: 4, total_count: 11 },
+        { date: '2026-04-10', bin_count: 2, total_count: 2 },
+      ],
+      rowCount: 2,
+    });
+
+    const handler = findHandler('get', '/:id/usage');
+    const req = { params: { id: 'loc-1' }, user: { id: 'user-1' } } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(res.json).toHaveBeenCalledWith({
+      results: [
+        { date: '2026-04-12', binCount: 4, totalCount: 11 },
+        { date: '2026-04-10', binCount: 2, totalCount: 2 },
+      ],
+      count: 2,
+    });
+  });
+
+  it('returns empty results envelope when no usage data exists', async () => {
+    mockVerifyLocationMembership.mockResolvedValueOnce(true);
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const handler = findHandler('get', '/:id/usage');
+    const req = { params: { id: 'loc-1' }, user: { id: 'user-1' } } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    handler(req, res, next);
+    await vi.waitFor(() => expect(res.json).toHaveBeenCalled());
+
+    expect(res.json).toHaveBeenCalledWith({ results: [], count: 0 });
+  });
+});

--- a/server/src/routes/binUsage.ts
+++ b/server/src/routes/binUsage.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import { query } from '../db.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+import { verifyBinAccess } from '../lib/binAccess.js';
+import { NotFoundError, ValidationError } from '../lib/httpErrors.js';
+import { getUserUsageTrackingPrefs, recordBinUsage } from '../lib/recordBinUsage.js';
+import { authenticate } from '../middleware/auth.js';
+
+const router = Router();
+
+router.use(authenticate);
+
+// GET /api/bins/:id/usage
+router.get('/:id/usage', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const access = await verifyBinAccess(id, req.user!.id);
+  if (!access) throw new NotFoundError('Bin not found');
+
+  const result = await query<{ date: string; count: number }>(
+    `SELECT date, count FROM bin_usage_days WHERE bin_id = $1 ORDER BY date DESC`,
+    [id],
+  );
+
+  res.json({ results: result.rows, count: result.rowCount });
+}));
+
+// POST /api/bins/:id/usage — record a dot (scan or manual trigger)
+router.post('/:id/usage', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const trigger = (req.body?.trigger as string | undefined)?.trim();
+
+  if (trigger !== 'scan' && trigger !== 'manual') {
+    throw new ValidationError("trigger must be 'scan' or 'manual'");
+  }
+
+  const access = await verifyBinAccess(id, req.user!.id);
+  if (!access) throw new NotFoundError('Bin not found');
+
+  const prefs = await getUserUsageTrackingPrefs(req.user!.id);
+  const enabled = trigger === 'scan' ? prefs.scan : prefs.manual_lookup;
+
+  if (enabled) {
+    await recordBinUsage(id, req.user!.id);
+    res.status(201).json({ ok: true, recorded: true });
+  } else {
+    res.json({ ok: true, recorded: false });
+  }
+}));
+
+export default router;

--- a/server/src/routes/bins.ts
+++ b/server/src/routes/bins.ts
@@ -240,7 +240,12 @@ router.get('/:id', asyncHandler(async (req, res) => {
     throw new NotFoundError('Bin not found');
   }
 
-  // Fire-and-forget: record a usage dot if the user has view tracking enabled
+  // Fire-and-forget: record a usage dot if the user has view tracking enabled.
+  // Note: when both scan and view prefs are enabled, a single QR scan can
+  // increment `count` multiple times (ScanDialog's validate fetch, the scan
+  // POST, and the detail page's mount fetch each trigger a write). This
+  // does not affect the dot's existence (one dot per UTC day) but does inflate
+  // the per-day `count` field. The default config (view=false) avoids this.
   getUserUsageTrackingPrefs(req.user!.id)
     .then((prefs) => {
       if (prefs.view) recordBinUsage(id, req.user!.id);

--- a/server/src/routes/bins.ts
+++ b/server/src/routes/bins.ts
@@ -14,6 +14,7 @@ import { cleanupBinPhotos } from '../lib/photoCleanup.js';
 import { generateThumbnail } from '../lib/photoHelpers.js';
 import { assertLocationWritable, generateUpgradeUrl, getUserFeatures, getUserPlanInfo, invalidateOverLimitCache } from '../lib/planGate.js';
 import { sensitiveAuthLimiter } from '../lib/rateLimiters.js';
+import { getUserUsageTrackingPrefs, recordBinUsage } from '../lib/recordBinUsage.js';
 import { logRouteActivity } from '../lib/routeHelpers.js';
 import { storage } from '../lib/storage.js';
 import { generateThumbnailBuffer } from '../lib/thumbnailPool.js';
@@ -98,6 +99,7 @@ router.get('/', asyncHandler(async (req, res) => {
     hasItems: req.query.has_items as string | undefined,
     hasNotes: req.query.has_notes as string | undefined,
     needsOrganizing: req.query.needs_organizing as string | undefined,
+    unusedSince: req.query.unused_since as string | undefined,  // NEW
     sort: req.query.sort as string | undefined,
     sortDir: req.query.sort_dir as string | undefined,
   });
@@ -238,6 +240,13 @@ router.get('/:id', asyncHandler(async (req, res) => {
     throw new NotFoundError('Bin not found');
   }
 
+  // Fire-and-forget: record a usage dot if the user has view tracking enabled
+  getUserUsageTrackingPrefs(req.user!.id)
+    .then((prefs) => {
+      if (prefs.view) recordBinUsage(id, req.user!.id);
+    })
+    .catch(() => {});
+
   res.json(bin);
 }));
 
@@ -325,6 +334,13 @@ router.put('/:id', asyncHandler(async (req, res) => {
   }
 
   res.json(bin);
+
+  // Fire-and-forget: record a usage dot if the user has modify tracking enabled
+  getUserUsageTrackingPrefs(req.user!.id)
+    .then((prefs) => {
+      if (prefs.modify) recordBinUsage(id, req.user!.id);
+    })
+    .catch(() => {});
 }));
 
 // DELETE /api/bins/:id — soft-delete bin (admin only)

--- a/server/src/routes/locations.ts
+++ b/server/src/routes/locations.ts
@@ -418,6 +418,33 @@ router.get('/:id/stats', asyncHandler(async (req, res) => {
   res.json(result.rows[0]);
 }));
 
+// GET /api/locations/:id/usage — daily aggregate across all bins in the location
+router.get('/:id/usage', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  const isMember = await verifyLocationMembership(id, req.user!.id);
+  if (!isMember) throw new ForbiddenError('Not a member of this location');
+
+  const result = await query<{ date: string; bin_count: number; total_count: number }>(
+    `SELECT bud.date,
+            COUNT(DISTINCT bud.bin_id) AS bin_count,
+            SUM(bud.count) AS total_count
+     FROM bin_usage_days bud
+     JOIN bins b ON b.id = bud.bin_id AND b.location_id = $1 AND b.deleted_at IS NULL
+     GROUP BY bud.date
+     ORDER BY bud.date DESC`,
+    [id],
+  );
+
+  const results = result.rows.map((r) => ({
+    date: r.date,
+    binCount: Number(r.bin_count),
+    totalCount: Number(r.total_count),
+  }));
+
+  res.json({ results, count: result.rowCount });
+}));
+
 // GET /api/locations/:id/members — list members
 router.get('/:id/members', asyncHandler(async (req, res) => {
   const locationId = req.params.id;

--- a/src/features/bins/BinDetailContent.tsx
+++ b/src/features/bins/BinDetailContent.tsx
@@ -10,6 +10,7 @@ import { AiSuggestionsPanel } from '@/features/ai/AiSuggestionsPanel';
 import { AreaPicker } from '@/features/areas/AreaPicker';
 import { QRCodeDisplay } from '@/features/qrcode/QRCodeDisplay';
 import { useTagStyle } from '@/features/tags/useTagStyle';
+import { BinUsageSection } from '@/features/usage/BinUsageSection';
 import { getSecondaryColorInfo, setSecondaryColor } from '@/lib/cardStyle';
 import { useTerminology } from '@/lib/terminology';
 import { cn, disclosureSectionLabel } from '@/lib/utils';
@@ -141,6 +142,7 @@ export function BinDetailContent({
         </Card>
 
         {photosSection}
+        <BinUsageSection binId={bin.id} />
       </div>
 
       {/* Right column */}

--- a/src/features/bins/BinFilterDialog.tsx
+++ b/src/features/bins/BinFilterDialog.tsx
@@ -16,6 +16,7 @@ const sortLabels: Record<SortOption, string> = {
   created: 'Created',
   name: 'Name',
   area: 'Area',
+  last_used: 'Last used',
 };
 
 function SectionHeader({ label, count }: { label: string; count?: number }) {
@@ -266,6 +267,32 @@ export function BinFilterDialog({
               </div>
             </div>
           )}
+
+          {/* Usage — filter by last-used date */}
+          <div className="space-y-2.5">
+            <SectionHeader label="Usage" count={draft.unusedSince ? 1 : 0} />
+            <div className="flex items-center gap-2">
+              <label htmlFor="unused-since-date" className="text-[13px] text-[var(--text-secondary)]">Unused since</label>
+              <input
+                id="unused-since-date"
+                type="date"
+                value={draft.unusedSince ?? ''}
+                onChange={(e) =>
+                  setDraft((d) => ({ ...d, unusedSince: e.target.value || undefined }))
+                }
+                className="rounded-[var(--radius-xs)] bg-[var(--bg-input)] px-2.5 py-1 text-[13px] text-[var(--text-primary)]"
+              />
+              {draft.unusedSince && (
+                <button
+                  type="button"
+                  onClick={() => setDraft((d) => ({ ...d, unusedSince: undefined }))}
+                  className="text-[12px] text-[var(--accent)] hover:underline"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
 
         </div>
 

--- a/src/features/bins/BinFilterDialog.tsx
+++ b/src/features/bins/BinFilterDialog.tsx
@@ -280,7 +280,7 @@ export function BinFilterDialog({
                 onChange={(e) =>
                   setDraft((d) => ({ ...d, unusedSince: e.target.value || undefined }))
                 }
-                className="rounded-[var(--radius-xs)] bg-[var(--bg-input)] px-2.5 py-1 text-[13px] text-[var(--text-primary)]"
+                className="rounded-[var(--radius-xs)] bg-[var(--bg-input)] border border-[var(--border-flat)] px-2.5 py-1 text-[13px] text-[var(--text-primary)]"
               />
               {draft.unusedSince && (
                 <button

--- a/src/features/bins/SortMenu.tsx
+++ b/src/features/bins/SortMenu.tsx
@@ -13,6 +13,7 @@ const sortLabels: Record<SortOption, string> = {
   created: 'Created',
   name: 'Name',
   area: 'Area',
+  last_used: 'Last used',
 };
 
 interface SortMenuProps {

--- a/src/features/bins/useBinSearchParams.ts
+++ b/src/features/bins/useBinSearchParams.ts
@@ -6,14 +6,15 @@ import { STORAGE_KEYS } from '@/lib/storageKeys';
 import { useDebounce } from '@/lib/useDebounce';
 import { type BinFilters, EMPTY_FILTERS, type SortOption } from './useBins';
 
-const SORT_TO_API: Record<SortOption, string> = { updated: 'updated_at', created: 'created_at', name: 'name', area: 'area' };
-const API_TO_SORT: Record<string, SortOption> = { updated_at: 'updated', created_at: 'created', name: 'name', area: 'area' };
+const SORT_TO_API: Record<SortOption, string> = { updated: 'updated_at', created: 'created_at', name: 'name', area: 'area', last_used: 'last_used' };
+const API_TO_SORT: Record<string, SortOption> = { updated_at: 'updated', created_at: 'created', name: 'name', area: 'area', last_used: 'last_used' };
 
 export const DEFAULT_BIN_SORT_DIRS: Record<SortOption, SortDirection> = {
   name: 'asc',
   updated: 'desc',
   created: 'desc',
   area: 'asc',
+  last_used: 'desc',
 };
 
 function parseSortFromParams(params: URLSearchParams): SortOption {
@@ -39,6 +40,7 @@ function parseFiltersFromParams(params: URLSearchParams): BinFilters {
     hasItems: params.get('has_items') === 'true',
     hasNotes: params.get('has_notes') === 'true',
     needsOrganizing: params.get('needs_organizing') === 'true' || undefined,
+    unusedSince: params.get('unused_since') ?? undefined,
   };
 }
 
@@ -60,6 +62,7 @@ export function buildViewSearchParams(view: SavedView): string {
   if (f.hasItems) params.set('has_items', 'true');
   if (f.hasNotes) params.set('has_notes', 'true');
   if (f.needsOrganizing) params.set('needs_organizing', 'true');
+  if (f.unusedSince) params.set('unused_since', f.unusedSince);
   return params.toString();
 }
 
@@ -139,6 +142,7 @@ export function useBinSearchParams() {
     if (filters.hasItems) params.set('has_items', 'true');
     if (filters.hasNotes) params.set('has_notes', 'true');
     if (filters.needsOrganizing) params.set('needs_organizing', 'true');
+    if (filters.unusedSince) params.set('unused_since', filters.unusedSince);
 
     if (page > 1) params.set('page', String(page));
 

--- a/src/features/bins/useBins.ts
+++ b/src/features/bins/useBins.ts
@@ -28,7 +28,7 @@ export function binMatchesSearch(bin: Bin, regex: RegExp): boolean {
 /** Notify all useBinList / useBin instances to refetch */
 export const notifyBinsChanged = () => notify(Events.BINS);
 
-export type SortOption = 'updated' | 'created' | 'name' | 'area';
+export type SortOption = 'updated' | 'created' | 'name' | 'area' | 'last_used';
 
 export interface BinFilters {
   tags: string[];
@@ -37,6 +37,7 @@ export interface BinFilters {
   hasItems: boolean;
   hasNotes: boolean;
   needsOrganizing?: boolean;
+  unusedSince?: string;  // 'YYYY-MM-DD'
 }
 
 export const EMPTY_FILTERS: BinFilters = {
@@ -49,6 +50,7 @@ export function countActiveFilters(f: BinFilters): number {
   if (f.areas.length) n++;
   if (f.hasItems) n++;
   if (f.hasNotes) n++;
+  if (f.unusedSince) n++;
   return n;
 }
 
@@ -115,6 +117,10 @@ export function useBinList(searchQuery?: string, sort: SortOption = 'updated', f
       });
     } else if (sort === 'created') {
       filtered.sort((a, b) => b.created_at.localeCompare(a.created_at));
+    } else if (sort === 'last_used') {
+      // Bin type doesn't carry last_used; fall back to updated_at order.
+      // Server-side paginated list honors the true last_used order.
+      filtered.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
     } else {
       filtered.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
     }
@@ -134,7 +140,13 @@ function buildFilterParams(
   const p = new URLSearchParams();
   if (searchQuery?.trim()) p.set('q', searchQuery.trim());
 
-  const sortMap: Record<SortOption, string> = { updated: 'updated_at', created: 'created_at', name: 'name', area: 'area' };
+  const sortMap: Record<SortOption, string> = {
+    updated: 'updated_at',
+    created: 'created_at',
+    name: 'name',
+    area: 'area',
+    last_used: 'last_used',
+  };
   p.set('sort', sortMap[sort]);
   p.set('sort_dir', sortDir);
 
@@ -147,6 +159,7 @@ function buildFilterParams(
     if (filters.hasItems) p.set('has_items', 'true');
     if (filters.hasNotes) p.set('has_notes', 'true');
     if (filters.needsOrganizing) p.set('needs_organizing', 'true');
+    if (filters.unusedSince) p.set('unused_since', filters.unusedSince);
   }
 
   const qs = p.toString();

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -20,6 +20,7 @@ import { useBulkSelection } from '@/features/bins/useBulkSelection';
 import { useReopenCreateOnCapture } from '@/features/capture/useAutoOpenOnCapture';
 import { useScanDialog } from '@/features/qrcode/ScanDialogContext';
 import { getCommandInputRef } from '@/features/tour/TourProvider';
+import { LocationActivityWidget } from '@/features/usage/LocationActivityWidget';
 import { useAiEnabled } from '@/lib/aiToggle';
 import { useAuth } from '@/lib/auth';
 import { useDashboardSettings } from '@/lib/dashboardSettings';
@@ -311,6 +312,11 @@ export function DashboardPage() {
           </section>
         )}
 
+        {/* Activity heatmap */}
+        {dashSettings.showActivity && activeLocationId && (
+          <LocationActivityWidget locationId={activeLocationId} />
+        )}
+
         {/* First-run onboarding (0 bins) */}
         {totalBins === 0 && (
           <div className="flex flex-col items-center justify-center gap-6 py-16">
@@ -365,6 +371,7 @@ export function DashboardPage() {
                 { key: 'showPinnedBins' as const, label: `Pinned ${t.Bins}` },
                 { key: 'showRecentlyScanned' as const, label: 'Recently Scanned' },
                 { key: 'showRecentlyUpdated' as const, label: 'Recently Updated' },
+                { key: 'showActivity' as const, label: 'Activity' },
               ]).map(({ key, label }) => (
                 <div key={key} className="flex items-center justify-between py-2 px-3 rounded-[var(--radius-md)]">
                   <span className="text-[14px] text-[var(--text-primary)]">{label}</span>

--- a/src/features/dashboard/DashboardSettingsMenu.tsx
+++ b/src/features/dashboard/DashboardSettingsMenu.tsx
@@ -21,6 +21,7 @@ const SECTION_TOGGLES: Array<{ key: keyof DashboardSettings & `show${string}`; l
   { key: 'showPinnedBins', label: 'Pinned' },
   { key: 'showRecentlyScanned', label: 'Recently Scanned' },
   { key: 'showRecentlyUpdated', label: 'Recently Updated' },
+  { key: 'showActivity', label: 'Activity' },
 ];
 
 export function DashboardSettingsMenu({ settings, onUpdate, terminology }: DashboardSettingsMenuProps) {

--- a/src/features/qrcode/ScanDialog.tsx
+++ b/src/features/qrcode/ScanDialog.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { BinCreateDialog } from '@/features/bins/BinCreateDialog';
 import { lookupBinByCode } from '@/features/bins/useBins';
 import { recordScan } from '@/features/dashboard/scanHistory';
+import { recordBinUsage } from '@/features/usage/recordBinUsage';
 import { ApiError, apiFetch } from '@/lib/api';
 import { BIN_URL_REGEX } from '@/lib/qr';
 import { useTerminology } from '@/lib/terminology';
@@ -54,6 +55,7 @@ export function ScanDialog({ open, onOpenChange }: ScanDialogProps) {
       const bin = await lookupBinByCode(code);
       haptic();
       recordScan(bin.id);
+      recordBinUsage(bin.id, 'manual');
       onOpenChange(false);
       navigate(`/bin/${bin.id}`);
     } catch {
@@ -73,6 +75,7 @@ export function ScanDialog({ open, onOpenChange }: ScanDialogProps) {
         try {
           await apiFetch(`/api/bins/${binId}`);
           recordScan(binId);
+          recordBinUsage(binId, 'scan');
           onOpenChange(false);
           navigate(`/bin/${binId}`);
         } catch (err: unknown) {

--- a/src/features/settings/sections/PreferencesSection.tsx
+++ b/src/features/settings/sections/PreferencesSection.tsx
@@ -200,6 +200,65 @@ export function PreferencesSection() {
           </FormField>
         </div>
       </SettingsSection>
+
+      <SettingsSection label="Usage Tracking">
+        <SettingsRow
+          label="Scan QR code"
+          description="Record a usage dot when you scan a QR code"
+          control={
+            <Switch
+              checked={preferences.usage_tracking_scan}
+              onCheckedChange={(checked) => updatePreferences({ usage_tracking_scan: checked })}
+            />
+          }
+        />
+        <SettingsRow
+          label="Manual code lookup"
+          description={`Record when you look up a ${t.bin} by typing its code`}
+          control={
+            <Switch
+              checked={preferences.usage_tracking_manual_lookup}
+              onCheckedChange={(checked) => updatePreferences({ usage_tracking_manual_lookup: checked })}
+            />
+          }
+        />
+        <SettingsRow
+          label={`View ${t.bin}`}
+          description={`Record every time you open a ${t.bin} detail page`}
+          control={
+            <Switch
+              checked={preferences.usage_tracking_view}
+              onCheckedChange={(checked) => updatePreferences({ usage_tracking_view: checked })}
+            />
+          }
+        />
+        <SettingsRow
+          label={`Modify ${t.bin}`}
+          description={`Record when you edit a ${t.bin}'s contents or metadata`}
+          control={
+            <Switch
+              checked={preferences.usage_tracking_modify}
+              onCheckedChange={(checked) => updatePreferences({ usage_tracking_modify: checked })}
+            />
+          }
+        />
+        <SettingsRow
+          label="Default granularity"
+          description="Heatmap display: day / week / month"
+          control={
+            <OptionGroup
+              options={[
+                { key: 'daily' as const, label: 'Day' },
+                { key: 'weekly' as const, label: 'Week' },
+                { key: 'monthly' as const, label: 'Month' },
+              ]}
+              value={preferences.usage_granularity}
+              onChange={(v) => updatePreferences({ usage_granularity: v })}
+              size="sm"
+            />
+          }
+        />
+      </SettingsSection>
     </>
   );
 }

--- a/src/features/usage/BinUsageSection.tsx
+++ b/src/features/usage/BinUsageSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Disclosure } from '@/components/ui/disclosure';
 import { useUserPreferences } from '@/lib/userPreferences';
@@ -42,7 +43,7 @@ export function BinUsageSection({ binId }: BinUsageSectionProps) {
             ) : usage.length === 0 ? (
               <div className="text-[13px] text-[var(--text-tertiary)]">
                 No activity recorded yet. Update triggers in{' '}
-                <a href="/settings/preferences" className="underline text-[var(--accent)]">preferences</a>.
+                <Link to="/settings/preferences" className="underline text-[var(--accent)]">preferences</Link>.
               </div>
             ) : (
               <>

--- a/src/features/usage/BinUsageSection.tsx
+++ b/src/features/usage/BinUsageSection.tsx
@@ -1,0 +1,74 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Disclosure } from '@/components/ui/disclosure';
+import { useUserPreferences } from '@/lib/userPreferences';
+import { cn, disclosureSectionLabel } from '@/lib/utils';
+import { GranularitySegmented } from './GranularitySegmented';
+import { UsageHeatmap } from './UsageHeatmap';
+import { availableYears, yearOf } from './usageBuckets';
+import { useBinUsage } from './useBinUsage';
+import { YearChipPager } from './YearChipPager';
+
+function formatDaysAgo(iso: string): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+  const days = Math.floor((Date.now() - then) / 86_400_000);
+  if (days === 0) return 'today';
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}
+
+interface BinUsageSectionProps {
+  binId: string;
+}
+
+export function BinUsageSection({ binId }: BinUsageSectionProps) {
+  const { usage, isLoading } = useBinUsage(binId);
+  const { preferences } = useUserPreferences();
+  const years = useMemo(() => availableYears(usage), [usage]);
+  const [year, setYear] = useState<number | null>(null);
+  const selectedYear = year ?? years[0] ?? new Date().getUTCFullYear();
+
+  const activeInYear = usage.filter((d) => yearOf(d.date) === selectedYear).length;
+  const lastUse = usage[0]?.date;
+
+  return (
+    <Card>
+      <CardContent className="!py-0">
+        <Disclosure label="Usage" labelClassName={disclosureSectionLabel}>
+          <div className="pb-3 flex flex-col gap-3">
+            {isLoading ? (
+              <div className="text-[13px] text-[var(--text-tertiary)]">Loading…</div>
+            ) : usage.length === 0 ? (
+              <div className="text-[13px] text-[var(--text-tertiary)]">
+                No activity recorded yet. Update triggers in{' '}
+                <a href="/settings/preferences" className="underline text-[var(--accent)]">preferences</a>.
+              </div>
+            ) : (
+              <>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <GranularitySegmented />
+                  <YearChipPager
+                    years={years}
+                    selected={selectedYear}
+                    onSelect={setYear}
+                  />
+                </div>
+                <UsageHeatmap
+                  data={usage}
+                  year={selectedYear}
+                  granularity={preferences.usage_granularity}
+                  mode="per-bin"
+                />
+                <p className={cn(disclosureSectionLabel, 'text-[11px] text-[var(--text-tertiary)]')}>
+                  {activeInYear} active day{activeInYear === 1 ? '' : 's'} in {selectedYear}
+                  {lastUse ? ` · last use ${formatDaysAgo(lastUse)}` : ''}
+                </p>
+              </>
+            )}
+          </div>
+        </Disclosure>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/usage/BinUsageSection.tsx
+++ b/src/features/usage/BinUsageSection.tsx
@@ -3,20 +3,34 @@ import { Link } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Disclosure } from '@/components/ui/disclosure';
 import { useUserPreferences } from '@/lib/userPreferences';
-import { cn, disclosureSectionLabel } from '@/lib/utils';
+import { disclosureSectionLabel, plural } from '@/lib/utils';
 import { GranularitySegmented } from './GranularitySegmented';
-import { UsageHeatmap } from './UsageHeatmap';
+import { InlineRetryError, UsageHeatmap, UsageHeatmapSkeleton } from './UsageHeatmap';
 import { availableYears, yearOf } from './usageBuckets';
 import { useBinUsage } from './useBinUsage';
 import { YearChipPager } from './YearChipPager';
 
-function formatDaysAgo(iso: string): string {
+const RELATIVE_FMT = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+function formatRelativeFromNow(iso: string): string {
   const then = Date.parse(iso);
-  if (Number.isNaN(then)) return '';
-  const days = Math.floor((Date.now() - then) / 86_400_000);
-  if (days === 0) return 'today';
-  if (days === 1) return '1 day ago';
-  return `${days} days ago`;
+  if (!Number.isFinite(then)) return '';
+  const days = Math.round((then - Date.now()) / 86_400_000);
+  if (Math.abs(days) < 1) return RELATIVE_FMT.format(0, 'day');
+  if (Math.abs(days) < 30) return RELATIVE_FMT.format(days, 'day');
+  const months = Math.round(days / 30);
+  if (Math.abs(months) < 12) return RELATIVE_FMT.format(months, 'month');
+  return RELATIVE_FMT.format(Math.round(months / 12), 'year');
+}
+
+/** Server sorts DESC but don't trust it — malformed rows at the head would mask a valid latest date. */
+function findLastValidDate(entries: Array<{ date: string }>): string | null {
+  let latest: string | null = null;
+  for (const e of entries) {
+    if (!Number.isFinite(yearOf(e.date))) continue;
+    if (latest === null || e.date > latest) latest = e.date;
+  }
+  return latest;
 }
 
 interface BinUsageSectionProps {
@@ -24,14 +38,20 @@ interface BinUsageSectionProps {
 }
 
 export function BinUsageSection({ binId }: BinUsageSectionProps) {
-  const { usage, isLoading } = useBinUsage(binId);
+  const { usage, isLoading, error, refresh } = useBinUsage(binId);
   const { preferences } = useUserPreferences();
   const years = useMemo(() => availableYears(usage), [usage]);
   const [year, setYear] = useState<number | null>(null);
-  const selectedYear = year ?? years[0] ?? new Date().getUTCFullYear();
 
-  const activeInYear = usage.filter((d) => yearOf(d.date) === selectedYear).length;
-  const lastUse = usage[0]?.date;
+  const selectedYear =
+    year !== null && years.includes(year) ? year : (years[0] ?? new Date().getUTCFullYear());
+
+  const lastUse = useMemo(() => findLastValidDate(usage), [usage]);
+  const activeInYear = useMemo(() => {
+    let count = 0;
+    for (const d of usage) if (yearOf(d.date) === selectedYear) count++;
+    return count;
+  }, [usage, selectedYear]);
 
   return (
     <Card>
@@ -39,12 +59,19 @@ export function BinUsageSection({ binId }: BinUsageSectionProps) {
         <Disclosure label="Usage" labelClassName={disclosureSectionLabel}>
           <div className="pb-3 flex flex-col gap-3">
             {isLoading ? (
-              <div className="text-[13px] text-[var(--text-tertiary)]">Loading…</div>
+              <UsageHeatmapSkeleton />
+            ) : error ? (
+              <InlineRetryError
+                title="Couldn't load usage data"
+                detail={error}
+                onRetry={refresh}
+                className="py-1"
+              />
             ) : usage.length === 0 ? (
-              <div className="text-[13px] text-[var(--text-tertiary)]">
-                No activity recorded yet. Update triggers in{' '}
+              <p className="text-[12px] text-[var(--text-tertiary)] leading-relaxed py-1">
+                No activity yet. Choose which actions count in{' '}
                 <Link to="/settings/preferences" className="underline text-[var(--accent)]">preferences</Link>.
-              </div>
+              </p>
             ) : (
               <>
                 <div className="flex flex-wrap items-center justify-between gap-2">
@@ -61,9 +88,9 @@ export function BinUsageSection({ binId }: BinUsageSectionProps) {
                   granularity={preferences.usage_granularity}
                   mode="per-bin"
                 />
-                <p className={cn(disclosureSectionLabel, 'text-[11px] text-[var(--text-tertiary)]')}>
-                  {activeInYear} active day{activeInYear === 1 ? '' : 's'} in {selectedYear}
-                  {lastUse ? ` · last use ${formatDaysAgo(lastUse)}` : ''}
+                <p className="text-[11px] text-[var(--text-tertiary)] tabular-nums">
+                  {activeInYear} active {plural(activeInYear, 'day')} in {selectedYear}
+                  {lastUse ? ` · last used ${formatRelativeFromNow(lastUse)}` : ''}
                 </p>
               </>
             )}

--- a/src/features/usage/GranularitySegmented.tsx
+++ b/src/features/usage/GranularitySegmented.tsx
@@ -1,0 +1,37 @@
+import { OptionGroup } from '@/components/ui/option-group';
+import { useUserPreferences } from '@/lib/userPreferences';
+import type { UsageGranularity } from '@/types';
+
+const OPTIONS = [
+  { key: 'daily' as const, label: 'Day' },
+  { key: 'weekly' as const, label: 'Week' },
+  { key: 'monthly' as const, label: 'Month' },
+];
+
+interface GranularitySegmentedProps {
+  /** Optional override — if provided, uses local state; otherwise persists to user prefs. */
+  value?: UsageGranularity;
+  onChange?: (granularity: UsageGranularity) => void;
+}
+
+export function GranularitySegmented({ value, onChange }: GranularitySegmentedProps) {
+  const { preferences, updatePreferences } = useUserPreferences();
+  const current = value ?? preferences.usage_granularity;
+
+  function handleChange(next: UsageGranularity) {
+    if (onChange) {
+      onChange(next);
+    } else {
+      updatePreferences({ usage_granularity: next });
+    }
+  }
+
+  return (
+    <OptionGroup
+      options={OPTIONS}
+      value={current}
+      onChange={handleChange}
+      size="sm"
+    />
+  );
+}

--- a/src/features/usage/LocationActivityWidget.tsx
+++ b/src/features/usage/LocationActivityWidget.tsx
@@ -1,0 +1,67 @@
+import { Activity } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SectionHeader } from '@/features/dashboard/DashboardWidgets';
+import { useUserPreferences } from '@/lib/userPreferences';
+import { cn, disclosureSectionLabel } from '@/lib/utils';
+import { GranularitySegmented } from './GranularitySegmented';
+import { UsageHeatmap } from './UsageHeatmap';
+import { availableYears, yearOf } from './usageBuckets';
+import { useLocationUsage } from './useLocationUsage';
+import { YearChipPager } from './YearChipPager';
+
+interface LocationActivityWidgetProps {
+  locationId: string;
+}
+
+export function LocationActivityWidget({ locationId }: LocationActivityWidgetProps) {
+  const navigate = useNavigate();
+  const { usage, isLoading } = useLocationUsage(locationId);
+  const { preferences } = useUserPreferences();
+  const years = useMemo(() => availableYears(usage), [usage]);
+  const [year, setYear] = useState<number | null>(null);
+  const selectedYear = year ?? years[0] ?? new Date().getUTCFullYear();
+
+  const inYear = usage.filter((d) => yearOf(d.date) === selectedYear);
+  const binDays = inYear.reduce((sum, d) => sum + d.binCount, 0);
+  const activeDays = inYear.length;
+  const hasData = usage.length > 0;
+
+  return (
+    <section aria-labelledby="dash-activity" className="flex flex-col gap-2">
+      <SectionHeader id="dash-activity" icon={Activity} title="Activity" />
+      <div className="rounded-[var(--radius-md)] bg-[var(--bg-flat)] border border-[var(--border-flat)] p-4 flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <GranularitySegmented />
+          <YearChipPager years={years} selected={selectedYear} onSelect={setYear} />
+        </div>
+        {isLoading && !hasData ? (
+          <p className="text-[12px] text-[var(--text-tertiary)] py-2">Loading…</p>
+        ) : !hasData ? (
+          <p className="text-[12px] text-[var(--text-tertiary)] py-2">
+            No activity recorded yet. Bins you scan, view, or modify will appear here.
+          </p>
+        ) : (
+          <>
+            <UsageHeatmap
+              data={usage}
+              year={selectedYear}
+              granularity={preferences.usage_granularity}
+              mode="aggregate"
+            />
+            <p className={cn(disclosureSectionLabel, 'text-[11px]')}>
+              {binDays} bin-day{binDays === 1 ? '' : 's'} · {activeDays} active day{activeDays === 1 ? '' : 's'} in {selectedYear}
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate(`/bins?unused_since=${selectedYear}-01-01`)}
+              className="text-[12px] text-[var(--accent)] self-start hover:underline"
+            >
+              Show bins unused since {selectedYear}-01-01
+            </button>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/features/usage/LocationActivityWidget.tsx
+++ b/src/features/usage/LocationActivityWidget.tsx
@@ -1,11 +1,11 @@
-import { Activity } from 'lucide-react';
+import { Activity, ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SectionHeader } from '@/features/dashboard/DashboardWidgets';
 import { useUserPreferences } from '@/lib/userPreferences';
-import { cn, disclosureSectionLabel } from '@/lib/utils';
+import { cn, flatCard, plural } from '@/lib/utils';
 import { GranularitySegmented } from './GranularitySegmented';
-import { UsageHeatmap } from './UsageHeatmap';
+import { InlineRetryError, UsageHeatmap, UsageHeatmapSkeleton } from './UsageHeatmap';
 import { availableYears, yearOf } from './usageBuckets';
 import { useLocationUsage } from './useLocationUsage';
 import { YearChipPager } from './YearChipPager';
@@ -16,29 +16,47 @@ interface LocationActivityWidgetProps {
 
 export function LocationActivityWidget({ locationId }: LocationActivityWidgetProps) {
   const navigate = useNavigate();
-  const { usage, isLoading } = useLocationUsage(locationId);
+  const { usage, isLoading, error, refresh } = useLocationUsage(locationId);
   const { preferences } = useUserPreferences();
   const years = useMemo(() => availableYears(usage), [usage]);
   const [year, setYear] = useState<number | null>(null);
-  const selectedYear = year ?? years[0] ?? new Date().getUTCFullYear();
 
-  const inYear = usage.filter((d) => yearOf(d.date) === selectedYear);
-  const binDays = inYear.reduce((sum, d) => sum + d.binCount, 0);
-  const activeDays = inYear.length;
+  const selectedYear =
+    year !== null && years.includes(year) ? year : (years[0] ?? new Date().getUTCFullYear());
+
+  const { binDays, activeDays } = useMemo(() => {
+    let bd = 0;
+    let ad = 0;
+    for (const d of usage) {
+      if (yearOf(d.date) !== selectedYear) continue;
+      const n = typeof d.binCount === 'number' && Number.isFinite(d.binCount) ? Math.max(0, d.binCount) : 0;
+      bd += n;
+      ad += 1;
+    }
+    return { binDays: bd, activeDays: ad };
+  }, [usage, selectedYear]);
+
   const hasData = usage.length > 0;
 
   return (
     <section aria-labelledby="dash-activity" className="flex flex-col gap-2">
       <SectionHeader id="dash-activity" icon={Activity} title="Activity" />
-      <div className="rounded-[var(--radius-md)] bg-[var(--bg-flat)] border border-[var(--border-flat)] p-4 flex flex-col gap-3">
+      <div className={cn(flatCard, 'p-4 flex flex-col gap-3')}>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <GranularitySegmented />
           <YearChipPager years={years} selected={selectedYear} onSelect={setYear} />
         </div>
         {isLoading && !hasData ? (
-          <p className="text-[12px] text-[var(--text-tertiary)] py-2">Loading…</p>
+          <UsageHeatmapSkeleton />
+        ) : error && !hasData ? (
+          <InlineRetryError
+            title="Couldn't load activity"
+            detail={error}
+            onRetry={refresh}
+            className="py-2"
+          />
         ) : !hasData ? (
-          <p className="text-[12px] text-[var(--text-tertiary)] py-2">
+          <p className="text-[12px] text-[var(--text-tertiary)] leading-relaxed py-2">
             No activity recorded yet. Bins you scan, view, or modify will appear here.
           </p>
         ) : (
@@ -49,16 +67,19 @@ export function LocationActivityWidget({ locationId }: LocationActivityWidgetPro
               granularity={preferences.usage_granularity}
               mode="aggregate"
             />
-            <p className={cn(disclosureSectionLabel, 'text-[11px]')}>
-              {binDays} bin-day{binDays === 1 ? '' : 's'} · {activeDays} active day{activeDays === 1 ? '' : 's'} in {selectedYear}
-            </p>
-            <button
-              type="button"
-              onClick={() => navigate(`/bins?unused_since=${selectedYear}-01-01`)}
-              className="text-[12px] text-[var(--accent)] self-start hover:underline"
-            >
-              Show bins unused since {selectedYear}-01-01
-            </button>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-[11px] text-[var(--text-tertiary)] tabular-nums">
+                {binDays} bin-{plural(binDays, 'day')} · {activeDays} active {plural(activeDays, 'day')} in {selectedYear}
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate(`/bins?unused_since=${selectedYear}-01-01`)}
+                className="inline-flex items-center gap-0.5 -mx-2 -my-1 px-2 py-1 text-[12px] font-medium text-[var(--accent)] hover:text-[var(--accent-hover)] transition-colors rounded-[var(--radius-xs)]"
+              >
+                View inactive bins
+                <ChevronRight className="h-3.5 w-3.5" />
+              </button>
+            </div>
           </>
         )}
       </div>

--- a/src/features/usage/UsageHeatmap.tsx
+++ b/src/features/usage/UsageHeatmap.tsx
@@ -13,7 +13,7 @@ interface UsageHeatmapProps {
   onDayClick?: (date: string) => void;
 }
 
-const OPACITY_BY_STEP = [0, 0.22, 0.48, 0.72, 1];
+const OPACITY_BY_STEP = [0, 0.22, 0.48, 0.72];
 
 function asCount(entry: AnyUsageDay, mode: 'per-bin' | 'aggregate'): number {
   if (mode === 'aggregate') return (entry as LocationUsageDay).binCount;

--- a/src/features/usage/UsageHeatmap.tsx
+++ b/src/features/usage/UsageHeatmap.tsx
@@ -1,0 +1,177 @@
+import { useMemo } from 'react';
+import { Tooltip } from '@/components/ui/tooltip';
+import type { LocationUsageDay, UsageDay, UsageGranularity } from '@/types';
+import { bucketByMonth, bucketByWeek, intensityStep, yearOf } from './usageBuckets';
+
+type AnyUsageDay = UsageDay | LocationUsageDay;
+
+interface UsageHeatmapProps {
+  data: AnyUsageDay[];
+  year: number;
+  granularity: UsageGranularity;
+  mode: 'per-bin' | 'aggregate';
+  onDayClick?: (date: string) => void;
+}
+
+const OPACITY_BY_STEP = [0, 0.22, 0.48, 0.72, 1];
+
+function asCount(entry: AnyUsageDay, mode: 'per-bin' | 'aggregate'): number {
+  if (mode === 'aggregate') return (entry as LocationUsageDay).binCount;
+  return (entry as UsageDay).count;
+}
+
+function formatDate(isoDate: string): string {
+  const [y, m, d] = isoDate.split('-');
+  return `${m}/${d}/${y}`;
+}
+
+function cellStyle(intensity: 0 | 1 | 2 | 3): React.CSSProperties {
+  const opacity = OPACITY_BY_STEP[intensity];
+  return {
+    backgroundColor:
+      intensity === 0
+        ? 'var(--border-subtle)'
+        : `color-mix(in srgb, var(--accent) ${Math.round(opacity * 100)}%, transparent)`,
+  };
+}
+
+function StaticCell({ intensity, tooltip }: { intensity: 0 | 1 | 2 | 3; tooltip?: string }) {
+  const body = (
+    <div
+      data-testid="usage-cell"
+      data-intensity={intensity}
+      className="rounded-[var(--radius-xs)] transition-colors w-full h-full"
+      style={cellStyle(intensity)}
+    />
+  );
+  if (tooltip) return <Tooltip content={tooltip}>{body}</Tooltip>;
+  return body;
+}
+
+function ButtonCell({
+  intensity,
+  tooltip,
+  onClick,
+}: {
+  intensity: 0 | 1 | 2 | 3;
+  tooltip: string | undefined;
+  onClick: () => void;
+}) {
+  const body = (
+    <button
+      type="button"
+      aria-label={tooltip}
+      data-testid="usage-cell"
+      data-intensity={intensity}
+      onClick={onClick}
+      className="rounded-[var(--radius-xs)] transition-colors w-full h-full cursor-pointer border-0 p-0"
+      style={cellStyle(intensity)}
+    />
+  );
+  if (tooltip) return <Tooltip content={tooltip}>{body}</Tooltip>;
+  return body;
+}
+
+function Cell({
+  intensity,
+  tooltip,
+  onClick,
+}: {
+  intensity: 0 | 1 | 2 | 3;
+  tooltip?: string;
+  onClick?: () => void;
+}) {
+  if (onClick) return <ButtonCell intensity={intensity} tooltip={tooltip} onClick={onClick} />;
+  return <StaticCell intensity={intensity} tooltip={tooltip} />;
+}
+
+export function UsageHeatmap({ data, year, granularity, mode, onDayClick }: UsageHeatmapProps) {
+  const normalized = useMemo(
+    () => data.map((d) => ({ date: d.date, count: asCount(d, mode) })),
+    [data, mode],
+  );
+
+  if (granularity === 'monthly') {
+    const buckets = bucketByMonth(normalized, year);
+    return (
+      <div className="grid grid-cols-12 gap-1 w-full">
+        {buckets.map((bucket) => {
+          const step = intensityStep(bucket.activeDays, 'monthly');
+          return (
+            <div key={bucket.index} className="aspect-square">
+              <Cell
+                intensity={step}
+                tooltip={`${bucket.label} ${year}: ${bucket.activeDays} active day${bucket.activeDays === 1 ? '' : 's'}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (granularity === 'weekly') {
+    const buckets = bucketByWeek(normalized, year);
+    return (
+      <div
+        className="grid gap-1 w-full"
+        style={{
+          gridTemplateColumns: `repeat(${Math.ceil(buckets.length / 7)}, minmax(0, 1fr))`,
+          gridAutoFlow: 'column',
+          gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
+        }}
+      >
+        {buckets.map((bucket) => {
+          const step = intensityStep(bucket.activeDays, 'weekly');
+          return (
+            <div key={bucket.index} className="aspect-square">
+              <Cell
+                intensity={step}
+                tooltip={`${bucket.label}: ${bucket.activeDays} active day${bucket.activeDays === 1 ? '' : 's'}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Daily: column-major 7-row grid (GitHub style)
+  const yearStart = Date.UTC(year, 0, 1);
+  const yearEnd = Date.UTC(year, 11, 31);
+  const totalDays = Math.round((yearEnd - yearStart) / 86_400_000) + 1;
+
+  const byDate = new Map<string, number>();
+  for (const n of normalized) if (yearOf(n.date) === year) byDate.set(n.date, n.count);
+
+  const cells: { date: string; count: number }[] = [];
+  for (let i = 0; i < totalDays; i++) {
+    const t = new Date(yearStart + i * 86_400_000);
+    const iso = `${t.getUTCFullYear()}-${String(t.getUTCMonth() + 1).padStart(2, '0')}-${String(t.getUTCDate()).padStart(2, '0')}`;
+    cells.push({ date: iso, count: byDate.get(iso) ?? 0 });
+  }
+
+  return (
+    <div
+      className="grid gap-[3px] w-full"
+      style={{
+        gridTemplateColumns: `repeat(${Math.ceil(totalDays / 7)}, 1fr)`,
+        gridAutoFlow: 'column',
+        gridTemplateRows: 'repeat(7, 1fr)',
+      }}
+    >
+      {cells.map((cell) => {
+        const step = intensityStep(cell.count, 'daily');
+        return (
+          <div key={cell.date} className="aspect-square min-w-[8px]">
+            <Cell
+              intensity={step}
+              tooltip={`${formatDate(cell.date)}: ${cell.count} hit${cell.count === 1 ? '' : 's'}`}
+              onClick={onDayClick ? () => onDayClick(cell.date) : undefined}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/usage/UsageHeatmap.tsx
+++ b/src/features/usage/UsageHeatmap.tsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 import { Tooltip } from '@/components/ui/tooltip';
+import { cn, haptic, plural } from '@/lib/utils';
 import type { LocationUsageDay, UsageDay, UsageGranularity } from '@/types';
-import { bucketByMonth, bucketByWeek, intensityStep, yearOf } from './usageBuckets';
+import { bucketByMonth, bucketByWeek, intensityStep, parseIsoDate, yearOf } from './usageBuckets';
 
 type AnyUsageDay = UsageDay | LocationUsageDay;
+type Intensity = 0 | 1 | 2 | 3;
 
 interface UsageHeatmapProps {
   data: AnyUsageDay[];
@@ -13,76 +15,468 @@ interface UsageHeatmapProps {
   onDayClick?: (date: string) => void;
 }
 
-const OPACITY_BY_STEP = [0, 0.22, 0.48, 0.72];
+const CELL_SIZE = 11;
+const CELL_GAP = 3;
+const CELL_STEP = CELL_SIZE + CELL_GAP;
+const OPACITY_BY_STEP = [0, 0.22, 0.48, 0.82];
+// Full weekday list is kept for a11y; display filters to Mon/Wed/Fri to reduce clutter.
+const VISIBLE_DOW = new Set([1, 3, 5]);
+
+const CELL_TRANSITION =
+  'transition-[background-color,outline-color] duration-150 ease-out motion-reduce:transition-none';
+
+function todayUtcIso(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+}
 
 function asCount(entry: AnyUsageDay, mode: 'per-bin' | 'aggregate'): number {
-  if (mode === 'aggregate') return (entry as LocationUsageDay).binCount;
-  return (entry as UsageDay).count;
+  const raw = mode === 'aggregate' ? (entry as LocationUsageDay).binCount : (entry as UsageDay).count;
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0) return 0;
+  return raw;
 }
 
-function formatDate(isoDate: string): string {
-  const [y, m, d] = isoDate.split('-');
-  return `${m}/${d}/${y}`;
+const DATE_FMT = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const MONTH_SHORT_FMT = new Intl.DateTimeFormat(undefined, { month: 'short' });
+const WEEKDAY_SHORT_FMT = new Intl.DateTimeFormat(undefined, { weekday: 'short' });
+
+const MONTH_LABELS: string[] = Array.from({ length: 12 }, (_, i) =>
+  MONTH_SHORT_FMT.format(new Date(Date.UTC(2024, i, 1))),
+);
+
+// 2024-01-07 is a Sunday in UTC; used to anchor the 7 weekday labels.
+const DOW_LABELS: string[] = Array.from({ length: 7 }, (_, i) =>
+  WEEKDAY_SHORT_FMT.format(new Date(Date.UTC(2024, 0, 7 + i))),
+);
+
+function formatPrettyDate(isoDate: string): string {
+  const parsed = parseIsoDate(isoDate);
+  if (!parsed) return isoDate;
+  return DATE_FMT.format(new Date(Date.UTC(parsed.y, parsed.m - 1, parsed.d)));
 }
 
-function cellStyle(intensity: 0 | 1 | 2 | 3): React.CSSProperties {
-  const opacity = OPACITY_BY_STEP[intensity];
-  return {
-    backgroundColor:
-      intensity === 0
-        ? 'var(--border-subtle)'
-        : `color-mix(in srgb, var(--accent) ${Math.round(opacity * 100)}%, transparent)`,
-  };
+function cellColor(intensity: Intensity): string {
+  if (intensity === 0) return 'var(--border-subtle)';
+  const pct = Math.round(OPACITY_BY_STEP[intensity] * 100);
+  return `color-mix(in srgb, var(--accent) ${pct}%, transparent)`;
 }
 
-function StaticCell({ intensity, tooltip }: { intensity: 0 | 1 | 2 | 3; tooltip?: string }) {
-  const body = (
-    <div
-      data-testid="usage-cell"
-      data-intensity={intensity}
-      className="rounded-[var(--radius-xs)] transition-colors w-full h-full"
-      style={cellStyle(intensity)}
-    />
+function cellBoxStyle(intensity: Intensity, fill?: boolean): React.CSSProperties {
+  const base: React.CSSProperties = { backgroundColor: cellColor(intensity) };
+  if (!fill) {
+    base.width = CELL_SIZE;
+    base.height = CELL_SIZE;
+  }
+  return base;
+}
+
+function cellClassName(interactive: boolean, fill?: boolean, highlight?: boolean): string {
+  return cn(
+    'rounded-[2px]',
+    CELL_TRANSITION,
+    interactive && [
+      'cursor-pointer border-0 p-0',
+      'hover:outline hover:outline-1 hover:outline-[var(--accent)]',
+      'focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-1',
+    ],
+    fill && 'w-full aspect-square',
+    highlight && 'outline outline-1 outline-[var(--accent)] outline-offset-1',
   );
-  if (tooltip) return <Tooltip content={tooltip}>{body}</Tooltip>;
-  return body;
-}
-
-function ButtonCell({
-  intensity,
-  tooltip,
-  onClick,
-}: {
-  intensity: 0 | 1 | 2 | 3;
-  tooltip: string | undefined;
-  onClick: () => void;
-}) {
-  const body = (
-    <button
-      type="button"
-      aria-label={tooltip}
-      data-testid="usage-cell"
-      data-intensity={intensity}
-      onClick={onClick}
-      className="rounded-[var(--radius-xs)] transition-colors w-full h-full cursor-pointer border-0 p-0"
-      style={cellStyle(intensity)}
-    />
-  );
-  if (tooltip) return <Tooltip content={tooltip}>{body}</Tooltip>;
-  return body;
 }
 
 function Cell({
   intensity,
   tooltip,
   onClick,
+  fill,
+  highlight,
 }: {
-  intensity: 0 | 1 | 2 | 3;
+  intensity: Intensity;
   tooltip?: string;
   onClick?: () => void;
+  fill?: boolean;
+  highlight?: boolean;
 }) {
-  if (onClick) return <ButtonCell intensity={intensity} tooltip={tooltip} onClick={onClick} />;
-  return <StaticCell intensity={intensity} tooltip={tooltip} />;
+  const todayAttr = highlight ? 'true' : undefined;
+  const style = cellBoxStyle(intensity, fill);
+  const body = onClick ? (
+    <button
+      type="button"
+      aria-label={tooltip}
+      data-testid="usage-cell"
+      data-intensity={intensity}
+      data-today={todayAttr}
+      onClick={() => {
+        haptic(8);
+        onClick();
+      }}
+      className={cellClassName(true, fill, highlight)}
+      style={style}
+    />
+  ) : (
+    <div
+      data-testid="usage-cell"
+      data-intensity={intensity}
+      data-today={todayAttr}
+      className={cellClassName(false, fill, highlight)}
+      style={style}
+    />
+  );
+  if (!tooltip) return body;
+  return (
+    <Tooltip content={tooltip} className={fill ? 'w-full' : undefined}>
+      {body}
+    </Tooltip>
+  );
+}
+
+function MonthLabelTrack({
+  positions,
+  width,
+}: {
+  positions: Array<{ month: string; col: number }>;
+  width: number;
+}) {
+  return (
+    <div className="relative h-3" style={{ width }}>
+      {positions.map((m) => (
+        <span
+          key={`${m.month}-${m.col}`}
+          style={{ left: m.col * CELL_STEP }}
+          className="absolute top-0 text-[11px] text-[var(--text-tertiary)] leading-none"
+        >
+          {m.month}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface DailyCell {
+  key: string;
+  date: string | null;
+  count: number;
+}
+
+interface DailyGrid {
+  cells: DailyCell[];
+  weeks: number;
+  monthPositions: Array<{ month: string; col: number }>;
+  activeDays: number;
+}
+
+function buildDailyGrid(
+  data: Array<{ date: string; count: number }>,
+  year: number,
+): DailyGrid {
+  if (!Number.isFinite(year)) return { cells: [], weeks: 0, monthPositions: [], activeDays: 0 };
+
+  const yearStart = Date.UTC(year, 0, 1);
+  const yearEnd = Date.UTC(year, 11, 31);
+  const totalDays = Math.round((yearEnd - yearStart) / 86_400_000) + 1;
+  const firstDow = new Date(yearStart).getUTCDay();
+
+  const byDate = new Map<string, number>();
+  for (const d of data) {
+    if (yearOf(d.date) !== year) continue;
+    const n = typeof d.count === 'number' && Number.isFinite(d.count) ? Math.max(0, d.count) : 0;
+    // Sum duplicates defensively — server shouldn't emit them, but collapse if it does.
+    byDate.set(d.date, (byDate.get(d.date) ?? 0) + n);
+  }
+  let activeDays = 0;
+  for (const v of byDate.values()) if (v > 0) activeDays++;
+
+  const cells: DailyCell[] = [];
+  for (let i = 0; i < firstDow; i++) {
+    cells.push({ key: `pad-lead-${year}-${i}`, date: null, count: 0 });
+  }
+  for (let i = 0; i < totalDays; i++) {
+    const t = new Date(yearStart + i * 86_400_000);
+    const iso = `${t.getUTCFullYear()}-${String(t.getUTCMonth() + 1).padStart(2, '0')}-${String(t.getUTCDate()).padStart(2, '0')}`;
+    cells.push({ key: iso, date: iso, count: byDate.get(iso) ?? 0 });
+  }
+  const weeks = Math.ceil(cells.length / 7);
+  let tailIdx = 0;
+  while (cells.length < weeks * 7) {
+    cells.push({ key: `pad-tail-${year}-${tailIdx++}`, date: null, count: 0 });
+  }
+
+  const monthPositions: Array<{ month: string; col: number }> = [];
+  let lastMonth = -1;
+  cells.forEach((cell, idx) => {
+    if (!cell.date) return;
+    const parsed = parseIsoDate(cell.date);
+    if (!parsed) return;
+    const monthIdx = parsed.m - 1;
+    if (monthIdx !== lastMonth) {
+      monthPositions.push({ month: MONTH_LABELS[monthIdx], col: Math.floor(idx / 7) });
+      lastMonth = monthIdx;
+    }
+  });
+
+  return { cells, weeks, monthPositions, activeDays };
+}
+
+function buildWeeklyMonthPositions(
+  year: number,
+  weekCount: number,
+): Array<{ month: string; col: number }> {
+  if (!Number.isFinite(year)) return [];
+  const yearStart = Date.UTC(year, 0, 1);
+  const positions: Array<{ month: string; col: number }> = [];
+  let lastMonth = -1;
+  for (let w = 0; w < weekCount; w++) {
+    const weekStart = new Date(yearStart + w * 7 * 86_400_000);
+    if (weekStart.getUTCFullYear() !== year) continue;
+    const month = weekStart.getUTCMonth();
+    if (month !== lastMonth) {
+      positions.push({ month: MONTH_LABELS[month], col: w });
+      lastMonth = month;
+    }
+  }
+  return positions;
+}
+
+function DailyView({
+  data,
+  year,
+  onDayClick,
+}: {
+  data: Array<{ date: string; count: number }>;
+  year: number;
+  onDayClick?: (date: string) => void;
+}) {
+  const { cells, weeks, monthPositions, activeDays } = useMemo(
+    () => buildDailyGrid(data, year),
+    [data, year],
+  );
+  const gridWidth = weeks * CELL_SIZE + (weeks - 1) * CELL_GAP;
+  const todayIso = todayUtcIso();
+
+  return (
+    <div
+      key={year}
+      className="flex flex-col gap-2 animate-fade-in motion-reduce:animate-none"
+      role="img"
+      aria-label={`Daily usage heatmap for ${year}. ${activeDays} active ${plural(activeDays, 'day')}.`}
+    >
+      <div className="overflow-x-auto scrollbar-thin -mx-1 px-1 pb-0.5" style={{ overscrollBehaviorX: 'contain' }}>
+        <div className="inline-flex gap-2 items-start">
+          <div
+            className="flex flex-col shrink-0"
+            style={{ rowGap: CELL_GAP, paddingTop: 16 }}
+            aria-hidden
+          >
+            {DOW_LABELS.map((label, i) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: fixed 7-slot week, locales may repeat short labels
+                key={i}
+                style={{ height: CELL_SIZE, lineHeight: `${CELL_SIZE}px` }}
+                className="text-[11px] text-[var(--text-tertiary)] pr-1 text-right"
+              >
+                {VISIBLE_DOW.has(i) ? label : '\u00A0'}
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <MonthLabelTrack positions={monthPositions} width={gridWidth} />
+            <div
+              className="grid"
+              style={{
+                gridTemplateColumns: `repeat(${weeks}, ${CELL_SIZE}px)`,
+                gridTemplateRows: `repeat(7, ${CELL_SIZE}px)`,
+                gridAutoFlow: 'column',
+                gap: CELL_GAP,
+              }}
+            >
+              {cells.map((cell) => {
+                if (!cell.date) return <div key={cell.key} aria-hidden />;
+                const intensity = intensityStep(cell.count, 'daily');
+                const date = cell.date;
+                const isToday = date === todayIso;
+                const tooltipBase = `${formatPrettyDate(date)} — ${cell.count} ${plural(cell.count, 'hit')}`;
+                return (
+                  <Cell
+                    key={cell.key}
+                    intensity={intensity}
+                    highlight={isToday}
+                    tooltip={isToday ? `${tooltipBase} (today)` : tooltipBase}
+                    onClick={onDayClick ? () => onDayClick(date) : undefined}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WeeklyView({
+  data,
+  year,
+}: {
+  data: Array<{ date: string; count: number }>;
+  year: number;
+}) {
+  const buckets = useMemo(() => bucketByWeek(data, year), [data, year]);
+  const monthPositions = useMemo(
+    () => buildWeeklyMonthPositions(year, buckets.length),
+    [year, buckets.length],
+  );
+  const gridWidth = buckets.length * CELL_SIZE + (buckets.length - 1) * CELL_GAP;
+  const activeWeeks = useMemo(
+    () => buckets.reduce((s, b) => s + (b.activeDays > 0 ? 1 : 0), 0),
+    [buckets],
+  );
+
+  return (
+    <div
+      key={year}
+      className="flex flex-col gap-2 animate-fade-in motion-reduce:animate-none"
+      role="img"
+      aria-label={`Weekly usage heatmap for ${year}. ${activeWeeks} active ${plural(activeWeeks, 'week')}.`}
+    >
+      <div className="overflow-x-auto scrollbar-thin -mx-1 px-1 pb-0.5" style={{ overscrollBehaviorX: 'contain' }}>
+        <div className="inline-flex flex-col gap-1">
+          <MonthLabelTrack positions={monthPositions} width={gridWidth} />
+          <div
+            className="grid"
+            style={{
+              gridTemplateColumns: `repeat(${buckets.length}, ${CELL_SIZE}px)`,
+              gridAutoRows: `${CELL_SIZE}px`,
+              gap: CELL_GAP,
+            }}
+          >
+            {buckets.map((bucket) => {
+              const intensity = intensityStep(bucket.activeDays, 'weekly');
+              return (
+                <Cell
+                  key={bucket.index}
+                  intensity={intensity}
+                  tooltip={`Week ${bucket.index + 1}, ${year} — ${bucket.activeDays} active ${plural(bucket.activeDays, 'day')}`}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MonthlyView({
+  data,
+  year,
+}: {
+  data: Array<{ date: string; count: number }>;
+  year: number;
+}) {
+  const buckets = useMemo(() => bucketByMonth(data, year), [data, year]);
+  const activeMonths = useMemo(
+    () => buckets.reduce((s, b) => s + (b.activeDays > 0 ? 1 : 0), 0),
+    [buckets],
+  );
+
+  return (
+    <div
+      key={year}
+      className="flex flex-col gap-2 animate-fade-in motion-reduce:animate-none"
+      role="img"
+      aria-label={`Monthly usage heatmap for ${year}. ${activeMonths} active ${plural(activeMonths, 'month')}.`}
+    >
+      <div className="grid grid-cols-12 gap-[6px]">
+        {buckets.map((bucket) => {
+          const intensity = intensityStep(bucket.activeDays, 'monthly');
+          const label = MONTH_LABELS[bucket.index] ?? bucket.label;
+          return (
+            <div key={bucket.index} className="flex flex-col items-center gap-1 min-w-0">
+              <Cell
+                intensity={intensity}
+                fill
+                tooltip={`${label} ${year} — ${bucket.activeDays} active ${plural(bucket.activeDays, 'day')}`}
+              />
+              <span className="text-[11px] text-[var(--text-tertiary)] leading-none">
+                {label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Loading skeleton that mirrors the heatmap footprint to avoid layout shift. */
+export function UsageHeatmapSkeleton() {
+  const weeks = 53;
+  const gridWidth = weeks * CELL_SIZE + (weeks - 1) * CELL_GAP;
+  return (
+    <div className="flex flex-col gap-2" aria-hidden aria-busy="true">
+      <div className="overflow-x-hidden -mx-1 px-1 pb-0.5">
+        <div className="inline-flex gap-2 items-start">
+          <div style={{ width: 24, paddingTop: 16 }} />
+          <div className="flex flex-col gap-1">
+            <div className="h-3" style={{ width: gridWidth }} />
+            <div
+              className="grid"
+              style={{
+                gridTemplateColumns: `repeat(${weeks}, ${CELL_SIZE}px)`,
+                gridTemplateRows: `repeat(7, ${CELL_SIZE}px)`,
+                gridAutoFlow: 'column',
+                gap: CELL_GAP,
+              }}
+            >
+              {Array.from({ length: weeks * 7 }).map((_, i) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton, never reordered
+                  key={i}
+                  className="rounded-[2px] animate-pulse motion-reduce:animate-none"
+                  style={{ backgroundColor: 'var(--border-subtle)', width: CELL_SIZE, height: CELL_SIZE }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Error state with a retry affordance — shared by bin and location usage views. */
+export function InlineRetryError({
+  title,
+  detail,
+  onRetry,
+  className,
+}: {
+  title: string;
+  detail?: string | null;
+  onRetry: () => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)} role="alert">
+      <p className="text-[13px] font-medium text-[var(--text-primary)] leading-snug">{title}</p>
+      {detail ? (
+        <p className="text-[12px] text-[var(--text-tertiary)] leading-relaxed">{detail}</p>
+      ) : null}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="self-start -mx-2 -my-1 px-2 py-1 text-[13px] font-medium text-[var(--accent)] hover:text-[var(--accent-hover)] rounded-[var(--radius-xs)]"
+      >
+        Try again
+      </button>
+    </div>
+  );
 }
 
 export function UsageHeatmap({ data, year, granularity, mode, onDayClick }: UsageHeatmapProps) {
@@ -91,87 +485,9 @@ export function UsageHeatmap({ data, year, granularity, mode, onDayClick }: Usag
     [data, mode],
   );
 
-  if (granularity === 'monthly') {
-    const buckets = bucketByMonth(normalized, year);
-    return (
-      <div className="grid grid-cols-12 gap-1 w-full">
-        {buckets.map((bucket) => {
-          const step = intensityStep(bucket.activeDays, 'monthly');
-          return (
-            <div key={bucket.index} className="aspect-square">
-              <Cell
-                intensity={step}
-                tooltip={`${bucket.label} ${year}: ${bucket.activeDays} active day${bucket.activeDays === 1 ? '' : 's'}`}
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+  const safeYear = Number.isFinite(year) ? Math.trunc(year) : new Date().getUTCFullYear();
 
-  if (granularity === 'weekly') {
-    const buckets = bucketByWeek(normalized, year);
-    return (
-      <div
-        className="grid gap-1 w-full"
-        style={{
-          gridTemplateColumns: `repeat(${Math.ceil(buckets.length / 7)}, minmax(0, 1fr))`,
-          gridAutoFlow: 'column',
-          gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
-        }}
-      >
-        {buckets.map((bucket) => {
-          const step = intensityStep(bucket.activeDays, 'weekly');
-          return (
-            <div key={bucket.index} className="aspect-square">
-              <Cell
-                intensity={step}
-                tooltip={`${bucket.label}: ${bucket.activeDays} active day${bucket.activeDays === 1 ? '' : 's'}`}
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  // Daily: column-major 7-row grid (GitHub style)
-  const yearStart = Date.UTC(year, 0, 1);
-  const yearEnd = Date.UTC(year, 11, 31);
-  const totalDays = Math.round((yearEnd - yearStart) / 86_400_000) + 1;
-
-  const byDate = new Map<string, number>();
-  for (const n of normalized) if (yearOf(n.date) === year) byDate.set(n.date, n.count);
-
-  const cells: { date: string; count: number }[] = [];
-  for (let i = 0; i < totalDays; i++) {
-    const t = new Date(yearStart + i * 86_400_000);
-    const iso = `${t.getUTCFullYear()}-${String(t.getUTCMonth() + 1).padStart(2, '0')}-${String(t.getUTCDate()).padStart(2, '0')}`;
-    cells.push({ date: iso, count: byDate.get(iso) ?? 0 });
-  }
-
-  return (
-    <div
-      className="grid gap-[3px] w-full"
-      style={{
-        gridTemplateColumns: `repeat(${Math.ceil(totalDays / 7)}, 1fr)`,
-        gridAutoFlow: 'column',
-        gridTemplateRows: 'repeat(7, 1fr)',
-      }}
-    >
-      {cells.map((cell) => {
-        const step = intensityStep(cell.count, 'daily');
-        return (
-          <div key={cell.date} className="aspect-square min-w-[8px]">
-            <Cell
-              intensity={step}
-              tooltip={`${formatDate(cell.date)}: ${cell.count} hit${cell.count === 1 ? '' : 's'}`}
-              onClick={onDayClick ? () => onDayClick(cell.date) : undefined}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
+  if (granularity === 'monthly') return <MonthlyView data={normalized} year={safeYear} />;
+  if (granularity === 'weekly') return <WeeklyView data={normalized} year={safeYear} />;
+  return <DailyView data={normalized} year={safeYear} onDayClick={onDayClick} />;
 }

--- a/src/features/usage/YearChipPager.tsx
+++ b/src/features/usage/YearChipPager.tsx
@@ -1,0 +1,71 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface YearChipPagerProps {
+  years: number[];
+  selected: number | null;
+  onSelect: (year: number) => void;
+}
+
+export function YearChipPager({ years, selected, onSelect }: YearChipPagerProps) {
+  if (years.length === 0) return null;
+
+  const sorted = [...years].sort((a, b) => a - b);
+  const idx = selected != null ? sorted.indexOf(selected) : sorted.length - 1;
+  const canPrev = idx > 0;
+  const canNext = idx >= 0 && idx < sorted.length - 1;
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        aria-label="Previous year"
+        onClick={() => canPrev && onSelect(sorted[idx - 1])}
+        disabled={!canPrev}
+        className={cn(
+          'h-7 w-7 inline-flex items-center justify-center rounded-[var(--radius-xs)]',
+          'text-[var(--text-secondary)] hover:bg-[var(--bg-active)]',
+          'disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default',
+        )}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+
+      <div className="flex gap-1.5 flex-wrap">
+        {sorted.map((year) => {
+          const active = year === selected;
+          return (
+            <button
+              key={year}
+              type="button"
+              onClick={() => onSelect(year)}
+              className={cn(
+                'px-2.5 py-1 rounded-[var(--radius-xs)] text-[12px] font-semibold',
+                'transition-colors',
+                active
+                  ? 'bg-[var(--accent)] text-[var(--text-on-accent)]'
+                  : 'bg-[var(--bg-input)] text-[var(--text-secondary)] border border-[var(--border-flat)] hover:bg-[var(--bg-active)]',
+              )}
+            >
+              {year}
+            </button>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        aria-label="Next year"
+        onClick={() => canNext && onSelect(sorted[idx + 1])}
+        disabled={!canNext}
+        className={cn(
+          'h-7 w-7 inline-flex items-center justify-center rounded-[var(--radius-xs)]',
+          'text-[var(--text-secondary)] hover:bg-[var(--bg-active)]',
+          'disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default',
+        )}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/features/usage/YearChipPager.tsx
+++ b/src/features/usage/YearChipPager.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, focusRing } from '@/lib/utils';
 
 interface YearChipPagerProps {
   years: number[];
@@ -7,62 +7,49 @@ interface YearChipPagerProps {
   onSelect: (year: number) => void;
 }
 
+const navButton = cn(
+  'h-7 w-7 inline-flex items-center justify-center rounded-[var(--radius-xs)]',
+  'text-[var(--text-secondary)] hover:bg-[var(--bg-active)] transition-colors',
+  'disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default',
+  focusRing,
+);
+
 export function YearChipPager({ years, selected, onSelect }: YearChipPagerProps) {
   if (years.length === 0) return null;
 
   const sorted = [...years].sort((a, b) => a - b);
   const idx = selected != null ? sorted.indexOf(selected) : sorted.length - 1;
-  const canPrev = idx > 0;
-  const canNext = idx >= 0 && idx < sorted.length - 1;
+  const safeIdx = idx < 0 ? sorted.length - 1 : idx;
+  const canPrev = safeIdx > 0;
+  const canNext = safeIdx < sorted.length - 1;
+  const displayYear = sorted[safeIdx];
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-0.5">
       <button
         type="button"
         aria-label="Previous year"
-        onClick={() => canPrev && onSelect(sorted[idx - 1])}
+        onClick={() => canPrev && onSelect(sorted[safeIdx - 1])}
         disabled={!canPrev}
-        className={cn(
-          'h-7 w-7 inline-flex items-center justify-center rounded-[var(--radius-xs)]',
-          'text-[var(--text-secondary)] hover:bg-[var(--bg-active)]',
-          'disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default',
-        )}
+        className={navButton}
       >
         <ChevronLeft className="h-4 w-4" />
       </button>
 
-      <div className="flex gap-1.5 flex-wrap">
-        {sorted.map((year) => {
-          const active = year === selected;
-          return (
-            <button
-              key={year}
-              type="button"
-              onClick={() => onSelect(year)}
-              className={cn(
-                'px-2.5 py-1 rounded-[var(--radius-xs)] text-[12px] font-semibold',
-                'transition-colors',
-                active
-                  ? 'bg-[var(--accent)] text-[var(--text-on-accent)]'
-                  : 'bg-[var(--bg-input)] text-[var(--text-secondary)] border border-[var(--border-flat)] hover:bg-[var(--bg-active)]',
-              )}
-            >
-              {year}
-            </button>
-          );
-        })}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="min-w-[2.75rem] px-1 text-center text-[13px] font-semibold tabular-nums text-[var(--text-primary)] select-none"
+      >
+        {displayYear}
       </div>
 
       <button
         type="button"
         aria-label="Next year"
-        onClick={() => canNext && onSelect(sorted[idx + 1])}
+        onClick={() => canNext && onSelect(sorted[safeIdx + 1])}
         disabled={!canNext}
-        className={cn(
-          'h-7 w-7 inline-flex items-center justify-center rounded-[var(--radius-xs)]',
-          'text-[var(--text-secondary)] hover:bg-[var(--bg-active)]',
-          'disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default',
-        )}
+        className={navButton}
       >
         <ChevronRight className="h-4 w-4" />
       </button>

--- a/src/features/usage/__tests__/UsageHeatmap.test.tsx
+++ b/src/features/usage/__tests__/UsageHeatmap.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { LocationUsageDay } from '@/types';
+import { UsageHeatmap } from '../UsageHeatmap';
+
+describe('UsageHeatmap', () => {
+  it('monthly: renders 12 cells', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[{ date: '2026-03-01', count: 1 }]}
+        year={2026}
+        granularity="monthly"
+        mode="per-bin"
+      />,
+    );
+    const cells = container.querySelectorAll('[data-testid="usage-cell"]');
+    expect(cells).toHaveLength(12);
+  });
+
+  it('weekly: renders 53 cells', () => {
+    const { container } = render(
+      <UsageHeatmap data={[]} year={2026} granularity="weekly" mode="per-bin" />,
+    );
+    const cells = container.querySelectorAll('[data-testid="usage-cell"]');
+    expect(cells).toHaveLength(53);
+  });
+
+  it('daily: renders 365 or 366 cells for a year', () => {
+    const { container } = render(
+      <UsageHeatmap data={[]} year={2026} granularity="daily" mode="per-bin" />,
+    );
+    const cells = container.querySelectorAll('[data-testid="usage-cell"]');
+    expect(cells.length).toBeGreaterThanOrEqual(365);
+    expect(cells.length).toBeLessThanOrEqual(366);
+  });
+
+  it('applies intensity-3 background to active cells with high count', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[{ date: '2026-03-05', count: 10 }]}
+        year={2026}
+        granularity="daily"
+        mode="per-bin"
+      />,
+    );
+    const activeCell = container.querySelector('[data-intensity="3"]');
+    expect(activeCell).not.toBeNull();
+  });
+
+  it('empty rendering when data has no dates in selected year', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[{ date: '2024-03-05', count: 10 }]}
+        year={2026}
+        granularity="monthly"
+        mode="per-bin"
+      />,
+    );
+    const activeCells = container.querySelectorAll('[data-intensity="3"]');
+    expect(activeCells).toHaveLength(0);
+  });
+
+  it('aggregate mode: intensity uses binCount for daily view', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[{ date: '2026-03-05', binCount: 4, totalCount: 8 }] as LocationUsageDay[]}
+        year={2026}
+        granularity="daily"
+        mode="aggregate"
+      />,
+    );
+    const activeCell = container.querySelector('[data-intensity="3"]');
+    expect(activeCell).not.toBeNull();
+  });
+});

--- a/src/features/usage/__tests__/UsageHeatmap.test.tsx
+++ b/src/features/usage/__tests__/UsageHeatmap.test.tsx
@@ -72,4 +72,68 @@ describe('UsageHeatmap', () => {
     const activeCell = container.querySelector('[data-intensity="3"]');
     expect(activeCell).not.toBeNull();
   });
+
+  it('ignores malformed date entries without crashing', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[
+          { date: 'garbage', count: 10 },
+          { date: '2026-13-99', count: 10 },
+          { date: '2026-03-05', count: 2 },
+        ]}
+        year={2026}
+        granularity="daily"
+        mode="per-bin"
+      />,
+    );
+    // Exactly one active cell (the valid 2026-03-05 entry)
+    const activeCells = container.querySelectorAll('[data-intensity="2"]');
+    expect(activeCells.length).toBe(1);
+  });
+
+  it('falls back safely when year is NaN', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[{ date: '2026-03-05', count: 10 }]}
+        year={Number.NaN}
+        granularity="monthly"
+        mode="per-bin"
+      />,
+    );
+    // Renders 12 month cells without crashing
+    const cells = container.querySelectorAll('[data-testid="usage-cell"]');
+    expect(cells).toHaveLength(12);
+  });
+
+  it('exposes a role="img" with an aria-label for screen readers', () => {
+    const { container } = render(
+      <UsageHeatmap
+        data={[{ date: '2026-03-05', count: 2 }]}
+        year={2026}
+        granularity="monthly"
+        mode="per-bin"
+      />,
+    );
+    const img = container.querySelector('[role="img"]');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('aria-label')).toContain('2026');
+  });
+
+  it('marks today with a highlight in daily view', () => {
+    // Use the current year so the "today" cell actually falls within the grid.
+    const currentYear = new Date().getUTCFullYear();
+    const { container } = render(
+      <UsageHeatmap data={[]} year={currentYear} granularity="daily" mode="per-bin" />,
+    );
+    const todayCells = container.querySelectorAll('[data-today="true"]');
+    expect(todayCells.length).toBe(1);
+  });
+
+  it('does not mark any cell as today when viewing a past year', () => {
+    const { container } = render(
+      <UsageHeatmap data={[]} year={2020} granularity="daily" mode="per-bin" />,
+    );
+    const todayCells = container.querySelectorAll('[data-today="true"]');
+    expect(todayCells.length).toBe(0);
+  });
 });

--- a/src/features/usage/__tests__/YearChipPager.test.tsx
+++ b/src/features/usage/__tests__/YearChipPager.test.tsx
@@ -3,18 +3,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { YearChipPager } from '../YearChipPager';
 
 describe('YearChipPager', () => {
-  it('renders a chip per year', () => {
-    render(<YearChipPager years={[2024, 2025, 2026]} selected={2026} onSelect={() => {}} />);
-    expect(screen.getByRole('button', { name: '2024' })).toBeDefined();
-    expect(screen.getByRole('button', { name: '2025' })).toBeDefined();
-    expect(screen.getByRole('button', { name: '2026' })).toBeDefined();
+  it('shows only the currently selected year', () => {
+    render(<YearChipPager years={[2024, 2025, 2026]} selected={2025} onSelect={() => {}} />);
+    expect(screen.getByText('2025')).toBeDefined();
+    expect(screen.queryByText('2024')).toBeNull();
+    expect(screen.queryByText('2026')).toBeNull();
   });
 
-  it('fires onSelect when a chip is clicked', () => {
-    const onSelect = vi.fn();
-    render(<YearChipPager years={[2024, 2025, 2026]} selected={2026} onSelect={onSelect} />);
-    fireEvent.click(screen.getByRole('button', { name: '2024' }));
-    expect(onSelect).toHaveBeenCalledWith(2024);
+  it('falls back to the newest year when none is selected', () => {
+    render(<YearChipPager years={[2024, 2025, 2026]} selected={null} onSelect={() => {}} />);
+    expect(screen.getByText('2026')).toBeDefined();
   });
 
   it('pager buttons move selection one year back/forward', () => {

--- a/src/features/usage/__tests__/YearChipPager.test.tsx
+++ b/src/features/usage/__tests__/YearChipPager.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { YearChipPager } from '../YearChipPager';
+
+describe('YearChipPager', () => {
+  it('renders a chip per year', () => {
+    render(<YearChipPager years={[2024, 2025, 2026]} selected={2026} onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: '2024' })).toBeDefined();
+    expect(screen.getByRole('button', { name: '2025' })).toBeDefined();
+    expect(screen.getByRole('button', { name: '2026' })).toBeDefined();
+  });
+
+  it('fires onSelect when a chip is clicked', () => {
+    const onSelect = vi.fn();
+    render(<YearChipPager years={[2024, 2025, 2026]} selected={2026} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: '2024' }));
+    expect(onSelect).toHaveBeenCalledWith(2024);
+  });
+
+  it('pager buttons move selection one year back/forward', () => {
+    const onSelect = vi.fn();
+    render(<YearChipPager years={[2024, 2025, 2026]} selected={2025} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByLabelText('Previous year'));
+    expect(onSelect).toHaveBeenCalledWith(2024);
+
+    fireEvent.click(screen.getByLabelText('Next year'));
+    expect(onSelect).toHaveBeenCalledWith(2026);
+  });
+
+  it('disables prev button on oldest year, next on newest', () => {
+    const onSelect = vi.fn();
+    const { rerender } = render(<YearChipPager years={[2024, 2025, 2026]} selected={2024} onSelect={onSelect} />);
+    expect(screen.getByLabelText('Previous year').getAttribute('disabled')).not.toBeNull();
+
+    rerender(<YearChipPager years={[2024, 2025, 2026]} selected={2026} onSelect={onSelect} />);
+    expect(screen.getByLabelText('Next year').getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('renders nothing when years list is empty', () => {
+    const { container } = render(<YearChipPager years={[]} selected={null} onSelect={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/usage/__tests__/usageBuckets.test.ts
+++ b/src/features/usage/__tests__/usageBuckets.test.ts
@@ -5,6 +5,7 @@ import {
   bucketByMonth,
   bucketByWeek,
   intensityStep,
+  parseIsoDate,
   yearOf,
 } from '../usageBuckets';
 
@@ -102,5 +103,71 @@ describe('yearOf', () => {
   it('extracts UTC year from ISO date', () => {
     expect(yearOf('2026-04-12')).toBe(2026);
     expect(yearOf('1999-12-31')).toBe(1999);
+  });
+
+  it('returns NaN for malformed input', () => {
+    expect(Number.isNaN(yearOf(''))).toBe(true);
+    expect(Number.isNaN(yearOf('garbage'))).toBe(true);
+    expect(Number.isNaN(yearOf('2026-13-01'))).toBe(true);
+    expect(Number.isNaN(yearOf('2026-01-32'))).toBe(true);
+    expect(Number.isNaN(yearOf('26-01-01'))).toBe(true);
+  });
+});
+
+describe('parseIsoDate', () => {
+  it('parses well-formed dates', () => {
+    expect(parseIsoDate('2026-04-12')).toEqual({ y: 2026, m: 4, d: 12 });
+  });
+
+  it('rejects malformed input', () => {
+    expect(parseIsoDate('')).toBeNull();
+    expect(parseIsoDate('garbage')).toBeNull();
+    expect(parseIsoDate('2026-00-01')).toBeNull();
+    expect(parseIsoDate('2026-13-01')).toBeNull();
+    expect(parseIsoDate('2026-01-32')).toBeNull();
+    expect(parseIsoDate(null as unknown as string)).toBeNull();
+    expect(parseIsoDate(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe('availableYears with malformed data', () => {
+  it('skips invalid dates and returns valid years', () => {
+    const data: UsageDay[] = [
+      { date: '2026-04-12', count: 1 },
+      { date: 'garbage', count: 1 },
+      { date: '2025-01-01', count: 1 },
+    ];
+    expect(availableYears(data)).toEqual([2026, 2025]);
+  });
+
+  it('returns current-year fallback when all dates are invalid', () => {
+    const data: UsageDay[] = [
+      { date: '', count: 1 },
+      { date: 'nope', count: 1 },
+    ];
+    expect(availableYears(data)).toEqual([new Date().getUTCFullYear()]);
+  });
+});
+
+describe('bucketByMonth with malformed data', () => {
+  it('skips invalid dates without throwing', () => {
+    const data: UsageDay[] = [
+      { date: '2026-01-05', count: 2 },
+      { date: 'garbage', count: 99 },
+      { date: '2026-01-06', count: Number.NaN },
+    ];
+    const buckets = bucketByMonth(data, 2026);
+    expect(buckets[0].activeDays).toBe(2);
+    expect(buckets[0].totalCount).toBe(2);
+  });
+
+  it('returns empty buckets when year is NaN', () => {
+    const buckets = bucketByMonth([{ date: '2026-01-05', count: 1 }], Number.NaN);
+    expect(buckets.every((b) => b.activeDays === 0)).toBe(true);
+  });
+
+  it('clamps negative counts to 0', () => {
+    const buckets = bucketByMonth([{ date: '2026-01-05', count: -10 }], 2026);
+    expect(buckets[0].totalCount).toBe(0);
   });
 });

--- a/src/features/usage/__tests__/usageBuckets.test.ts
+++ b/src/features/usage/__tests__/usageBuckets.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { UsageDay } from '@/types';
+import {
+  availableYears,
+  bucketByMonth,
+  bucketByWeek,
+  intensityStep,
+  yearOf,
+} from '../usageBuckets';
+
+describe('availableYears', () => {
+  it('returns unique years from usage data, descending', () => {
+    const data: UsageDay[] = [
+      { date: '2024-03-01', count: 1 },
+      { date: '2025-06-15', count: 2 },
+      { date: '2026-04-12', count: 1 },
+      { date: '2025-07-01', count: 1 },
+    ];
+    expect(availableYears(data)).toEqual([2026, 2025, 2024]);
+  });
+
+  it('returns current year when data is empty', () => {
+    expect(availableYears([])).toEqual([new Date().getUTCFullYear()]);
+  });
+});
+
+describe('bucketByMonth', () => {
+  it('produces 12 buckets indexed 0–11 (Jan–Dec)', () => {
+    const data: UsageDay[] = [
+      { date: '2026-01-05', count: 1 },
+      { date: '2026-01-06', count: 2 },
+      { date: '2026-03-10', count: 1 },
+    ];
+    const buckets = bucketByMonth(data, 2026);
+    expect(buckets).toHaveLength(12);
+    expect(buckets[0].activeDays).toBe(2);
+    expect(buckets[0].totalCount).toBe(3);
+    expect(buckets[2].activeDays).toBe(1);
+    expect(buckets[1].activeDays).toBe(0);
+  });
+
+  it('ignores dates outside the requested year', () => {
+    const data: UsageDay[] = [
+      { date: '2025-12-31', count: 5 },
+      { date: '2026-01-01', count: 1 },
+    ];
+    const buckets = bucketByMonth(data, 2026);
+    expect(buckets[0].activeDays).toBe(1);
+    expect(buckets.reduce((s, b) => s + b.activeDays, 0)).toBe(1);
+  });
+});
+
+describe('bucketByWeek', () => {
+  it('produces exactly 53 weekly buckets for a year', () => {
+    const buckets = bucketByWeek([], 2026);
+    expect(buckets).toHaveLength(53);
+  });
+
+  it('groups days into week-of-year buckets', () => {
+    const data: UsageDay[] = [
+      { date: '2026-01-01', count: 1 },
+      { date: '2026-01-05', count: 1 },
+      { date: '2026-01-08', count: 1 },
+    ];
+    const buckets = bucketByWeek(data, 2026);
+    expect(buckets[0].activeDays + buckets[1].activeDays).toBe(3);
+  });
+});
+
+describe('intensityStep', () => {
+  it('daily: 0/1/2-3/4+', () => {
+    expect(intensityStep(0, 'daily')).toBe(0);
+    expect(intensityStep(1, 'daily')).toBe(1);
+    expect(intensityStep(2, 'daily')).toBe(2);
+    expect(intensityStep(3, 'daily')).toBe(2);
+    expect(intensityStep(4, 'daily')).toBe(3);
+    expect(intensityStep(99, 'daily')).toBe(3);
+  });
+
+  it('weekly: 0/1-2/3-4/5+', () => {
+    expect(intensityStep(0, 'weekly')).toBe(0);
+    expect(intensityStep(1, 'weekly')).toBe(1);
+    expect(intensityStep(2, 'weekly')).toBe(1);
+    expect(intensityStep(3, 'weekly')).toBe(2);
+    expect(intensityStep(4, 'weekly')).toBe(2);
+    expect(intensityStep(5, 'weekly')).toBe(3);
+    expect(intensityStep(7, 'weekly')).toBe(3);
+  });
+
+  it('monthly: 0/1-5/6-10/11+', () => {
+    expect(intensityStep(0, 'monthly')).toBe(0);
+    expect(intensityStep(1, 'monthly')).toBe(1);
+    expect(intensityStep(5, 'monthly')).toBe(1);
+    expect(intensityStep(6, 'monthly')).toBe(2);
+    expect(intensityStep(10, 'monthly')).toBe(2);
+    expect(intensityStep(11, 'monthly')).toBe(3);
+    expect(intensityStep(31, 'monthly')).toBe(3);
+  });
+});
+
+describe('yearOf', () => {
+  it('extracts UTC year from ISO date', () => {
+    expect(yearOf('2026-04-12')).toBe(2026);
+    expect(yearOf('1999-12-31')).toBe(1999);
+  });
+});

--- a/src/features/usage/__tests__/useBinUsage.test.ts
+++ b/src/features/usage/__tests__/useBinUsage.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApiFetch = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, msg: string) { super(msg); }
+  },
+}));
+
+const { useBinUsage } = await import('../useBinUsage');
+const { Events } = await import('@/lib/eventBus');
+
+describe('useBinUsage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches usage data for the given binId', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      results: [{ date: '2026-04-12', count: 3 }],
+      count: 1,
+    });
+
+    const { result } = renderHook(() => useBinUsage('bin-1'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.usage).toEqual([{ date: '2026-04-12', count: 3 }]);
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/bins/bin-1/usage');
+  });
+
+  it('returns empty array when binId is null', async () => {
+    const { result } = renderHook(() => useBinUsage(null));
+    expect(result.current.usage).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when BIN_USAGE event fires', async () => {
+    mockApiFetch.mockResolvedValue({ results: [], count: 0 });
+
+    renderHook(() => useBinUsage('bin-1'));
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      window.dispatchEvent(new Event(Events.BIN_USAGE));
+    });
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/features/usage/__tests__/useLocationUsage.test.ts
+++ b/src/features/usage/__tests__/useLocationUsage.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApiFetch = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, msg: string) { super(msg); }
+  },
+}));
+
+const { useLocationUsage } = await import('../useLocationUsage');
+const { Events } = await import('@/lib/eventBus');
+
+describe('useLocationUsage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches aggregate usage for the location', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      results: [{ date: '2026-04-12', binCount: 4, totalCount: 11 }],
+      count: 1,
+    });
+
+    const { result } = renderHook(() => useLocationUsage('loc-1'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.usage).toEqual([{ date: '2026-04-12', binCount: 4, totalCount: 11 }]);
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/locations/loc-1/usage');
+  });
+
+  it('returns empty array when locationId is null', async () => {
+    const { result } = renderHook(() => useLocationUsage(null));
+    expect(result.current.usage).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('refreshes when BIN_USAGE event fires', async () => {
+    mockApiFetch.mockResolvedValue({ results: [], count: 0 });
+
+    renderHook(() => useLocationUsage('loc-1'));
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      window.dispatchEvent(new Event(Events.BIN_USAGE));
+    });
+
+    await waitFor(() => expect(mockApiFetch).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/features/usage/recordBinUsage.ts
+++ b/src/features/usage/recordBinUsage.ts
@@ -1,0 +1,22 @@
+import { apiFetch } from '@/lib/api';
+import { Events, notify } from '@/lib/eventBus';
+
+export type UsageTrigger = 'scan' | 'manual';
+
+/**
+ * Fire-and-forget POST to record a usage dot. Server enforces the caller's
+ * preferences — returns `{ ok: true, recorded: boolean }`. If recording is
+ * disabled in prefs, the POST still succeeds but writes nothing.
+ * Any network failure is silently swallowed — usage tracking is non-critical.
+ */
+export async function recordBinUsage(binId: string, trigger: UsageTrigger): Promise<void> {
+  try {
+    const result = await apiFetch<{ ok: boolean; recorded: boolean }>(
+      `/api/bins/${binId}/usage`,
+      { method: 'POST', body: { trigger } },
+    );
+    if (result.recorded) notify(Events.BIN_USAGE);
+  } catch {
+    // Non-critical; swallow
+  }
+}

--- a/src/features/usage/usageBuckets.ts
+++ b/src/features/usage/usageBuckets.ts
@@ -11,36 +11,56 @@ export interface Bucket {
   label: string;
 }
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse a strict `YYYY-MM-DD` string. Returns null for any malformed input. */
+export function parseIsoDate(iso: unknown): { y: number; m: number; d: number } | null {
+  if (typeof iso !== 'string' || !ISO_DATE_RE.test(iso)) return null;
+  const y = parseInt(iso.slice(0, 4), 10);
+  const m = parseInt(iso.slice(5, 7), 10);
+  const d = parseInt(iso.slice(8, 10), 10);
+  if (m < 1 || m > 12 || d < 1 || d > 31) return null;
+  return { y, m, d };
+}
+
+/** UTC year from an ISO date, or NaN for unparsable input. */
 export function yearOf(isoDate: string): number {
-  return parseInt(isoDate.slice(0, 4), 10);
+  return parseIsoDate(isoDate)?.y ?? Number.NaN;
 }
 
 export function availableYears(data: { date: string }[]): number[] {
-  if (data.length === 0) return [new Date().getUTCFullYear()];
+  const fallback = [new Date().getUTCFullYear()];
+  if (data.length === 0) return fallback;
   const years = new Set<number>();
-  for (const d of data) years.add(yearOf(d.date));
+  for (const d of data) {
+    const y = yearOf(d.date);
+    if (Number.isFinite(y)) years.add(y);
+  }
+  if (years.size === 0) return fallback;
   return [...years].sort((a, b) => b - a);
 }
 
-const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const FALLBACK_MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 export function bucketByMonth(
   data: { date: string; count: number }[],
   year: number,
 ): Bucket[] {
-  const buckets: Bucket[] = MONTH_LABELS.map((label, index) => ({
+  const buckets: Bucket[] = FALLBACK_MONTH_LABELS.map((label, index) => ({
     index,
     activeDays: 0,
     totalCount: 0,
     label,
   }));
 
+  if (!Number.isFinite(year)) return buckets;
+
   for (const day of data) {
-    if (yearOf(day.date) !== year) continue;
-    const month = parseInt(day.date.slice(5, 7), 10) - 1;
-    if (month < 0 || month > 11) continue;
-    buckets[month].activeDays += 1;
-    buckets[month].totalCount += day.count;
+    const parsed = parseIsoDate(day.date);
+    if (!parsed || parsed.y !== year) continue;
+    const monthIdx = parsed.m - 1;
+    buckets[monthIdx].activeDays += 1;
+    buckets[monthIdx].totalCount += Math.max(0, Number.isFinite(day.count) ? day.count : 0);
   }
 
   return buckets;
@@ -61,17 +81,19 @@ export function bucketByWeek(
     label: `W${index + 1}`,
   }));
 
+  if (!Number.isFinite(year)) return buckets;
+
   const yearStart = Date.UTC(year, 0, 1);
 
   for (const day of data) {
-    if (yearOf(day.date) !== year) continue;
-    const parts = day.date.split('-').map(Number);
-    const dayUtc = Date.UTC(parts[0], parts[1] - 1, parts[2]);
+    const parsed = parseIsoDate(day.date);
+    if (!parsed || parsed.y !== year) continue;
+    const dayUtc = Date.UTC(parsed.y, parsed.m - 1, parsed.d);
     const dayOfYear = Math.floor((dayUtc - yearStart) / 86_400_000);
     if (dayOfYear < 0) continue;
     const weekIdx = Math.min(52, Math.floor(dayOfYear / 7));
     buckets[weekIdx].activeDays += 1;
-    buckets[weekIdx].totalCount += day.count;
+    buckets[weekIdx].totalCount += Math.max(0, Number.isFinite(day.count) ? day.count : 0);
   }
 
   return buckets;

--- a/src/features/usage/usageBuckets.ts
+++ b/src/features/usage/usageBuckets.ts
@@ -1,0 +1,100 @@
+import type { UsageGranularity } from '@/types';
+
+export interface Bucket {
+  /** 0-indexed position within the year */
+  index: number;
+  /** Count of distinct UTC dates with any activity inside this bucket */
+  activeDays: number;
+  /** Sum of all `count` values inside this bucket */
+  totalCount: number;
+  /** Human-readable label (e.g. 'Jan', 'Feb' for monthly) */
+  label: string;
+}
+
+export function yearOf(isoDate: string): number {
+  return parseInt(isoDate.slice(0, 4), 10);
+}
+
+export function availableYears(data: { date: string }[]): number[] {
+  if (data.length === 0) return [new Date().getUTCFullYear()];
+  const years = new Set<number>();
+  for (const d of data) years.add(yearOf(d.date));
+  return [...years].sort((a, b) => b - a);
+}
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export function bucketByMonth(
+  data: { date: string; count: number }[],
+  year: number,
+): Bucket[] {
+  const buckets: Bucket[] = MONTH_LABELS.map((label, index) => ({
+    index,
+    activeDays: 0,
+    totalCount: 0,
+    label,
+  }));
+
+  for (const day of data) {
+    if (yearOf(day.date) !== year) continue;
+    const month = parseInt(day.date.slice(5, 7), 10) - 1;
+    if (month < 0 || month > 11) continue;
+    buckets[month].activeDays += 1;
+    buckets[month].totalCount += day.count;
+  }
+
+  return buckets;
+}
+
+/**
+ * Week-of-year bucketing: day-of-year divided by 7. Always 53 buckets
+ * (covers both 52- and 53-week years).
+ */
+export function bucketByWeek(
+  data: { date: string; count: number }[],
+  year: number,
+): Bucket[] {
+  const buckets: Bucket[] = Array.from({ length: 53 }, (_, index) => ({
+    index,
+    activeDays: 0,
+    totalCount: 0,
+    label: `W${index + 1}`,
+  }));
+
+  const yearStart = Date.UTC(year, 0, 1);
+
+  for (const day of data) {
+    if (yearOf(day.date) !== year) continue;
+    const parts = day.date.split('-').map(Number);
+    const dayUtc = Date.UTC(parts[0], parts[1] - 1, parts[2]);
+    const dayOfYear = Math.floor((dayUtc - yearStart) / 86_400_000);
+    if (dayOfYear < 0) continue;
+    const weekIdx = Math.min(52, Math.floor(dayOfYear / 7));
+    buckets[weekIdx].activeDays += 1;
+    buckets[weekIdx].totalCount += day.count;
+  }
+
+  return buckets;
+}
+
+/**
+ * Map a bucket's `activeDays` (weekly/monthly) or daily `count` to an intensity
+ * step 0..3. 0 = empty.
+ */
+export function intensityStep(value: number, granularity: UsageGranularity): 0 | 1 | 2 | 3 {
+  if (value <= 0) return 0;
+  if (granularity === 'daily') {
+    if (value === 1) return 1;
+    if (value <= 3) return 2;
+    return 3;
+  }
+  if (granularity === 'weekly') {
+    if (value <= 2) return 1;
+    if (value <= 4) return 2;
+    return 3;
+  }
+  // monthly
+  if (value <= 5) return 1;
+  if (value <= 10) return 2;
+  return 3;
+}

--- a/src/features/usage/useBinUsage.ts
+++ b/src/features/usage/useBinUsage.ts
@@ -1,0 +1,11 @@
+import { Events } from '@/lib/eventBus';
+import { useListData } from '@/lib/useListData';
+import type { UsageDay } from '@/types';
+
+export function useBinUsage(binId: string | null | undefined) {
+  const { data, isLoading, error, refresh } = useListData<UsageDay>(
+    binId ? `/api/bins/${binId}/usage` : null,
+    [Events.BIN_USAGE, Events.BINS],
+  );
+  return { usage: data, isLoading, error, refresh };
+}

--- a/src/features/usage/useLocationUsage.ts
+++ b/src/features/usage/useLocationUsage.ts
@@ -1,0 +1,11 @@
+import { Events } from '@/lib/eventBus';
+import { useListData } from '@/lib/useListData';
+import type { LocationUsageDay } from '@/types';
+
+export function useLocationUsage(locationId: string | null | undefined) {
+  const { data, isLoading, error, refresh } = useListData<LocationUsageDay>(
+    locationId ? `/api/locations/${locationId}/usage` : null,
+    [Events.BIN_USAGE, Events.BINS],
+  );
+  return { usage: data, isLoading, error, refresh };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -210,6 +210,47 @@ body {
   display: none;
 }
 
+/* ─── Thin auto-hiding scrollbar ───
+   Desktop (hover-capable): slim thumb reveals on hover/focus, invisible at rest.
+   Touch (no hover): thumb stays visible so scrollable regions are discoverable. */
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 180ms ease;
+}
+.scrollbar-thin::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: var(--radius-full);
+  transition: background 180ms ease;
+}
+
+@media (hover: hover) {
+  .scrollbar-thin:hover,
+  .scrollbar-thin:focus-within {
+    scrollbar-color: var(--bg-active) transparent;
+  }
+  .scrollbar-thin:hover::-webkit-scrollbar-thumb,
+  .scrollbar-thin:focus-within::-webkit-scrollbar-thumb {
+    background: var(--bg-active);
+  }
+}
+
+@media (hover: none) {
+  .scrollbar-thin {
+    scrollbar-color: var(--bg-active) transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    background: var(--bg-active);
+  }
+}
+
 /* ─── Selection ─── */
 ::selection {
   background: var(--accent);

--- a/src/lib/dashboardSettings.ts
+++ b/src/lib/dashboardSettings.ts
@@ -11,6 +11,7 @@ export interface DashboardSettings {
   showPinnedBins: boolean;
   showRecentlyScanned: boolean;
   showRecentlyUpdated: boolean;
+  showActivity: boolean;
   showTimestamps: boolean;
 }
 
@@ -32,6 +33,7 @@ const DEFAULTS: DashboardSettings = {
   showPinnedBins: DEFAULT_PREFERENCES.dashboard_show_pinned_bins,
   showRecentlyScanned: DEFAULT_PREFERENCES.dashboard_show_recently_scanned,
   showRecentlyUpdated: DEFAULT_PREFERENCES.dashboard_show_recently_updated,
+  showActivity: DEFAULT_PREFERENCES.dashboard_show_activity,
   showTimestamps: DEFAULT_PREFERENCES.dashboard_show_timestamps,
 };
 
@@ -59,6 +61,7 @@ export function useDashboardSettings() {
     showPinnedBins: preferences.dashboard_show_pinned_bins,
     showRecentlyScanned: preferences.dashboard_show_recently_scanned,
     showRecentlyUpdated: preferences.dashboard_show_recently_updated,
+    showActivity: preferences.dashboard_show_activity,
     showTimestamps: preferences.dashboard_show_timestamps,
   };
 
@@ -76,6 +79,7 @@ export function useDashboardSettings() {
     if (patch.showPinnedBins !== undefined) dbPatch.dashboard_show_pinned_bins = patch.showPinnedBins;
     if (patch.showRecentlyScanned !== undefined) dbPatch.dashboard_show_recently_scanned = patch.showRecentlyScanned;
     if (patch.showRecentlyUpdated !== undefined) dbPatch.dashboard_show_recently_updated = patch.showRecentlyUpdated;
+    if (patch.showActivity !== undefined) dbPatch.dashboard_show_activity = patch.showActivity;
     if (patch.showTimestamps !== undefined) dbPatch.dashboard_show_timestamps = patch.showTimestamps;
     updatePreferences(dbPatch);
   }, [updatePreferences]);
@@ -90,6 +94,7 @@ export function useDashboardSettings() {
       dashboard_show_pinned_bins: DEFAULT_PREFERENCES.dashboard_show_pinned_bins,
       dashboard_show_recently_scanned: DEFAULT_PREFERENCES.dashboard_show_recently_scanned,
       dashboard_show_recently_updated: DEFAULT_PREFERENCES.dashboard_show_recently_updated,
+      dashboard_show_activity: DEFAULT_PREFERENCES.dashboard_show_activity,
       dashboard_show_timestamps: DEFAULT_PREFERENCES.dashboard_show_timestamps,
     });
   }, [updatePreferences]);

--- a/src/lib/eventBus.ts
+++ b/src/lib/eventBus.ts
@@ -11,6 +11,7 @@ export const Events = {
   CUSTOM_FIELDS: 'custom-fields-changed',
   PLAN: 'plan-changed',
   CHECKOUTS: 'checkouts-changed',
+  BIN_USAGE: 'bin-usage-changed',
 } as const;
 
 export type EventName = (typeof Events)[keyof typeof Events];

--- a/src/lib/userPreferences.tsx
+++ b/src/lib/userPreferences.tsx
@@ -10,6 +10,7 @@ export interface UserPreferences {
   dashboard_show_pinned_bins: boolean;
   dashboard_show_recently_scanned: boolean;
   dashboard_show_recently_updated: boolean;
+  dashboard_show_activity: boolean;
   dashboard_show_timestamps: boolean;
   ai_enabled: boolean;
   onboarding_completed: boolean;
@@ -19,6 +20,11 @@ export interface UserPreferences {
   tour_version: number;
   keyboard_shortcuts_enabled: boolean;
   checklist_dismissed: boolean;
+  usage_tracking_scan: boolean;
+  usage_tracking_manual_lookup: boolean;
+  usage_tracking_view: boolean;
+  usage_tracking_modify: boolean;
+  usage_granularity: 'daily' | 'weekly' | 'monthly';
 }
 
 export const DEFAULT_PREFERENCES: UserPreferences = {
@@ -30,6 +36,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   dashboard_show_pinned_bins: true,
   dashboard_show_recently_scanned: true,
   dashboard_show_recently_updated: true,
+  dashboard_show_activity: true,
   dashboard_show_timestamps: false,
   ai_enabled: true,
   onboarding_completed: false,
@@ -39,6 +46,11 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   tour_version: 0,
   keyboard_shortcuts_enabled: true,
   checklist_dismissed: false,
+  usage_tracking_scan: true,
+  usage_tracking_manual_lookup: true,
+  usage_tracking_view: false,
+  usage_tracking_modify: false,
+  usage_granularity: 'monthly',
 };
 
 const PREFERENCES_EVENT = 'user-preferences-changed';

--- a/src/types.ts
+++ b/src/types.ts
@@ -330,3 +330,16 @@ export interface PlanInfo {
   canDowngradeToFree: boolean;
   aiCredits: { used: number; limit: number; resetsAt: string | null } | null;
 }
+
+export interface UsageDay {
+  date: string;       // 'YYYY-MM-DD' UTC
+  count: number;
+}
+
+export interface LocationUsageDay {
+  date: string;
+  binCount: number;
+  totalCount: number;
+}
+
+export type UsageGranularity = 'daily' | 'weekly' | 'monthly';


### PR DESCRIPTION
## Summary
- Adds a `bin_usage_days` table (per-day scan/view/modify counts) with migration, recording helper, and two API endpoints: `GET/POST /api/bins/:id/usage` and `GET /api/locations/:id/usage`.
- Auto-records usage on view, modify, scan, and manual lookup when enabled in location preferences; exposes a new "Last used" sort and "Unused since" filter in the bin list.
- Ships the `UsageHeatmap`, `GranularitySegmented`, and `YearChipPager` components, wires a `BinUsageSection` into the bin detail page, and adds an Activity widget to the dashboard plus a Usage Tracking section in preferences.
- Documents the new endpoints in `server/openapi.yaml`, adds a `BIN_USAGE` event, and seeds realistic multi-year usage data for demo users.

## Test plan
- [ ] `npx biome check .`
- [ ] `npx tsc --noEmit` and `cd server && npx tsc --noEmit`
- [ ] `npx vitest run` (client) and `cd server && npx vitest run`
- [ ] Manual: toggle Usage Tracking in preferences, scan a bin, confirm the heatmap updates on the bin detail page and dashboard widget
- [ ] Manual: verify the Last used sort and Unused since filter behave correctly in the bin list