### PR TITLE
feat: group photos per bin during bulk capture

### DIFF
--- a/src/features/ai/ConversationUI.tsx
+++ b/src/features/ai/ConversationUI.tsx
@@ -80,6 +80,7 @@ export function ConversationUI({
 
   const [photoMode, setPhotoMode] = useState(false);
   const [initialFiles, setInitialFiles] = useState<File[]>([]);
+  const [initialGroups, setInitialGroups] = useState<number[] | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const canTranscribe = !!settings && settings.provider !== 'anthropic' && isRecordingSupported();
@@ -98,6 +99,7 @@ export function ConversationUI({
       conversation.clearConversation();
       setPhotoMode(false);
       setInitialFiles([]);
+      setInitialGroups(null);
       transcription.cancel();
     }
   }, [active]);
@@ -122,8 +124,9 @@ export function ConversationUI({
     if (capturePickedUpRef.current) return;
     capturePickedUpRef.current = true;
     const captured = takeCapturedPhotos();
-    if (captured.length > 0) {
-      setInitialFiles(captured);
+    if (captured.files.length > 0) {
+      setInitialFiles(captured.files);
+      setInitialGroups(captured.groups);
       setPhotoMode(true);
     }
   }, [active]);
@@ -132,6 +135,7 @@ export function ConversationUI({
     const files = e.target.files;
     if (!files || files.length === 0) return;
     setInitialFiles(Array.from(files));
+    setInitialGroups(null);
     setPhotoMode(true);
     if (fileInputRef.current) fileInputRef.current.value = '';
   }
@@ -151,11 +155,13 @@ export function ConversationUI({
   const photoBulkAdd = (
     <PhotoBulkAdd
       initialFiles={initialFiles}
+      initialGroups={initialGroups}
       aiSettings={settings}
       onClose={onPhotoClose}
       onBack={() => {
         setPhotoMode(false);
         setInitialFiles([]);
+        setInitialGroups(null);
       }}
     />
   );

--- a/src/features/ai/PhotoBulkAdd.tsx
+++ b/src/features/ai/PhotoBulkAdd.tsx
@@ -15,6 +15,7 @@ import {
   createPhoto,
   type Group,
   initialState,
+  type Photo,
 } from '@/features/bulk-add/useBulkGroupAdd';
 import { compressImage } from '@/features/photos/compressImage';
 import { addPhoto } from '@/features/photos/usePhotos';
@@ -27,22 +28,59 @@ const DEMO_MAX_PHOTOS = 3;
 
 interface PhotoBulkAddProps {
   initialFiles: File[];
+  initialGroups?: number[] | null;
   aiSettings: AiSettings | null;
   onClose: () => void;
   onBack: () => void;
 }
 
-function initState(files: File[]): BulkAddState {
-  return {
-    ...initialState,
-    groups: files.map((f) => createGroupFromPhoto(createPhoto(f), null)),
-  };
+export function initBulkAddStateFromFiles(
+  files: File[],
+  groupIds: number[] | null | undefined,
+): BulkAddState {
+  if (!groupIds || groupIds.length === 0 || groupIds.length !== files.length) {
+    return {
+      ...initialState,
+      groups: files.map((f) => createGroupFromPhoto(createPhoto(f), null)),
+    };
+  }
+  const buckets = new Map<number, Photo[]>();
+  const order: number[] = [];
+  for (let i = 0; i < files.length; i++) {
+    const gid = groupIds[i];
+    const photo = createPhoto(files[i]);
+    let bucket = buckets.get(gid);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(gid, bucket);
+      order.push(gid);
+    }
+    bucket.push(photo);
+  }
+  const groups: Group[] = order.map((gid) => {
+    const photos = buckets.get(gid) ?? [];
+    return {
+      ...createGroupFromPhoto(photos[0], null),
+      photos,
+    };
+  });
+  return { ...initialState, groups };
 }
 
-export function PhotoBulkAdd({ initialFiles, aiSettings, onClose, onBack }: PhotoBulkAddProps) {
+export function PhotoBulkAdd({
+  initialFiles,
+  initialGroups,
+  aiSettings,
+  onClose,
+  onBack,
+}: PhotoBulkAddProps) {
   const t = useTerminology();
   const { activeLocationId, demoMode: isDemo } = useAuth();
-  const [state, dispatch] = useReducer(bulkAddReducer, initialFiles, initState);
+  const [state, dispatch] = useReducer(
+    bulkAddReducer,
+    { files: initialFiles, groups: initialGroups ?? null },
+    ({ files, groups }) => initBulkAddStateFromFiles(files, groups),
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const hadPhotos = useRef(initialFiles.length > 0);
   const [successBins, setSuccessBins] = useState<CreatedBinInfo[] | null>(null);

--- a/src/features/ai/__tests__/AskPage.test.tsx
+++ b/src/features/ai/__tests__/AskPage.test.tsx
@@ -76,7 +76,7 @@ vi.mock('@/features/bins/useBins', () => ({
 }));
 
 vi.mock('@/features/capture/capturedPhotos', () => ({
-  takeCapturedPhotos: () => [],
+  takeCapturedPhotos: () => ({ files: [], groups: null }),
 }));
 
 vi.mock('@/lib/audioRecorder', () => ({

--- a/src/features/ai/__tests__/CommandInput.test.tsx
+++ b/src/features/ai/__tests__/CommandInput.test.tsx
@@ -78,7 +78,7 @@ vi.mock('@/features/bins/useBins', () => ({
 }));
 
 vi.mock('@/features/capture/capturedPhotos', () => ({
-  takeCapturedPhotos: () => [],
+  takeCapturedPhotos: () => ({ files: [], groups: null }),
 }));
 
 vi.mock('@/lib/audioRecorder', () => ({

--- a/src/features/ai/__tests__/PhotoBulkAdd.initState.test.ts
+++ b/src/features/ai/__tests__/PhotoBulkAdd.initState.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { initBulkAddStateFromFiles } from '../PhotoBulkAdd';
+
+function f(name: string): File {
+  return new File([''], name, { type: 'image/jpeg' });
+}
+
+describe('initBulkAddStateFromFiles', () => {
+  it('creates one group per photo when no groupIds provided', () => {
+    const state = initBulkAddStateFromFiles([f('a.jpg'), f('b.jpg')], null);
+    expect(state.groups).toHaveLength(2);
+    expect(state.groups[0].photos).toHaveLength(1);
+    expect(state.groups[1].photos).toHaveLength(1);
+  });
+
+  it('buckets by groupIds parallel array', () => {
+    const state = initBulkAddStateFromFiles(
+      [f('a.jpg'), f('b.jpg'), f('c.jpg'), f('d.jpg')],
+      [0, 0, 1, 1],
+    );
+    expect(state.groups).toHaveLength(2);
+    expect(state.groups[0].photos).toHaveLength(2);
+    expect(state.groups[1].photos).toHaveLength(2);
+  });
+
+  it('preserves insertion order of group IDs', () => {
+    const state = initBulkAddStateFromFiles(
+      [f('a.jpg'), f('b.jpg')],
+      [7, 3],
+    );
+    expect(state.groups[0].photos[0].file.name).toBe('a.jpg');
+    expect(state.groups[1].photos[0].file.name).toBe('b.jpg');
+  });
+
+  it('falls back to per-photo when arrays mismatch', () => {
+    const state = initBulkAddStateFromFiles(
+      [f('a.jpg'), f('b.jpg')],
+      [0],
+    );
+    expect(state.groups).toHaveLength(2);
+  });
+
+  it('returns empty when no files', () => {
+    const state = initBulkAddStateFromFiles([], null);
+    expect(state.groups).toHaveLength(0);
+  });
+});

--- a/src/features/bins/BinCreateForm.tsx
+++ b/src/features/bins/BinCreateForm.tsx
@@ -226,7 +226,7 @@ export function BinCreateForm({
   useEffect(() => {
     function checkCapturedPhotos() {
       if (hasCapturedPhotos() && getCapturedReturnTarget() === 'bin-create') {
-        const files = takeCapturedPhotos();
+        const { files } = takeCapturedPhotos();
         addPhotosFromFiles(files);
       }
     }

--- a/src/features/bins/BinDetailActivitySection.tsx
+++ b/src/features/bins/BinDetailActivitySection.tsx
@@ -1,6 +1,5 @@
 import { AlertTriangle, Clock } from 'lucide-react';
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { Crossfade } from '@/components/ui/crossfade';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ActivityTableSkeleton } from '@/features/activity/ActivityTableSkeleton';
@@ -24,21 +23,12 @@ export function BinDetailActivitySection({ binId }: BinDetailActivitySectionProp
 
   const visibleEntries = expanded ? entries : entries.slice(0, PREVIEW_COUNT);
   const hasHiddenEntries = entries.length > PREVIEW_COUNT || hasMore;
+  const showToggle = hasHiddenEntries && !isLoading && !error;
 
   return (
     <section>
       <header className={sectionHeaderRow}>
         <h3 className={sectionHeader}>Activity</h3>
-        {hasHiddenEntries && !isLoading && !error && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setExpanded((prev) => !prev)}
-            aria-expanded={expanded}
-          >
-            {expanded ? 'Show less' : 'Show all'}
-          </Button>
-        )}
       </header>
 
       <Crossfade
@@ -69,6 +59,19 @@ export function BinDetailActivitySection({ binId }: BinDetailActivitySectionProp
           />
         )}
       </Crossfade>
+
+      {showToggle && (
+        <div className="mt-3 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            aria-expanded={expanded}
+            className="text-[13px] text-[var(--accent)] underline-offset-4 hover:underline focus-visible:underline focus-visible:outline-none rounded-sm"
+          >
+            {expanded ? 'Show less' : 'Show all events'}
+          </button>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/features/bins/BinDetailInformationTab.tsx
+++ b/src/features/bins/BinDetailInformationTab.tsx
@@ -5,12 +5,11 @@ import { resolveColor } from '@/lib/colorPalette';
 import { resolveIcon } from '@/lib/iconMap';
 import { generateQRDataURL } from '@/lib/qr';
 import { relativeTime, sectionHeader, sectionHeaderRow } from '@/lib/utils';
-import type { Bin, ItemCheckout } from '@/types';
+import type { Bin } from '@/types';
 import { BinDetailActivitySection } from './BinDetailActivitySection';
 
 interface BinDetailInformationTabProps {
   bin: Bin;
-  checkouts?: ItemCheckout[];
 }
 
 const QR_FG = '#000';
@@ -19,9 +18,7 @@ const QR_BG_FALLBACK = '#fff';
 // makes the library's integer-rounding leftover (proportional margin) negligible.
 const QR_GEN_SIZE = 540;
 
-export function BinDetailInformationTab({ bin, checkouts }: BinDetailInformationTabProps) {
-  const openCheckouts = (checkouts ?? []).filter((c) => !c.returned_at);
-
+export function BinDetailInformationTab({ bin }: BinDetailInformationTabProps) {
   const Icon = resolveIcon(bin.icon);
   const colorPreset = useMemo(
     () => (bin.color ? resolveColor(bin.color) : null),
@@ -59,25 +56,38 @@ export function BinDetailInformationTab({ bin, checkouts }: BinDetailInformation
     <div className="flex flex-col gap-8">
       <section>
         <header className={sectionHeaderRow}>
-          <h3 className={sectionHeader}>Usage</h3>
-        </header>
-        <BinUsageSection binId={bin.id} />
-      </section>
-
-      <section>
-        <header className={sectionHeaderRow}>
           <h3 className={sectionHeader}>Details</h3>
         </header>
-        <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-4 items-start md:gap-8">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-start md:gap-8">
+          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-5 gap-y-2.5 text-[13px] self-start">
+            {bin.created_by_name && (
+              <>
+                <dt className="text-[var(--text-tertiary)]">Creator</dt>
+                <dd className="text-[var(--text-primary)]">{bin.created_by_name}</dd>
+              </>
+            )}
+
+            <dt className="text-[var(--text-tertiary)]">Created</dt>
+            <dd className="text-[var(--text-primary)]">{createdAbsolute}</dd>
+
+            <dt className="text-[var(--text-tertiary)]">Updated</dt>
+            <dd className="text-[var(--text-primary)]">{relativeTime(bin.updated_at)}</dd>
+
+            <dt className="text-[var(--text-tertiary)]">Last scanned</dt>
+            <dd className="text-[var(--text-primary)]">
+              {lastScan ? relativeTime(lastScan.scannedAt) : 'Never'}
+            </dd>
+          </dl>
+
           <div
-            className="p-[5px] md:p-[7px]"
+            className="p-[4px] md:p-[6px]"
             style={{
               backgroundColor: cardBg,
               borderRadius: 'var(--radius-lg)',
               border: colorPreset ? 'none' : '1px solid var(--border-flat)',
             }}
           >
-            <div className="relative w-[128px] h-[128px] md:w-[180px] md:h-[180px]">
+            <div className="relative w-[80px] h-[80px] md:w-[108px] md:h-[108px]">
               {qrUrl && (
                 <img
                   src={qrUrl}
@@ -103,54 +113,17 @@ export function BinDetailInformationTab({ bin, checkouts }: BinDetailInformation
               )}
             </div>
           </div>
-
-          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-5 gap-y-2.5 text-[13px] self-start">
-            {bin.created_by_name && (
-              <>
-                <dt className="text-[var(--text-tertiary)]">Creator</dt>
-                <dd className="text-[var(--text-primary)]">{bin.created_by_name}</dd>
-              </>
-            )}
-
-            <dt className="text-[var(--text-tertiary)]">Created</dt>
-            <dd className="text-[var(--text-primary)]">{createdAbsolute}</dd>
-
-            <dt className="text-[var(--text-tertiary)]">Updated</dt>
-            <dd className="text-[var(--text-primary)]">{relativeTime(bin.updated_at)}</dd>
-
-            <dt className="text-[var(--text-tertiary)]">Last scanned</dt>
-            <dd className="text-[var(--text-primary)]">
-              {lastScan ? relativeTime(lastScan.scannedAt) : 'Never'}
-            </dd>
-          </dl>
         </div>
       </section>
 
       <BinDetailActivitySection binId={bin.id} />
 
-      {openCheckouts.length > 0 && (
-        <section>
-          <header className={sectionHeaderRow}>
-            <h3 className={sectionHeader}>Checked out</h3>
-            <span className="text-[12px] text-[var(--text-tertiary)] tabular-nums">
-              {openCheckouts.length}
-            </span>
-          </header>
-          <ul className="divide-y divide-[var(--border-subtle)]">
-            {openCheckouts.map((c) => (
-              <li
-                key={c.id}
-                className="flex justify-between items-baseline py-2 text-[13px]"
-              >
-                <span className="text-[var(--text-primary)]">{c.checked_out_by_name}</span>
-                <span className="text-[var(--text-tertiary)] tabular-nums">
-                  {relativeTime(c.checked_out_at)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
+      <section>
+        <header className={sectionHeaderRow}>
+          <h3 className={sectionHeader}>Usage</h3>
+        </header>
+        <BinUsageSection binId={bin.id} />
+      </section>
     </div>
   );
 }

--- a/src/features/bins/BinDetailTabs.tsx
+++ b/src/features/bins/BinDetailTabs.tsx
@@ -132,9 +132,7 @@ export function BinDetailTabs({
         {tab === 'files' && (
           <BinDetailFilesTab binId={bin.id} photos={photos} canEdit={canEdit} />
         )}
-        {tab === 'information' && (
-          <BinDetailInformationTab bin={bin} checkouts={checkouts} />
-        )}
+        {tab === 'information' && <BinDetailInformationTab bin={bin} />}
       </div>
     </div>
   );

--- a/src/features/bulk-add/__tests__/useBulkGroupAdd.test.ts
+++ b/src/features/bulk-add/__tests__/useBulkGroupAdd.test.ts
@@ -845,3 +845,4 @@ describe('BULK_ADD_STEPS export', () => {
     ]);
   });
 });
+

--- a/src/features/capture/CapturePage.tsx
+++ b/src/features/capture/CapturePage.tsx
@@ -2,9 +2,21 @@ import { Camera, Check, RotateCcw, SwitchCamera } from 'lucide-react';
 import { useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
-import { setCapturedPhotos } from './capturedPhotos';
+import { CapturePageBulkGroup } from './CapturePageBulkGroup';
+import { getCapturedReturnTarget, setCapturedPhotos } from './capturedPhotos';
 import type { CapturedPhoto } from './useCapture';
 import { useCapture } from './useCapture';
+
+type CaptureMode = 'single-bin' | 'bin-create' | 'bulk-group';
+
+function resolveCaptureMode(
+  binId: string | null,
+  returnTarget: ReturnType<typeof getCapturedReturnTarget>,
+): CaptureMode {
+  if (binId) return 'single-bin';
+  if (returnTarget === 'bin-create') return 'bin-create';
+  return 'bulk-group';
+}
 
 function StatusBadge({ photo, onRetry }: { photo: CapturedPhoto; onRetry: () => void }) {
   switch (photo.status) {
@@ -40,10 +52,8 @@ function StatusBadge({ photo, onRetry }: { photo: CapturedPhoto; onRetry: () => 
   }
 }
 
-export function CapturePage() {
+function CapturePageLegacy({ binId }: { binId?: string }) {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const binId = searchParams.get('binId') ?? undefined;
 
   const {
     videoRef,
@@ -175,7 +185,7 @@ export function CapturePage() {
 
             <button
               type="button"
-              onClick={capture}
+              onClick={() => capture()}
               className="h-[68px] w-[68px] rounded-[50%] border-[3px] border-white flex items-center justify-center active:scale-95 transition-transform"
               aria-label="Take photo"
             >
@@ -194,4 +204,16 @@ export function CapturePage() {
       )}
     </div>
   );
+}
+
+export function CapturePage() {
+  const [searchParams] = useSearchParams();
+  const binIdParam = searchParams.get('binId');
+  const mode = resolveCaptureMode(binIdParam, getCapturedReturnTarget());
+
+  if (mode === 'bulk-group') {
+    return <CapturePageBulkGroup />;
+  }
+
+  return <CapturePageLegacy binId={binIdParam ?? undefined} />;
 }

--- a/src/features/capture/CapturePageBulkGroup.tsx
+++ b/src/features/capture/CapturePageBulkGroup.tsx
@@ -1,0 +1,411 @@
+import { Check, Images, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { cn, focusRing } from '@/lib/utils';
+import { setCapturedPhotos, setCapturedReturnTarget } from './capturedPhotos';
+import { useCaptureGrouping } from './useCaptureGrouping';
+
+const LONG_PRESS_MS = 500;
+
+function viewfinderHint(currentGroup: number, photosInCurrentGroup: number): string {
+  if (currentGroup === 0 && photosInCurrentGroup === 0) return 'tap shutter to capture';
+  if (currentGroup === 0 && photosInCurrentGroup > 0) return 'keep shooting — same bin';
+  if (currentGroup > 0 && photosInCurrentGroup === 0) return 'new bin — aim & shoot';
+  return 'Done when finished';
+}
+
+function ThumbnailItem({
+  photo,
+  groupIdx,
+  photoIdx,
+  onRemove,
+}: {
+  photo: { id: string; thumbnailUrl: string };
+  groupIdx: number;
+  photoIdx: number;
+  onRemove: (id: string) => void;
+}) {
+  const [showRemove, setShowRemove] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const liRef = useRef<HTMLLIElement>(null);
+
+  function start() {
+    timerRef.current = window.setTimeout(() => setShowRemove(true), LONG_PRESS_MS);
+  }
+  function cancel() {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }
+
+  // Dismiss the remove overlay when the user taps outside this thumbnail.
+  useEffect(() => {
+    if (!showRemove) return;
+    function handlePointerDown(e: PointerEvent) {
+      if (liRef.current && !liRef.current.contains(e.target as Node)) {
+        setShowRemove(false);
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [showRemove]);
+
+  // Clear any pending long-press timer if the component unmounts mid-press.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <li
+      ref={liRef}
+      aria-label={`Bin ${groupIdx + 1}, photo ${photoIdx + 1}`}
+      className="h-11 w-11 flex-shrink-0 relative"
+      onPointerDown={start}
+      onPointerUp={cancel}
+      onPointerLeave={cancel}
+      onPointerCancel={cancel}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setShowRemove(true);
+      }}
+    >
+      <img
+        src={photo.thumbnailUrl}
+        alt=""
+        className="h-full w-full rounded-[var(--radius-sm)] object-cover"
+      />
+      {showRemove && (
+        <button
+          type="button"
+          onClick={() => {
+            setShowRemove(false);
+            onRemove(photo.id);
+          }}
+          aria-label="Remove photo"
+          className={cn(
+            focusRing,
+            'absolute inset-0 flex items-center justify-center bg-black/60 rounded-[var(--radius-sm)] focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+          )}
+        >
+          <X className="h-4 w-4 text-white" />
+        </button>
+      )}
+    </li>
+  );
+}
+
+export function CapturePageBulkGroup() {
+  const navigate = useNavigate();
+  const {
+    videoRef,
+    isStreaming,
+    error,
+    photos,
+    currentGroup,
+    photosInCurrentGroup,
+    groups,
+    importFiles,
+    capture,
+    nextGroup,
+    removePhoto,
+    startCamera,
+    cleanup,
+  } = useCaptureGrouping();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => cleanup, [cleanup]);
+
+  function handleClose() {
+    if (photos.length > 0) {
+      const ok = window.confirm(`Discard ${photos.length} photo${photos.length === 1 ? '' : 's'}?`);
+      if (!ok) return;
+    }
+    navigate(-1);
+  }
+
+  function handleLibrary() {
+    fileInputRef.current?.click();
+  }
+
+  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    importFiles(Array.from(files));
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }
+
+  function handleDone() {
+    if (photos.length === 0) return;
+    const files: File[] = [];
+    const groupIds: number[] = [];
+    photos.forEach((p, i) => {
+      files.push(new File([p.blob], `capture-${i + 1}.jpg`, { type: 'image/jpeg' }));
+      groupIds.push(p.groupId ?? currentGroup);
+    });
+    setCapturedPhotos(files, groupIds);
+    setCapturedReturnTarget('bulk-add');
+    navigate(-1);
+  }
+
+  const photoLabel = photosInCurrentGroup === 1 ? 'photo' : 'photos';
+  const hasCamera = !!navigator.mediaDevices?.getUserMedia;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-black">
+      {/* Video element — always rendered so ref is available when startCamera fires */}
+      <video
+        ref={videoRef}
+        playsInline
+        muted
+        className="absolute inset-0 h-full w-full object-cover"
+      />
+
+      {!isStreaming && (
+        <div className="absolute inset-0 z-20 flex flex-col bg-[var(--bg-base)] items-center justify-center gap-5 px-6">
+          {!hasCamera ? (
+            <>
+              <h2 className="text-[17px] font-semibold text-[var(--text-primary)] text-center">
+                Camera not available
+              </h2>
+              <p className="text-[14px] text-[var(--text-secondary)] text-center max-w-sm">
+                Your browser does not support camera access. Make sure you are using HTTPS.
+              </p>
+              <button
+                type="button"
+                onClick={() => navigate(-1)}
+                className={cn(
+                  focusRing,
+                  'px-4 py-2 text-[14px] border border-[var(--border-flat)] rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
+                )}
+              >
+                Go Back
+              </button>
+            </>
+          ) : error ? (
+            <>
+              <p className="text-[15px] text-[var(--text-primary)] text-center max-w-sm font-medium">
+                {error}
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => navigate(-1)}
+                  className={cn(
+                    focusRing,
+                    'px-4 py-2 text-[14px] border border-[var(--border-flat)] rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
+                  )}
+                >
+                  Go Back
+                </button>
+                <button
+                  type="button"
+                  onClick={() => startCamera()}
+                  className={cn(
+                    focusRing,
+                    'px-4 py-2 text-[14px] bg-[var(--accent)] text-white rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
+                  )}
+                >
+                  Try Again
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <h2 className="text-[17px] font-semibold text-[var(--text-primary)]">
+                Ready to capture
+              </h2>
+              <p className="text-[14px] text-[var(--text-secondary)] text-center max-w-sm">
+                Tap the button below to start the camera and take photos.
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => navigate(-1)}
+                  className={cn(
+                    focusRing,
+                    'px-4 py-2 text-[14px] border border-[var(--border-flat)] rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
+                  )}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => startCamera()}
+                  className={cn(
+                    focusRing,
+                    'px-4 py-2 text-[14px] bg-[var(--accent)] text-white rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
+                  )}
+                >
+                  Start Camera
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {isStreaming && (
+        <>
+          {/* Top bar */}
+          <div
+            className="relative z-10 flex items-center justify-between px-3 py-2 bg-black/50"
+            style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top, 0.5rem))' }}
+          >
+            <button
+              type="button"
+              onClick={handleClose}
+              className={cn(
+                focusRing,
+                'h-8 w-8 flex items-center justify-center text-white/90 hover:text-white focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
+              aria-label="Close"
+            >
+              <X className="h-5 w-5" />
+            </button>
+
+            <div
+              aria-live="polite"
+              className="text-[11px] font-medium text-white/90 tracking-wide"
+            >
+              Bin #{currentGroup + 1} · {photosInCurrentGroup} {photoLabel}
+            </div>
+
+            <button
+              type="button"
+              onClick={handleLibrary}
+              className={cn(
+                focusRing,
+                'h-8 w-8 flex items-center justify-center text-white/90 hover:text-white focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
+              aria-label="Open photo library"
+            >
+              <Images className="h-5 w-5" />
+            </button>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={handleFileInput}
+            />
+          </div>
+
+          {/* Viewfinder */}
+          <div className="flex-1 relative flex items-center justify-center">
+            <div className="absolute inset-4 border border-dashed border-white/40 pointer-events-none">
+              <div className="absolute -top-px -left-px h-4 w-4 border-t-2 border-l-2 border-[var(--accent)]" />
+              <div className="absolute -top-px -right-px h-4 w-4 border-t-2 border-r-2 border-[var(--accent)]" />
+              <div className="absolute -bottom-px -left-px h-4 w-4 border-b-2 border-l-2 border-[var(--accent)]" />
+              <div className="absolute -bottom-px -right-px h-4 w-4 border-b-2 border-r-2 border-[var(--accent)]" />
+            </div>
+            <p className="relative text-[13px] text-white/55 font-medium text-center px-6">
+              {viewfinderHint(currentGroup, photosInCurrentGroup)}
+            </p>
+          </div>
+          {/* Photo strip */}
+          <div
+            className="relative z-10 bg-black/50 overflow-x-auto overflow-y-hidden"
+            style={{ minHeight: 56 }}
+          >
+            {photos.length === 0 ? (
+              <div className="px-3 py-3 text-[12px] text-white/40 italic">
+                No photos yet
+              </div>
+            ) : (
+              /* Outer wrapper is <div> not <ul>: groups are visual clusters; only photo <li>s are listitems */
+              <div className="flex items-center gap-0 px-3 py-2">
+                {groups.map((group, groupIdx) => (
+                  <div key={group.id} className="flex items-center">
+                    <ul className="flex items-center gap-[2px]">
+                      {group.photos.map((photo, photoIdx) => (
+                        <ThumbnailItem
+                          key={photo.id}
+                          photo={photo}
+                          groupIdx={groupIdx}
+                          photoIdx={photoIdx}
+                          onRemove={removePhoto}
+                        />
+                      ))}
+                    </ul>
+                    {groupIdx < groups.length - 1 && (
+                      <div
+                        data-testid={`group-divider-${group.id}-${groups[groupIdx + 1].id}`}
+                        className="mx-1 h-9 w-[2px] rounded-[1px] bg-[var(--accent)]"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Bottom controls */}
+          <div
+            className="relative z-10 flex items-center justify-between px-4 pt-2 pb-4 bg-black/50"
+            style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom, 1rem))' }}
+          >
+            <button
+              type="button"
+              disabled={photos.length === 0}
+              onClick={handleDone}
+              aria-label="Done"
+              className={cn(
+                focusRing,
+                'w-[54px] text-[13px] focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+                photos.length === 0
+                  ? 'font-medium text-white/35 cursor-not-allowed'
+                  : 'font-semibold text-white hover:text-white/90',
+              )}
+            >
+              Done
+            </button>
+
+            <button
+              type="button"
+              onClick={capture}
+              aria-label="Take photo"
+              className={cn(
+                focusRing,
+                'h-[54px] w-[54px] rounded-[50%] border-[3px] border-white flex items-center justify-center active:scale-95 transition-transform relative focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
+            >
+              <div className="h-[42px] w-[42px] rounded-[50%] bg-white" />
+              {photosInCurrentGroup === 0 && (
+                <div
+                  aria-hidden="true"
+                  className="absolute -inset-1 rounded-[50%] ring-[3px] ring-[var(--accent)]"
+                />
+              )}
+            </button>
+
+            <button
+              type="button"
+              disabled={photosInCurrentGroup === 0}
+              onClick={nextGroup}
+              aria-label="Next bin"
+              className={cn(
+                focusRing,
+                'w-[54px] text-[9px] leading-[1.1] flex flex-col items-center gap-[1px] focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+                photosInCurrentGroup === 0
+                  ? 'text-white/35 cursor-not-allowed'
+                  : 'text-[var(--accent)] font-semibold hover:brightness-125',
+              )}
+            >
+              <Check className="h-3 w-3" aria-hidden="true" />
+              <span>Next</span>
+              <span>bin</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/capture/__tests__/CapturePageBulkGroup.test.tsx
+++ b/src/features/capture/__tests__/CapturePageBulkGroup.test.tsx
@@ -1,0 +1,281 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CapturePageBulkGroup } from '../CapturePageBulkGroup';
+import { takeCapturedPhotos } from '../capturedPhotos';
+
+// Mock the grouping hook to drive the UI deterministically
+const mockHook = {
+  videoRef: { current: null },
+  isStreaming: true,
+  photos: [] as Array<{ id: string; blob: Blob; thumbnailUrl: string; status: string; groupId?: number }>,
+  error: null as string | null,
+  currentGroup: 0,
+  photosInCurrentGroup: 0,
+  groups: [] as Array<{ id: number; photos: Array<{ id: string; blob: Blob; thumbnailUrl: string; status: string; groupId?: number }> }>,
+  startCamera: vi.fn(),
+  stopCamera: vi.fn(),
+  capture: vi.fn(),
+  nextGroup: vi.fn(),
+  importFiles: vi.fn(),
+  cleanup: vi.fn(),
+  removePhoto: vi.fn(),
+};
+
+vi.mock('../useCaptureGrouping', () => ({
+  useCaptureGrouping: () => mockHook,
+}));
+
+beforeEach(() => {
+  mockHook.photos = [];
+  mockHook.currentGroup = 0;
+  mockHook.photosInCurrentGroup = 0;
+  mockHook.groups = [];
+  mockHook.isStreaming = true;
+  mockHook.error = null;
+  mockHook.capture.mockClear();
+  mockHook.nextGroup.mockClear();
+  mockHook.importFiles.mockClear();
+  mockHook.removePhoto.mockClear();
+  // happy-dom doesn't provide navigator.mediaDevices — stub it so the pre-stream
+  // overlay renders the "Ready to capture" / error branches instead of "Camera not available".
+  if (!navigator.mediaDevices) {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn() },
+    });
+  }
+});
+
+function renderUI() {
+  return render(
+    <MemoryRouter>
+      <CapturePageBulkGroup />
+    </MemoryRouter>,
+  );
+}
+
+describe('CapturePageBulkGroup top bar', () => {
+  it('shows Bin #1 · 0 photos at start', () => {
+    renderUI();
+    expect(screen.getByText(/Bin #1/)).toBeTruthy();
+    expect(screen.getByText(/0 photos/)).toBeTruthy();
+  });
+
+  it('shows pluralization correctly at 1 photo', () => {
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    expect(screen.getByText(/1 photo/)).toBeTruthy();
+    expect(screen.queryByText(/1 photos/)).toBeNull();
+  });
+
+  it('increments bin number with currentGroup', () => {
+    mockHook.currentGroup = 4;
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    expect(screen.getByText(/Bin #5/)).toBeTruthy();
+  });
+});
+
+describe('CapturePageBulkGroup viewfinder hint', () => {
+  it('shows "tap shutter to capture" when fresh', () => {
+    renderUI();
+    expect(screen.getByText(/tap shutter to capture/i)).toBeTruthy();
+  });
+
+  it('shows "keep shooting — same bin" while group 0 has photos', () => {
+    mockHook.currentGroup = 0;
+    mockHook.photosInCurrentGroup = 2;
+    renderUI();
+    expect(screen.getByText(/keep shooting/i)).toBeTruthy();
+  });
+
+  it('shows "new bin — aim & shoot" after next bin tapped', () => {
+    mockHook.currentGroup = 1;
+    mockHook.photosInCurrentGroup = 0;
+    renderUI();
+    expect(screen.getByText(/new bin/i)).toBeTruthy();
+  });
+
+  it('shows "Done when finished" with multi-bin progress', () => {
+    mockHook.currentGroup = 3;
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    expect(screen.getByText(/done when finished/i)).toBeTruthy();
+  });
+});
+
+describe('CapturePageBulkGroup photo strip', () => {
+  it('shows empty placeholder when no photos', () => {
+    renderUI();
+    expect(screen.getByText(/no photos yet/i)).toBeTruthy();
+  });
+
+  it('renders one thumbnail per photo', () => {
+    const blob = new Blob();
+    mockHook.groups = [
+      {
+        id: 0,
+        photos: [
+          { id: 'p1', blob, thumbnailUrl: 'blob:p1', status: 'uploaded', groupId: 0 },
+          { id: 'p2', blob, thumbnailUrl: 'blob:p2', status: 'uploaded', groupId: 0 },
+        ],
+      },
+    ];
+    mockHook.photos = mockHook.groups.flatMap((g) => g.photos);
+    renderUI();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('renders a divider between groups', () => {
+    const blob = new Blob();
+    mockHook.groups = [
+      {
+        id: 0,
+        photos: [{ id: 'p1', blob, thumbnailUrl: 'blob:p1', status: 'uploaded', groupId: 0 }],
+      },
+      {
+        id: 1,
+        photos: [{ id: 'p2', blob, thumbnailUrl: 'blob:p2', status: 'uploaded', groupId: 1 }],
+      },
+    ];
+    mockHook.photos = mockHook.groups.flatMap((g) => g.photos);
+    renderUI();
+    expect(screen.getByTestId('group-divider-0-1')).toBeTruthy();
+  });
+});
+
+describe('CapturePageBulkGroup bottom controls', () => {
+  beforeEach(() => {
+    takeCapturedPhotos(); // reset store between tests
+  });
+
+  it('Done is disabled when no photos', () => {
+    renderUI();
+    const done = screen.getByRole('button', { name: /^done$/i });
+    expect(done.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('Done is enabled with photos', () => {
+    mockHook.photos = [
+      { id: 'p1', blob: new Blob(), thumbnailUrl: 'blob:p1', status: 'uploaded', groupId: 0 },
+    ];
+    mockHook.groups = [{ id: 0, photos: mockHook.photos }];
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    const done = screen.getByRole('button', { name: /^done$/i });
+    expect(done.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('Next bin is disabled when current group empty', () => {
+    renderUI();
+    const nextBtn = screen.getByRole('button', { name: /^next bin$/i });
+    expect(nextBtn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('Next bin is enabled when current group has photos', () => {
+    mockHook.photos = [
+      { id: 'p1', blob: new Blob(), thumbnailUrl: 'blob:p1', status: 'uploaded', groupId: 0 },
+    ];
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    const nextBtn = screen.getByRole('button', { name: /^next bin$/i });
+    expect(nextBtn.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('tapping Next bin calls hook.nextGroup', () => {
+    mockHook.photos = [
+      { id: 'p1', blob: new Blob(), thumbnailUrl: 'blob:p1', status: 'uploaded', groupId: 0 },
+    ];
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    fireEvent.click(screen.getByRole('button', { name: /^next bin$/i }));
+    expect(mockHook.nextGroup).toHaveBeenCalled();
+  });
+
+  it('tapping shutter calls hook.capture', () => {
+    renderUI();
+    fireEvent.click(screen.getByRole('button', { name: /take photo/i }));
+    expect(mockHook.capture).toHaveBeenCalled();
+  });
+
+  it('Done packages photos+groups into capturedPhotos store', () => {
+    const blob1 = new Blob(['a'], { type: 'image/jpeg' });
+    const blob2 = new Blob(['b'], { type: 'image/jpeg' });
+    mockHook.photos = [
+      { id: 'p1', blob: blob1, thumbnailUrl: 'blob:p1', status: 'uploaded', groupId: 0 },
+      { id: 'p2', blob: blob2, thumbnailUrl: 'blob:p2', status: 'uploaded', groupId: 1 },
+    ];
+    mockHook.groups = [
+      { id: 0, photos: [mockHook.photos[0]] },
+      { id: 1, photos: [mockHook.photos[1]] },
+    ];
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+    fireEvent.click(screen.getByRole('button', { name: /^done$/i }));
+
+    const taken = takeCapturedPhotos();
+    expect(taken.files).toHaveLength(2);
+    expect(taken.groups).toEqual([0, 1]);
+  });
+});
+
+describe('CapturePageBulkGroup long-press removal', () => {
+  it('long-press on thumbnail reveals a remove button', () => {
+    vi.useFakeTimers();
+    const blob = new Blob();
+    const photo = { id: 'p1', blob, thumbnailUrl: 'blob:p1', status: 'uploaded' as const, groupId: 0 };
+    mockHook.photos = [photo];
+    mockHook.groups = [{ id: 0, photos: [photo] }];
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+
+    const thumb = screen.getByLabelText(/Bin 1, photo 1/i);
+    fireEvent.pointerDown(thumb);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    const removeBtn = screen.getByRole('button', { name: /remove photo/i });
+    expect(removeBtn).toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it('tapping remove calls hook.removePhoto', () => {
+    vi.useFakeTimers();
+    const blob = new Blob();
+    const photo = { id: 'p1', blob, thumbnailUrl: 'blob:p1', status: 'uploaded' as const, groupId: 0 };
+    mockHook.photos = [photo];
+    mockHook.groups = [{ id: 0, photos: [photo] }];
+    mockHook.photosInCurrentGroup = 1;
+    renderUI();
+
+    const thumb = screen.getByLabelText(/Bin 1, photo 1/i);
+    fireEvent.pointerDown(thumb);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    const removeBtn = screen.getByRole('button', { name: /remove photo/i });
+    fireEvent.click(removeBtn);
+
+    expect(mockHook.removePhoto).toHaveBeenCalledWith('p1');
+    vi.useRealTimers();
+  });
+});
+
+describe('CapturePageBulkGroup pre-stream', () => {
+  it('shows start camera screen before streaming', () => {
+    mockHook.isStreaming = false;
+    renderUI();
+    expect(screen.getByText(/ready to capture/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /start camera/i })).toBeTruthy();
+  });
+
+  it('shows error screen when error is set', () => {
+    mockHook.isStreaming = false;
+    mockHook.error = 'Camera access denied.';
+    renderUI();
+    expect(screen.getByText(/camera access denied/i)).toBeTruthy();
+  });
+});

--- a/src/features/capture/__tests__/bulkGroupHandoff.test.tsx
+++ b/src/features/capture/__tests__/bulkGroupHandoff.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { initBulkAddStateFromFiles } from '@/features/ai/PhotoBulkAdd';
+import {
+  getCapturedReturnTarget,
+  setCapturedPhotos,
+  setCapturedReturnTarget,
+  takeCapturedPhotos,
+} from '../capturedPhotos';
+
+describe('bulk-group camera → PhotoBulkAdd handoff', () => {
+  it('round-trips grouped photos from capture to PhotoBulkAdd state', () => {
+    const files = [
+      new File(['a'], 'bin1-photo1.jpg', { type: 'image/jpeg' }),
+      new File(['b'], 'bin1-photo2.jpg', { type: 'image/jpeg' }),
+      new File(['c'], 'bin2-photo1.jpg', { type: 'image/jpeg' }),
+    ];
+    const groupIds = [0, 0, 1];
+
+    setCapturedPhotos(files, groupIds);
+    setCapturedReturnTarget('bulk-add');
+
+    expect(getCapturedReturnTarget()).toBe('bulk-add');
+    const taken = takeCapturedPhotos();
+    expect(taken.files).toEqual(files);
+    expect(taken.groups).toEqual(groupIds);
+
+    const state = initBulkAddStateFromFiles(taken.files, taken.groups);
+    expect(state.groups).toHaveLength(2);
+    expect(state.groups[0].photos).toHaveLength(2);
+    expect(state.groups[0].photos[0].file.name).toBe('bin1-photo1.jpg');
+    expect(state.groups[0].photos[1].file.name).toBe('bin1-photo2.jpg');
+    expect(state.groups[1].photos).toHaveLength(1);
+    expect(state.groups[1].photos[0].file.name).toBe('bin2-photo1.jpg');
+  });
+
+  it('handles flat handoff (no grouping) for gallery-upload compatibility', () => {
+    const files = [
+      new File(['a'], 'a.jpg', { type: 'image/jpeg' }),
+      new File(['b'], 'b.jpg', { type: 'image/jpeg' }),
+    ];
+    setCapturedPhotos(files);
+    const taken = takeCapturedPhotos();
+    expect(taken.groups).toBeNull();
+
+    const state = initBulkAddStateFromFiles(taken.files, taken.groups);
+    expect(state.groups).toHaveLength(2); // one group per photo (legacy behavior)
+  });
+});

--- a/src/features/capture/__tests__/capturedPhotos.test.ts
+++ b/src/features/capture/__tests__/capturedPhotos.test.ts
@@ -23,19 +23,50 @@ describe('capturedPhotos store', () => {
     expect(hasCapturedPhotos()).toBe(true);
   });
 
-  it('takeCapturedPhotos returns and clears photos', () => {
+  it('takeCapturedPhotos returns files and null groups when no grouping provided', () => {
     const files = [new File(['x'], 'x.jpg')];
     setCapturedPhotos(files);
 
     const taken = takeCapturedPhotos();
-    expect(taken).toHaveLength(1);
-    expect(taken[0].name).toBe('x.jpg');
-
-    expect(hasCapturedPhotos()).toBe(false);
-    expect(takeCapturedPhotos()).toHaveLength(0);
+    expect(taken.files).toHaveLength(1);
+    expect(taken.files[0].name).toBe('x.jpg');
+    expect(taken.groups).toBeNull();
   });
 
-  it('manages return target', () => {
+  it('takeCapturedPhotos clears pending on subsequent calls', () => {
+    setCapturedPhotos([new File(['y'], 'y.jpg')]);
+
+    takeCapturedPhotos();
+
+    expect(hasCapturedPhotos()).toBe(false);
+    const empty = takeCapturedPhotos();
+    expect(empty.files).toHaveLength(0);
+    expect(empty.groups).toBeNull();
+  });
+
+  it('round-trips a parallel groups array', () => {
+    const files = [
+      new File(['a'], 'a.jpg'),
+      new File(['b'], 'b.jpg'),
+      new File(['c'], 'c.jpg'),
+    ];
+    setCapturedPhotos(files, [0, 0, 1]);
+
+    const taken = takeCapturedPhotos();
+    expect(taken.files).toHaveLength(3);
+    expect(taken.groups).toEqual([0, 0, 1]);
+  });
+
+  it('clears groups on take', () => {
+    setCapturedPhotos([new File([''], 'f.jpg')], [5]);
+    takeCapturedPhotos();
+
+    const empty = takeCapturedPhotos();
+    expect(empty.files).toHaveLength(0);
+    expect(empty.groups).toBeNull();
+  });
+
+  it('manages bin-create return target', () => {
     expect(getCapturedReturnTarget()).toBeNull();
 
     setCapturedReturnTarget('bin-create');
@@ -45,9 +76,14 @@ describe('capturedPhotos store', () => {
     expect(getCapturedReturnTarget()).toBeNull();
   });
 
+  it('manages bulk-add return target', () => {
+    setCapturedReturnTarget('bulk-add');
+    expect(getCapturedReturnTarget()).toBe('bulk-add');
+  });
+
   it('takeCapturedPhotos resets return target', () => {
-    setCapturedReturnTarget('bin-create');
-    setCapturedPhotos([new File([''], 'f.jpg')]);
+    setCapturedReturnTarget('bulk-add');
+    setCapturedPhotos([new File([''], 'f.jpg')], [0]);
 
     takeCapturedPhotos();
 

--- a/src/features/capture/__tests__/useCaptureGrouping.test.ts
+++ b/src/features/capture/__tests__/useCaptureGrouping.test.ts
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCaptureGrouping } from '../useCaptureGrouping';
+
+// Mock useCapture so we can control its returned photo list deterministically
+let mockPhotos: Array<{ id: string; groupId?: number; status: string; blob: Blob; thumbnailUrl: string }> = [];
+const mockCapture = vi.fn();
+const mockAppendImported = vi.fn((blob: Blob, groupId?: number) => {
+  const id = `import-${mockPhotos.length}`;
+  mockPhotos.push({ id, groupId, status: 'uploaded', blob, thumbnailUrl: `blob:${id}` });
+});
+const mockRemovePhoto = vi.fn((id: string) => {
+  mockPhotos = mockPhotos.filter((p) => p.id !== id);
+});
+
+vi.mock('../useCapture', () => ({
+  useCapture: () => ({
+    videoRef: { current: null },
+    isStreaming: true,
+    facingMode: 'environment',
+    photos: mockPhotos,
+    error: null,
+    startCamera: vi.fn(),
+    stopCamera: vi.fn(),
+    flipCamera: vi.fn(),
+    capture: mockCapture,
+    retryUpload: vi.fn(),
+    appendImportedPhoto: mockAppendImported,
+    removePhoto: mockRemovePhoto,
+    cleanup: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  mockPhotos = [];
+  mockCapture.mockClear();
+  mockAppendImported.mockClear();
+  mockRemovePhoto.mockClear();
+});
+
+describe('useCaptureGrouping', () => {
+  it('starts with currentGroup = 0', () => {
+    const { result } = renderHook(() => useCaptureGrouping());
+    expect(result.current.currentGroup).toBe(0);
+  });
+
+  it('nextGroup() increments currentGroup', () => {
+    const { result } = renderHook(() => useCaptureGrouping());
+    act(() => {
+      result.current.nextGroup();
+    });
+    expect(result.current.currentGroup).toBe(1);
+    act(() => {
+      result.current.nextGroup();
+    });
+    expect(result.current.currentGroup).toBe(2);
+  });
+});
+
+describe('useCaptureGrouping capture stamping', () => {
+  it('passes currentGroup to underlying capture()', () => {
+    const { result } = renderHook(() => useCaptureGrouping());
+    act(() => {
+      result.current.capture();
+    });
+    expect(mockCapture).toHaveBeenCalledWith(0);
+  });
+
+  it('passes new currentGroup after nextGroup()', () => {
+    const { result } = renderHook(() => useCaptureGrouping());
+    act(() => {
+      result.current.nextGroup();
+    });
+    act(() => {
+      result.current.capture();
+    });
+    expect(mockCapture).toHaveBeenLastCalledWith(1);
+  });
+
+  it('exposes photosInCurrentGroup count', () => {
+    const { result, rerender } = renderHook(() => useCaptureGrouping());
+    mockPhotos = [
+      { id: 'p1', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p1' },
+      { id: 'p2', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p2' },
+    ];
+    rerender();
+    expect(result.current.photosInCurrentGroup).toBe(2);
+
+    act(() => {
+      result.current.nextGroup();
+    });
+    expect(result.current.photosInCurrentGroup).toBe(0);
+  });
+});
+
+describe('useCaptureGrouping derived groups', () => {
+  it('buckets photos into groups in insertion order', () => {
+    const { result, rerender } = renderHook(() => useCaptureGrouping());
+    mockPhotos = [
+      { id: 'p1', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p1' },
+      { id: 'p2', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p2' },
+      { id: 'p3', groupId: 1, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p3' },
+    ];
+    rerender();
+    expect(result.current.groups).toHaveLength(2);
+    expect(result.current.groups[0].photos.map((p) => p.id)).toEqual(['p1', 'p2']);
+    expect(result.current.groups[1].photos.map((p) => p.id)).toEqual(['p3']);
+  });
+
+  it('orders groups by first-seen insertion order (not numeric groupId)', () => {
+    const { result, rerender } = renderHook(() => useCaptureGrouping());
+    mockPhotos = [
+      { id: 'p1', groupId: 2, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p1' },
+      { id: 'p2', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p2' },
+    ];
+    rerender();
+    expect(result.current.groups[0].id).toBe(2);
+    expect(result.current.groups[1].id).toBe(0);
+  });
+
+  it('excludes photos without a groupId from derived groups', () => {
+    const { result, rerender } = renderHook(() => useCaptureGrouping());
+    mockPhotos = [
+      { id: 'p1', status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p1' },
+    ];
+    rerender();
+    expect(result.current.groups).toHaveLength(0);
+  });
+});
+
+describe('useCaptureGrouping importFiles', () => {
+  it('appends files into the current group', () => {
+    const { result } = renderHook(() => useCaptureGrouping());
+    act(() => {
+      result.current.importFiles([
+        new File(['a'], 'a.jpg', { type: 'image/jpeg' }),
+      ]);
+    });
+    expect(mockAppendImported).toHaveBeenCalledTimes(1);
+    expect(mockAppendImported).toHaveBeenCalledWith(expect.any(File), 0);
+  });
+
+  it('stamps imported files with the current group', () => {
+    const { result } = renderHook(() => useCaptureGrouping());
+    act(() => {
+      result.current.nextGroup();
+    });
+    act(() => {
+      result.current.importFiles([
+        new File(['a'], 'a.jpg', { type: 'image/jpeg' }),
+      ]);
+    });
+    expect(mockAppendImported).toHaveBeenCalledWith(expect.any(File), 1);
+  });
+});
+
+describe('useCaptureGrouping removePhoto', () => {
+  it('forwards removePhoto to useCapture', () => {
+    mockPhotos = [
+      { id: 'p1', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p1' },
+      { id: 'p2', groupId: 0, status: 'uploaded', blob: new Blob(), thumbnailUrl: 'blob:p2' },
+    ];
+    const { result, rerender } = renderHook(() => useCaptureGrouping());
+    rerender();
+    act(() => {
+      result.current.removePhoto('p1');
+    });
+    expect(mockRemovePhoto).toHaveBeenCalledWith('p1');
+  });
+});

--- a/src/features/capture/capturedPhotos.ts
+++ b/src/features/capture/capturedPhotos.ts
@@ -1,23 +1,32 @@
 /**
  * Module-level store for passing captured photos from the CapturePage
- * back to the AI CommandInput dialog without shared React state.
+ * back to downstream consumers without shared React state.
  *
  * returnTarget controls which consumer picks up the photos:
- * - null (default) → useAutoOpenOnCapture opens CommandInput
+ * - null (default) → useAutoOpenOnCapture opens CommandInput with a flat list
  * - 'bin-create'   → BinCreateForm picks them up, CommandInput ignores
+ * - 'bulk-add'     → ConversationUI hands them to PhotoBulkAdd with pre-grouped state
+ *
+ * `pendingGroups` is a parallel array where `pendingGroups[i]` is the groupId of
+ * `pending[i]`. Set only when the camera ran in `bulk-group` mode; flat captures
+ * (single-bin / bin-create / gallery upload) leave it null.
  */
 let pending: File[] = [];
-let returnTarget: 'bin-create' | null = null;
+let pendingGroups: number[] | null = null;
+let returnTarget: 'bin-create' | 'bulk-add' | null = null;
 
-export function setCapturedPhotos(files: File[]): void {
+export type CapturedReturnTarget = 'bin-create' | 'bulk-add' | null;
+
+export function setCapturedPhotos(files: File[], groups?: number[]): void {
 	pending = files;
+	pendingGroups = groups ?? null;
 }
 
-export function setCapturedReturnTarget(target: 'bin-create' | null): void {
+export function setCapturedReturnTarget(target: CapturedReturnTarget): void {
 	returnTarget = target;
 }
 
-export function getCapturedReturnTarget(): 'bin-create' | null {
+export function getCapturedReturnTarget(): CapturedReturnTarget {
 	return returnTarget;
 }
 
@@ -25,9 +34,11 @@ export function hasCapturedPhotos(): boolean {
 	return pending.length > 0;
 }
 
-export function takeCapturedPhotos(): File[] {
+export function takeCapturedPhotos(): { files: File[]; groups: number[] | null } {
 	const files = pending;
+	const groups = pendingGroups;
 	pending = [];
+	pendingGroups = null;
 	returnTarget = null;
-	return files;
+	return { files, groups };
 }

--- a/src/features/capture/useCapture.ts
+++ b/src/features/capture/useCapture.ts
@@ -9,6 +9,7 @@ export interface CapturedPhoto {
   blob: Blob;
   thumbnailUrl: string;
   status: PhotoStatus;
+  groupId?: number;
   error?: string;
 }
 
@@ -135,37 +136,41 @@ export function useCapture(binId?: string) {
     startCamera(newFacing);
   }, [facingMode, stopCamera, startCamera]);
 
-  const capture = useCallback(() => {
-    const video = videoRef.current;
-    if (!video || !isStreaming || video.videoWidth === 0) return;
+  const capture = useCallback(
+    (groupId?: number) => {
+      const video = videoRef.current;
+      if (!video || !isStreaming || video.videoWidth === 0) return;
 
-    const canvas = document.createElement('canvas');
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
 
-    ctx.drawImage(video, 0, 0);
-    canvas.toBlob(
-      (blob) => {
-        if (!blob) return;
-        const id = `capture-${nextId.current++}`;
-        const thumbnailUrl = URL.createObjectURL(blob);
-        const photo: CapturedPhoto = {
-          id,
-          blob,
-          thumbnailUrl,
-          status: binId ? 'pending' : 'uploaded',
-        };
-        updatePhotos((prev) => [...prev, photo]);
-        if (binId) {
-          doUpload(photo, binId);
-        }
-      },
-      'image/jpeg',
-      0.92,
-    );
-  }, [isStreaming, binId, updatePhotos, doUpload]);
+      ctx.drawImage(video, 0, 0);
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) return;
+          const id = `capture-${nextId.current++}`;
+          const thumbnailUrl = URL.createObjectURL(blob);
+          const photo: CapturedPhoto = {
+            id,
+            blob,
+            thumbnailUrl,
+            status: binId ? 'pending' : 'uploaded',
+            groupId,
+          };
+          updatePhotos((prev) => [...prev, photo]);
+          if (binId) {
+            doUpload(photo, binId);
+          }
+        },
+        'image/jpeg',
+        0.92,
+      );
+    },
+    [isStreaming, binId, updatePhotos, doUpload],
+  );
 
   const retryUpload = useCallback(
     (photoId: string) => {
@@ -186,6 +191,42 @@ export function useCapture(binId?: string) {
     }
   }, [stopCamera]);
 
+  const setPhotoGroupId = useCallback(
+    (photoId: string, groupId: number) => {
+      updatePhotos((prev) =>
+        prev.map((p) => (p.id === photoId ? { ...p, groupId } : p)),
+      );
+    },
+    [updatePhotos],
+  );
+
+  const appendImportedPhoto = useCallback(
+    (blob: Blob, groupId?: number) => {
+      const id = `import-${nextId.current++}`;
+      const thumbnailUrl = URL.createObjectURL(blob);
+      const photo: CapturedPhoto = {
+        id,
+        blob,
+        thumbnailUrl,
+        status: 'uploaded',
+        groupId,
+      };
+      updatePhotos((prev) => [...prev, photo]);
+    },
+    [updatePhotos],
+  );
+
+  const removePhoto = useCallback(
+    (photoId: string) => {
+      updatePhotos((prev) => {
+        const target = prev.find((p) => p.id === photoId);
+        if (target) URL.revokeObjectURL(target.thumbnailUrl);
+        return prev.filter((p) => p.id !== photoId);
+      });
+    },
+    [updatePhotos],
+  );
+
   return {
     videoRef,
     isStreaming,
@@ -197,6 +238,9 @@ export function useCapture(binId?: string) {
     flipCamera,
     capture,
     retryUpload,
+    setPhotoGroupId,
+    appendImportedPhoto,
+    removePhoto,
     cleanup,
   };
 }

--- a/src/features/capture/useCaptureGrouping.ts
+++ b/src/features/capture/useCaptureGrouping.ts
@@ -1,0 +1,67 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { CapturedPhoto } from './useCapture';
+import { useCapture } from './useCapture';
+
+export interface CaptureGroup {
+  id: number;
+  photos: CapturedPhoto[];
+}
+
+export function useCaptureGrouping(binId?: string) {
+  const baseCapture = useCapture(binId);
+  const [currentGroup, setCurrentGroup] = useState(0);
+
+  const capture = useCallback(() => {
+    baseCapture.capture(currentGroup);
+  }, [baseCapture.capture, currentGroup]);
+
+  const importFiles = useCallback(
+    (files: File[]) => {
+      for (const file of files) {
+        baseCapture.appendImportedPhoto(file, currentGroup);
+      }
+    },
+    [baseCapture.appendImportedPhoto, currentGroup],
+  );
+
+  const nextGroup = useCallback(() => {
+    setCurrentGroup((g) => g + 1);
+  }, []);
+
+  const photosInCurrentGroup = useMemo(
+    () => baseCapture.photos.filter((p) => p.groupId === currentGroup).length,
+    [baseCapture.photos, currentGroup],
+  );
+
+  const groups = useMemo<CaptureGroup[]>(() => {
+    const order: number[] = [];
+    const buckets = new Map<number, CapturedPhoto[]>();
+    for (const photo of baseCapture.photos) {
+      if (photo.groupId === undefined) continue;
+      let bucket = buckets.get(photo.groupId);
+      if (!bucket) {
+        bucket = [];
+        buckets.set(photo.groupId, bucket);
+        order.push(photo.groupId);
+      }
+      bucket.push(photo);
+    }
+    return order.map((id) => ({ id, photos: buckets.get(id) ?? [] }));
+  }, [baseCapture.photos]);
+
+  return {
+    videoRef: baseCapture.videoRef,
+    isStreaming: baseCapture.isStreaming,
+    error: baseCapture.error,
+    photos: baseCapture.photos,
+    startCamera: baseCapture.startCamera,
+    cleanup: baseCapture.cleanup,
+    removePhoto: baseCapture.removePhoto,
+    capture,
+    currentGroup,
+    nextGroup,
+    photosInCurrentGroup,
+    groups,
+    importFiles,
+  };
+}

--- a/src/features/dashboard/DashboardMonthHeatmap.tsx
+++ b/src/features/dashboard/DashboardMonthHeatmap.tsx
@@ -2,8 +2,8 @@ import { Flame } from 'lucide-react';
 import { useMemo } from 'react';
 import { Tooltip } from '@/components/ui/tooltip';
 import {
-  HEATMAP_OPACITY_BY_STEP,
   heatmapCellColor,
+  INTENSITY_STEPS,
   type Intensity,
   intensityStep,
   toIsoUtc,
@@ -23,8 +23,6 @@ const DATE_FMT = new Intl.DateTimeFormat(undefined, {
 });
 
 const WEEKDAY_FMT = new Intl.DateTimeFormat(undefined, { weekday: 'short', timeZone: 'UTC' });
-
-const INTENSITY_STEPS: readonly Intensity[] = HEATMAP_OPACITY_BY_STEP.map((_, i) => i as Intensity);
 
 interface DayCell {
   iso: string;

--- a/src/features/usage/BinUsageSection.tsx
+++ b/src/features/usage/BinUsageSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useUserPreferences } from '@/lib/userPreferences';
-import { plural } from '@/lib/utils';
+import { flatCard, plural } from '@/lib/utils';
 import { GranularitySegmented } from './GranularitySegmented';
 import { InlineRetryError, UsageHeatmap, UsageHeatmapSkeleton } from './UsageHeatmap';
 import { availableYears, yearOf } from './usageBuckets';
@@ -51,39 +51,51 @@ export function BinUsageSection({ binId }: BinUsageSectionProps) {
     return count;
   }, [usage, selectedYear]);
 
+  if (isLoading) {
+    return (
+      <div className={`${flatCard} p-4`}>
+        <UsageHeatmapSkeleton />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <InlineRetryError
+        title="Couldn't load usage data"
+        detail={error}
+        onRetry={refresh}
+        className="py-1"
+      />
+    );
+  }
+
+  if (usage.length === 0) {
+    return (
+      <p className="text-[12px] text-[var(--text-tertiary)] leading-relaxed py-1">
+        No activity yet. Choose which actions count in{' '}
+        <Link to="/settings/preferences" className="underline text-[var(--accent)]">preferences</Link>.
+      </p>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-3">
-      {isLoading ? (
-        <UsageHeatmapSkeleton />
-      ) : error ? (
-        <InlineRetryError
-          title="Couldn't load usage data"
-          detail={error}
-          onRetry={refresh}
-          className="py-1"
+      <p className="text-[12px] text-[var(--text-secondary)] tabular-nums">
+        {activeInYear} active {plural(activeInYear, 'day')} in {selectedYear}
+        {lastUse ? ` · last used ${formatRelativeFromNow(lastUse)}` : ''}
+      </p>
+      <div className={`${flatCard} p-4 flex flex-col gap-3`}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <GranularitySegmented />
+          <YearChipPager years={years} selected={selectedYear} onSelect={setYear} />
+        </div>
+        <UsageHeatmap
+          data={usage}
+          year={selectedYear}
+          granularity={preferences.usage_granularity}
         />
-      ) : usage.length === 0 ? (
-        <p className="text-[12px] text-[var(--text-tertiary)] leading-relaxed py-1">
-          No activity yet. Choose which actions count in{' '}
-          <Link to="/settings/preferences" className="underline text-[var(--accent)]">preferences</Link>.
-        </p>
-      ) : (
-        <>
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <GranularitySegmented />
-            <YearChipPager years={years} selected={selectedYear} onSelect={setYear} />
-          </div>
-          <UsageHeatmap
-            data={usage}
-            year={selectedYear}
-            granularity={preferences.usage_granularity}
-          />
-          <p className="text-[11px] text-[var(--text-tertiary)] tabular-nums">
-            {activeInYear} active {plural(activeInYear, 'day')} in {selectedYear}
-            {lastUse ? ` · last used ${formatRelativeFromNow(lastUse)}` : ''}
-          </p>
-        </>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/features/usage/UsageHeatmap.tsx
+++ b/src/features/usage/UsageHeatmap.tsx
@@ -435,7 +435,7 @@ export function UsageHeatmapSkeleton() {
                   // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton, never reordered
                   key={i}
                   className="rounded-full animate-pulse motion-reduce:animate-none"
-                  style={{ backgroundColor: 'var(--border-subtle)', width: CELL_SIZE, height: CELL_SIZE }}
+                  style={{ backgroundColor: 'var(--heatmap-cell-0)', width: CELL_SIZE, height: CELL_SIZE }}
                 />
               ))}
             </div>

--- a/src/features/usage/usageBuckets.ts
+++ b/src/features/usage/usageBuckets.ts
@@ -35,13 +35,10 @@ export function toIsoUtc(date: Date): string {
 
 export type Intensity = 0 | 1 | 2 | 3;
 
-export const HEATMAP_OPACITY_BY_STEP: readonly number[] = [0, 0.22, 0.48, 0.82];
+export const INTENSITY_STEPS: readonly Intensity[] = [0, 1, 2, 3];
 
-/** Accent color-mix string for a given intensity step; step 0 falls back to the subtle border token. */
 export function heatmapCellColor(intensity: Intensity): string {
-  if (intensity === 0) return 'var(--border-subtle)';
-  const pct = Math.round(HEATMAP_OPACITY_BY_STEP[intensity] * 100);
-  return `color-mix(in srgb, var(--accent) ${pct}%, transparent)`;
+  return `var(--heatmap-cell-${intensity})`;
 }
 
 export function availableYears(data: { date: string }[]): number[] {

--- a/src/index.css
+++ b/src/index.css
@@ -51,6 +51,10 @@
   --text-on-accent: #ffffff;
   --accent: #5e2fe0;
   --accent-hover: #4e1fd0;
+  --heatmap-cell-0: var(--border-subtle);
+  --heatmap-cell-1: color-mix(in srgb, var(--accent) 22%, transparent);
+  --heatmap-cell-2: color-mix(in srgb, var(--accent) 48%, transparent);
+  --heatmap-cell-3: color-mix(in srgb, var(--accent) 82%, transparent);
   --destructive: #db2b2b;
   --destructive-hover: #c42020;
   --shadow-flat: none;
@@ -112,6 +116,12 @@
   --text-on-accent: #ffffff;
   --accent: #7b52f5;
   --accent-hover: #9b7af7;
+  /* Hand-tuned opaque ramp: translucent accent over dark bg flattens
+     step 1 to near-L0 luminance. Re-tune alongside --accent on rebrand. */
+  --heatmap-cell-0: #2d2d2d;
+  --heatmap-cell-1: #4a2e91;
+  --heatmap-cell-2: #6d4ad8;
+  --heatmap-cell-3: #9b7af7;
   --destructive: #ff453a;
   --destructive-hover: #ff6961;
   --shadow-flat: none;


### PR DESCRIPTION
## Summary

- Adds a new bulk-group capture mode so one camera session can gather photos for multiple bins, stamping each shot with a `groupId` that survives the handoff into `PhotoBulkAdd`.
- Ships the full vertical slice: `capturedPhotos` store extension → `useCaptureGrouping` hook → `CapturePageBulkGroup` UI → `PhotoBulkAdd` `initialGroups` support.

## Scope note

The last two commits (heatmap CSS tokens, Bin Detail Information tab restructure + `BinUsageSection` polish) are unrelated to the capture feature but travelled with this branch. They can be split back out on request.

## Commits

- `feat: extend capturedPhotos store with groups and return target`
- `feat: useCaptureGrouping stamps groupId on captured photos`
- `feat: CapturePageBulkGroup — camera UI for grouped capture`
- `feat: forward captured groups from capture into PhotoBulkAdd`
- `refactor: drive heatmap cell colors from CSS tokens`
- `refactor: restructure bin detail Information tab`

## Test plan

- [ ] Open `/capture` with no `binId` → lands in bulk-group mode, viewfinder brackets + hints render
- [ ] Capture several photos, tap **Next bin**, capture more → photo strip shows a divider between groups
- [ ] Long-press a thumbnail → photo removed from its group
- [ ] Tap **Done** → lands in `PhotoBulkAdd` with groups preserved (no manual re-grouping)
- [ ] Deny camera / block stream → pre-stream error overlay shows, retry recovers without remounting the video element
- [ ] Legacy flows: `/capture?binId=…` and bin-create return target still dispatch to `CapturePageLegacy`
- [ ] Dark mode: heatmap cells in Dashboard + Bin Usage use the tuned opaque ramp (step 1 no longer blends into background)
- [ ] Bin detail Information tab: Details (with smaller QR) → Activity (with centered "Show all events" link) → Usage (in flat card) reads correctly at mobile width
- [ ] `npm run check` passes