### PR TITLE
feat: add shopping list with flat table UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@
 # ── Upload Limits ─────────────────────────────
 # MAX_PHOTO_SIZE_MB=5                # 1–50 MB per photo upload
 # MAX_PHOTOS_PER_BIN=1               # Max photos per bin (1–100)
-# ATTACHMENTS_ENABLED=false          # Enable non-image file attachments on bins (PDFs, docs, archives — 5 MB cap)
+# ATTACHMENTS_ENABLED=true           # Non-image file attachments on bins (PDFs, docs, archives — 5 MB cap). Set to false to disable.
 
 # ── AI Provider (server-wide fallback) ────────
 # When set, all users get AI features without configuring their own keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ OpenAPI spec at `server/openapi.yaml`.
 
 ## Gotchas
 
-- **Attachments feature flag**: `ATTACHMENTS_ENABLED` (default `false`) gates the non-image attachments routes. When off, every `/api/bins/:id/attachments` and `/api/attachments/:id/*` endpoint 404s; the table is always created but unused. Client reads it from `/api/auth/status` via `isAttachmentsEnabled()` in `src/lib/qrConfig.ts`.
+- **Attachments feature flag**: `ATTACHMENTS_ENABLED` (default `true`) gates the non-image attachments routes. When set to `false`, every `/api/bins/:id/attachments` and `/api/attachments/:id/*` endpoint 404s; the table is always created. Client reads it from `/api/auth/status` via `isAttachmentsEnabled()` in `src/lib/qrConfig.ts`.
 - **Theme**: `localStorage('openbin-theme')`, applied via `<html class="dark|light">` before first paint. `useTheme()` in `lib/theme.ts` is runtime source of truth.
 - **`html5-qrcode`** is ~330KB gzipped — always dynamic-import the scanner page.
 - **Photos served via API**: `getPhotoUrl(id)` → `/api/photos/${id}/file`. Auth via httpOnly cookies (no query param).

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -773,6 +773,39 @@ components:
             checked_out_by_name:
               type: string
 
+    # ── Shopping List ─────────────────────────────────────
+    ShoppingListEntry:
+      type: object
+      required: [id, location_id, name, origin_bin_id, origin_bin_trashed, created_by, created_by_name, created_at]
+      properties:
+        id:
+          type: string
+        location_id:
+          type: string
+        name:
+          type: string
+        origin_bin_id:
+          type: string
+          nullable: true
+        origin_bin_name:
+          type: string
+          nullable: true
+        origin_bin_icon:
+          type: string
+          nullable: true
+        origin_bin_color:
+          type: string
+          nullable: true
+        origin_bin_trashed:
+          type: boolean
+        created_by:
+          type: string
+        created_by_name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
     # ── Activity ───────────────────────────────────────────
     ActivityLogEntry:
       type: object
@@ -3757,6 +3790,143 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  # Shopping List
+  /bins/{id}/shopping-list:
+    post:
+      summary: Bulk-add items to shopping list from a bin
+      tags: [Shopping List]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [names]
+              properties:
+                names:
+                  type: array
+                  items: { type: string }
+                  minItems: 1
+                  maxItems: 50
+      responses:
+        '201':
+          description: Entries created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ShoppingListEntry'
+                  count: { type: integer }
+        '422': { description: Validation error }
+        '404': { description: Bin not found }
+
+  /locations/{locationId}/shopping-list:
+    get:
+      summary: List shopping list entries for a location
+      tags: [Shopping List]
+      parameters:
+        - in: path
+          name: locationId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ShoppingListEntry'
+                  count: { type: integer }
+    post:
+      summary: Manually add an entry to the shopping list
+      tags: [Shopping List]
+      parameters:
+        - in: path
+          name: locationId
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                originBinId: { type: string, nullable: true }
+      responses:
+        '201':
+          description: Entry created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entry:
+                    $ref: '#/components/schemas/ShoppingListEntry'
+
+  /shopping-list/{id}/purchase:
+    post:
+      summary: Mark entry as bought — deletes entry and re-adds to origin bin if possible
+      tags: [Shopping List]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Bought
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+                  restored:
+                    type: object
+                    nullable: true
+                    properties:
+                      binId: { type: string }
+                      itemId: { type: string }
+                      name: { type: string }
+        '404': { description: Entry not found }
+
+  /shopping-list/{id}:
+    delete:
+      summary: Remove a shopping list entry without purchase
+      tags: [Shopping List]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        '404': { description: Entry not found }
 
   /bins/{id}/usage:
     get:

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -35,7 +35,7 @@ tags:
   - name: Photos
     description: Photo retrieval and deletion
   - name: Attachments
-    description: Non-image file attachments on bins. Gated by the `ATTACHMENTS_ENABLED` server env var — returns 404 for every endpoint when disabled.
+    description: Non-image file attachments on bins. Enabled by default; set `ATTACHMENTS_ENABLED=false` to disable — every endpoint returns 404 when disabled.
   - name: TagColors
     description: Per-location tag color assignments
   - name: PrintSettings
@@ -1627,7 +1627,7 @@ paths:
                     description: Whether the server is running in self-hosted mode (all plan features unlocked)
                   attachmentsEnabled:
                     type: boolean
-                    description: Whether the non-image attachments feature is enabled (set via `ATTACHMENTS_ENABLED` env var)
+                    description: Whether the non-image attachments feature is enabled (controlled by the `ATTACHMENTS_ENABLED` env var; defaults to `true`)
 
   /auth/demo-login:
     post:
@@ -3941,13 +3941,13 @@ paths:
           $ref: '#/components/responses/NotFound'
 
   # ════════════════════════════════════════════════════════
-  # Attachments (opt-in: ATTACHMENTS_ENABLED server env var)
+  # Attachments (on by default; disable with ATTACHMENTS_ENABLED=false)
   # ════════════════════════════════════════════════════════
   /bins/{id}/attachments:
     get:
       tags: [Attachments]
       summary: List attachments on a bin
-      description: Returns 404 when `ATTACHMENTS_ENABLED` is not set on the server.
+      description: Returns 404 when `ATTACHMENTS_ENABLED=false` is set on the server.
       parameters:
         - name: id
           in: path
@@ -3979,7 +3979,7 @@ paths:
       description: |
         Accepts common document and archive formats (PDF, plain text, CSV, Markdown, JSON, RTF,
         Microsoft Office, OpenDocument, ZIP, 7z, tar, gzip) up to 5 MB. Images are rejected —
-        use the photos endpoints instead. Returns 404 when `ATTACHMENTS_ENABLED` is not set.
+        use the photos endpoints instead. Returns 404 when `ATTACHMENTS_ENABLED=false` is set.
       parameters:
         - name: id
           in: path
@@ -4024,7 +4024,7 @@ paths:
       summary: Download an attachment
       description: |
         Streams the raw bytes with `Content-Disposition: attachment` (forces download).
-        Returns 404 when `ATTACHMENTS_ENABLED` is not set.
+        Returns 404 when `ATTACHMENTS_ENABLED=false` is set.
       parameters:
         - name: id
           in: path
@@ -4050,7 +4050,7 @@ paths:
       summary: Delete an attachment
       description: |
         Removes the attachment record and deletes the file from storage. Only the uploader
-        or a location admin may delete. Returns 404 when `ATTACHMENTS_ENABLED` is not set.
+        or a location admin may delete. Returns 404 when `ATTACHMENTS_ENABLED=false` is set.
       parameters:
         - name: id
           in: path

--- a/server/schema.pg.sql
+++ b/server/schema.pg.sql
@@ -115,6 +115,19 @@ CREATE INDEX IF NOT EXISTS idx_item_checkouts_active
 CREATE INDEX IF NOT EXISTS idx_item_checkouts_item
   ON item_checkouts(item_id, returned_at);
 
+CREATE TABLE IF NOT EXISTS shopping_list_items (
+  id              TEXT PRIMARY KEY,
+  location_id     TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+  name            TEXT NOT NULL,
+  origin_bin_id   TEXT REFERENCES bins(id) ON DELETE SET NULL DEFERRABLE INITIALLY IMMEDIATE,
+  created_by      TEXT NOT NULL REFERENCES users(id),
+  created_at      TEXT NOT NULL DEFAULT (NOW())
+);
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_location
+  ON shopping_list_items(location_id);
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_bin
+  ON shopping_list_items(origin_bin_id);
+
 CREATE TABLE IF NOT EXISTS photos (
   id            TEXT PRIMARY KEY,
   bin_id        TEXT NOT NULL REFERENCES bins(id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,

--- a/server/schema.sqlite.sql
+++ b/server/schema.sqlite.sql
@@ -104,6 +104,19 @@ CREATE INDEX IF NOT EXISTS idx_item_checkouts_active
 CREATE INDEX IF NOT EXISTS idx_item_checkouts_item
   ON item_checkouts(item_id, returned_at);
 
+CREATE TABLE IF NOT EXISTS shopping_list_items (
+  id              TEXT PRIMARY KEY,
+  location_id     TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  origin_bin_id   TEXT REFERENCES bins(id) ON DELETE SET NULL,
+  created_by      TEXT NOT NULL REFERENCES users(id),
+  created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_location
+  ON shopping_list_items(location_id);
+CREATE INDEX IF NOT EXISTS idx_shopping_list_items_bin
+  ON shopping_list_items(origin_bin_id);
+
 CREATE TABLE IF NOT EXISTS photos (
   id            TEXT PRIMARY KEY,
   bin_id        TEXT NOT NULL REFERENCES bins(id) ON DELETE CASCADE,

--- a/server/src/__tests__/planGating.test.ts
+++ b/server/src/__tests__/planGating.test.ts
@@ -252,7 +252,7 @@ describe('API key route plan gating', () => {
     expect(res.body.error).toBe('PLAN_RESTRICTED');
   });
 
-  it('GET /api/api-keys works for cloud FREE user (list is not gated)', async () => {
+  it('GET /api/api-keys is blocked for cloud FREE user', async () => {
     mockFreeUser();
     const { token } = await createTestUser(app);
 
@@ -260,8 +260,8 @@ describe('API key route plan gating', () => {
       .get('/api/api-keys')
       .set('Authorization', `Bearer ${token}`);
 
-    expect(res.status).toBe(200);
-    expect(res.body.results).toEqual([]);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('PLAN_RESTRICTED');
   });
 
   it('POST /api/api-keys works for cloud PRO user', async () => {

--- a/server/src/__tests__/setup.ts
+++ b/server/src/__tests__/setup.ts
@@ -5,7 +5,6 @@ process.env.DATABASE_PATH = ':memory:';
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'test-secret';
 process.env.PHOTO_STORAGE_PATH = '/tmp/openbin-test-photos';
-process.env.ATTACHMENTS_ENABLED = 'true';
 // Ensure SQLite mode in tests (no DATABASE_URL)
 delete process.env.DATABASE_URL;
 

--- a/server/src/__tests__/shoppingList.test.ts
+++ b/server/src/__tests__/shoppingList.test.ts
@@ -1,0 +1,435 @@
+import type { Express } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from '../index.js';
+import { createTestBin, createTestLocation, createTestUser } from './helpers.js';
+
+let app: Express;
+
+beforeEach(() => {
+  app = createApp();
+});
+
+describe('POST /api/bins/:binId/shopping-list', () => {
+  it('bulk-adds entries from a bin', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Peanut butter', 'Milk', 'Eggs'] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.count).toBe(3);
+    expect(res.body.entries).toHaveLength(3);
+    expect(res.body.entries[0].origin_bin_id).toBe(bin.id);
+    expect(res.body.entries.map((e: { name: string }) => e.name).sort()).toEqual(
+      ['Eggs', 'Milk', 'Peanut butter'],
+    );
+  });
+
+  it('allows duplicate names in one call', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Milk', 'Milk'] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.count).toBe(2);
+  });
+
+  it('rejects empty names array', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: [] });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects too many names (> 50)', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const names = Array.from({ length: 51 }, (_, i) => `Item ${i}`);
+    const res = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 404 when bin does not exist', async () => {
+    const { token } = await createTestUser(app);
+    await createTestLocation(app, token);
+
+    const res = await request(app)
+      .post('/api/bins/nonexistent/shopping-list')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Milk'] });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/locations/:locationId/shopping-list', () => {
+  it('returns entries for the location in newest-first order', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id, { name: 'Pantry' });
+
+    await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['First'] });
+    await new Promise((r) => setTimeout(r, 10));
+    await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Second'] });
+
+    const res = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(2);
+    expect(res.body.results[0].name).toBe('Second');
+    expect(res.body.results[1].name).toBe('First');
+    expect(res.body.results[0].origin_bin_id).toBe(bin.id);
+    expect(res.body.results[0].origin_bin_name).toBe('Pantry');
+    expect(res.body.results[0].origin_bin_trashed).toBe(false);
+  });
+
+  it('returns origin_bin_trashed: true when the bin is in trash', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Milk'] });
+
+    await request(app)
+      .delete(`/api/bins/${bin.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    const res = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].origin_bin_trashed).toBe(true);
+    expect(res.body.results[0].origin_bin_id).toBe(bin.id);
+  });
+
+  it('excludes entries from private bins for non-creator members', async () => {
+    const { token: creatorToken, user: creator } = await createTestUser(app);
+    const location = await createTestLocation(app, creatorToken);
+    const privateBin = await createTestBin(app, creatorToken, location.id, { name: 'Secret' });
+    await request(app)
+      .put(`/api/bins/${privateBin.id}`)
+      .set('Authorization', `Bearer ${creatorToken}`)
+      .send({ visibility: 'private' });
+    await request(app)
+      .post(`/api/bins/${privateBin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${creatorToken}`)
+      .send({ names: ['Secret item'] });
+
+    const { token: otherToken } = await createTestUser(app);
+    await request(app)
+      .post('/api/locations/join')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ inviteCode: location.invite_code });
+
+    const res = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(0);
+
+    const resCreator = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${creatorToken}`);
+    expect(resCreator.body.count).toBe(1);
+    expect(resCreator.body.results[0].created_by).toBe(creator.id);
+  });
+
+  it('rejects non-member access with 403', async () => {
+    const { token: ownerToken } = await createTestUser(app);
+    const location = await createTestLocation(app, ownerToken);
+
+    const { token: strangerToken } = await createTestUser(app);
+    const res = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${strangerToken}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/shopping-list/:id', () => {
+  it('removes an entry', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const createRes = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Milk'] });
+    const entryId = createRes.body.entries[0].id;
+
+    const res = await request(app)
+      .delete(`/api/shopping-list/${entryId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    const listRes = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.body.count).toBe(0);
+  });
+
+  it('returns 404 for nonexistent entry', async () => {
+    const { token } = await createTestUser(app);
+    await createTestLocation(app, token);
+
+    const res = await request(app)
+      .delete('/api/shopping-list/nonexistent')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects non-member', async () => {
+    const { token: ownerToken } = await createTestUser(app);
+    const location = await createTestLocation(app, ownerToken);
+    const bin = await createTestBin(app, ownerToken, location.id);
+    const createRes = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ names: ['Milk'] });
+    const entryId = createRes.body.entries[0].id;
+
+    const { token: strangerToken } = await createTestUser(app);
+    const res = await request(app)
+      .delete(`/api/shopping-list/${entryId}`)
+      .set('Authorization', `Bearer ${strangerToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects viewer role with 403', async () => {
+    const { token: adminToken } = await createTestUser(app);
+    const location = await createTestLocation(app, adminToken);
+    const bin = await createTestBin(app, adminToken, location.id);
+    const createRes = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ names: ['Milk'] });
+    const entryId = createRes.body.entries[0].id;
+
+    const { token: viewerToken } = await createTestUser(app);
+    await request(app)
+      .post('/api/locations/join')
+      .set('Authorization', `Bearer ${viewerToken}`)
+      .send({ inviteCode: location.invite_code });
+
+    // Downgrade to viewer (same pattern as itemCheckouts.test.ts line 62-77)
+    const { query } = await import('../db.js');
+    const meRes = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${adminToken}`);
+    await query(
+      "UPDATE location_members SET role = 'viewer' WHERE location_id = $1 AND user_id != $2",
+      [location.id, meRes.body.id],
+    );
+
+    const res = await request(app)
+      .delete(`/api/shopping-list/${entryId}`)
+      .set('Authorization', `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/locations/:locationId/shopping-list', () => {
+  it('adds a manual entry with no origin bin', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+
+    const res = await request(app)
+      .post(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Bread' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.entry.name).toBe('Bread');
+    expect(res.body.entry.origin_bin_id).toBeNull();
+    expect(res.body.entry.origin_bin_trashed).toBe(false);
+  });
+
+  it('adds a manual entry with an origin bin', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const res = await request(app)
+      .post(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Bread', originBinId: bin.id });
+
+    expect(res.status).toBe(201);
+    expect(res.body.entry.origin_bin_id).toBe(bin.id);
+  });
+
+  it('rejects missing name', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+
+    const res = await request(app)
+      .post(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects originBinId that is not in this location', async () => {
+    const { token: ownerToken } = await createTestUser(app);
+    const location = await createTestLocation(app, ownerToken);
+
+    const { token: otherToken } = await createTestUser(app);
+    const otherLocation = await createTestLocation(app, otherToken);
+    const otherBin = await createTestBin(app, otherToken, otherLocation.id);
+
+    const res = await request(app)
+      .post(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ name: 'Bread', originBinId: otherBin.id });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/shopping-list/:id/purchase', () => {
+  it('deletes the entry and adds the name back to the origin bin', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const createRes = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Peanut butter'] });
+    const entryId = createRes.body.entries[0].id;
+
+    const res = await request(app)
+      .post(`/api/shopping-list/${entryId}/purchase`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+    expect(res.body.restored).not.toBeNull();
+    expect(res.body.restored.binId).toBe(bin.id);
+    expect(res.body.restored.name).toBe('Peanut butter');
+
+    const binRes = await request(app)
+      .get(`/api/bins/${bin.id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(binRes.body.items.map((i: { name: string }) => i.name)).toContain('Peanut butter');
+
+    const listRes = await request(app)
+      .get(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.body.count).toBe(0);
+  });
+
+  it('returns restored: null when origin bin is trashed', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const createRes = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Milk'] });
+    const entryId = createRes.body.entries[0].id;
+
+    await request(app)
+      .delete(`/api/bins/${bin.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    const res = await request(app)
+      .post(`/api/shopping-list/${entryId}/purchase`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+    expect(res.body.restored).toBeNull();
+  });
+
+  it('returns restored: null when origin_bin_id is NULL', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+
+    const createRes = await request(app)
+      .post(`/api/locations/${location.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Bread' });
+    const entryId = createRes.body.entry.id;
+
+    const res = await request(app)
+      .post(`/api/shopping-list/${entryId}/purchase`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.restored).toBeNull();
+  });
+
+  it('returns 404 for a nonexistent entry', async () => {
+    const { token } = await createTestUser(app);
+    await createTestLocation(app, token);
+
+    const res = await request(app)
+      .post('/api/shopping-list/nonexistent/purchase')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 on second purchase (entry already gone)', async () => {
+    const { token } = await createTestUser(app);
+    const location = await createTestLocation(app, token);
+    const bin = await createTestBin(app, token, location.id);
+
+    const createRes = await request(app)
+      .post(`/api/bins/${bin.id}/shopping-list`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ names: ['Milk'] });
+    const entryId = createRes.body.entries[0].id;
+
+    await request(app).post(`/api/shopping-list/${entryId}/purchase`).set('Authorization', `Bearer ${token}`);
+
+    const res = await request(app)
+      .post(`/api/shopping-list/${entryId}/purchase`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -46,6 +46,10 @@ import printSettingsRoutes from './routes/printSettings.js';
 import savedViewsRoutes from './routes/savedViews.js';
 import scanHistoryRoutes from './routes/scanHistory.js';
 import { sharedRoutes } from './routes/shared.js';
+import binShoppingListRoutes, {
+  locationShoppingListRouter as locationShoppingListRoutes,
+  shoppingListRouter as shoppingListRoutes,
+} from './routes/shoppingList.js';
 import tagColorsRoutes from './routes/tagColors.js';
 import tagsRoutes from './routes/tags.js';
 import userPreferencesRoutes from './routes/userPreferences.js';
@@ -148,12 +152,14 @@ export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => voi
   app.use('/api/locations', activityRoutes);
   app.use('/api/locations', customFieldsRoutes);
   app.use('/api/locations', locationCheckoutsRoutes);
+  app.use('/api/locations', locationShoppingListRoutes);
   app.use('/api/bins', binPinsRoutes);
   app.use('/api/bins', binSharesRoutes);
   app.use('/api/bins', binsRoutes);
   app.use('/api/bins', binUsageRoutes);  // new — mounts GET/POST /:id/usage
   app.use('/api/bins', binItemsRoutes);
   app.use('/api/bins', itemCheckoutsRoutes);
+  app.use('/api/bins', binShoppingListRoutes);
   app.use('/api/photos', photosRoutes);
   if (config.attachmentsEnabled) {
     app.use('/api', attachmentsRoutes);
@@ -163,6 +169,7 @@ export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => voi
   app.use('/api/user-preferences', userPreferencesRoutes);
   app.use('/api/saved-views', savedViewsRoutes);
   app.use('/api/scan-history', scanHistoryRoutes);
+  app.use('/api/shopping-list', shoppingListRoutes);
   app.use('/api/plan', planRoutes);
   app.use('/api/shared', sharedRoutes);
   opts?.mountEeRoutes?.(app);

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -150,8 +150,8 @@ export const config = Object.freeze({
   uploadQuotaDemoMb: 5,
   uploadQuotaGlobalDemoMb: 50,
 
-  // Non-image file attachments on bins (off by default; gated at the route layer)
-  attachmentsEnabled: parseBool(process.env.ATTACHMENTS_ENABLED, false),
+  // Non-image file attachments on bins (on by default; set ATTACHMENTS_ENABLED=false to disable)
+  attachmentsEnabled: parseBool(process.env.ATTACHMENTS_ENABLED, true),
 
   // AI API key encryption (separate from JWT to avoid single point of compromise)
   aiEncryptionKey: process.env.AI_ENCRYPTION_KEY || null,

--- a/server/src/routes/__tests__/reorganizeTagsStream.test.ts
+++ b/server/src/routes/__tests__/reorganizeTagsStream.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../lib/config.js', () => ({
     aiMock: true,
     photoStoragePath: '/tmp/photos',
     storageBackend: 'local',
-    attachmentsEnabled: false,
+    attachmentsEnabled: true,
   },
   isDemoUser: () => false,
   getEnvAiConfig: () => null,

--- a/server/src/routes/__tests__/tagsSuggestionIntegration.test.ts
+++ b/server/src/routes/__tests__/tagsSuggestionIntegration.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../lib/config.js', () => ({
     aiMock: true,
     photoStoragePath: '/tmp/photos',
     storageBackend: 'local',
-    attachmentsEnabled: false,
+    attachmentsEnabled: true,
   },
   isDemoUser: () => false,
   AI_TASK_GROUPS: ['vision', 'quickText', 'deepText'],
@@ -90,6 +90,7 @@ describe('Tag suggestion end-to-end', () => {
     // Capture SSE events
     const streamChunks: Array<{ type: string; text?: string }> = [];
     const streamRes: any = {
+      locals: {},
       setHeader: vi.fn(),
       write: (data: string) => {
         const match = data.match(/^data:\s*(.*?)\n\n$/s);

--- a/server/src/routes/apiKeys.ts
+++ b/server/src/routes/apiKeys.ts
@@ -23,7 +23,7 @@ function hashKey(key: string): string {
 }
 
 // GET /api/api-keys — list user's API keys
-router.get('/', asyncHandler(async (req, res) => {
+router.get('/', requirePro(), asyncHandler(async (req, res) => {
   const result = await query(
     `SELECT id, key_prefix, name, created_at, last_used_at, revoked_at
      FROM api_keys

--- a/server/src/routes/shoppingList.ts
+++ b/server/src/routes/shoppingList.ts
@@ -197,9 +197,10 @@ shoppingListRouter.post('/:id/purchase', asyncHandler(async (req, res) => {
   await requireMemberOrAbove(row.location_id, userId, 'mark shopping list item as bought');
 
   let restored: { binId: string; itemId: string; name: string } | null = null;
+  let restoredBinName: string | null = null;
   if (row.origin_bin_id) {
-    const bin = await query<{ id: string; deleted_at: string | null; visibility: string; created_by: string | null }>(
-      'SELECT id, deleted_at, visibility, created_by FROM bins WHERE id = $1',
+    const bin = await query<{ id: string; name: string; deleted_at: string | null; visibility: string; created_by: string | null }>(
+      'SELECT id, name, deleted_at, visibility, created_by FROM bins WHERE id = $1',
       [row.origin_bin_id],
     );
     const b = bin.rows[0];
@@ -207,6 +208,7 @@ shoppingListRouter.post('/:id/purchase', asyncHandler(async (req, res) => {
       && b.deleted_at === null
       && (b.visibility === 'location' || b.created_by === userId);
     if (binVisible) {
+      restoredBinName = b.name;
       const posResult = await query<{ max_pos: number | null }>(
         'SELECT MAX(position) AS max_pos FROM bin_items WHERE bin_id = $1',
         [row.origin_bin_id],
@@ -243,7 +245,7 @@ shoppingListRouter.post('/:id/purchase', asyncHandler(async (req, res) => {
     changes: {
       purchased: {
         old: row.name,
-        new: restored ? `→ ${restored.binId}` : null,
+        new: restoredBinName ? `→ ${restoredBinName}` : null,
       },
     },
   });

--- a/server/src/routes/shoppingList.ts
+++ b/server/src/routes/shoppingList.ts
@@ -1,0 +1,377 @@
+import { Router } from 'express';
+import { generateUuid, query, withTransaction } from '../db.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+import { requireMemberOrAbove, verifyBinAccess } from '../lib/binAccess.js';
+import { NotFoundError, ValidationError } from '../lib/httpErrors.js';
+import { logRouteActivity } from '../lib/routeHelpers.js';
+import { authenticate } from '../middleware/auth.js';
+import { requireLocationMember } from '../middleware/locationAccess.js';
+
+const MAX_NAME_LEN = 200;
+const MAX_BULK = 50;
+
+// ── Bin-nested router (mounted at /api/bins) ─────────────────────────
+export const binShoppingListRouter = Router();
+binShoppingListRouter.use(authenticate);
+
+// POST /api/bins/:id/shopping-list — bulk-add from a bin (undo-toast path)
+binShoppingListRouter.post('/:id/shopping-list', asyncHandler(async (req, res) => {
+  const { id: binId } = req.params;
+  const userId = req.user!.id;
+  const rawNames: unknown = req.body?.names;
+
+  if (!Array.isArray(rawNames)) {
+    throw new ValidationError('names must be an array');
+  }
+  if (rawNames.length === 0) {
+    throw new ValidationError('names must not be empty');
+  }
+  if (rawNames.length > MAX_BULK) {
+    throw new ValidationError(`names must contain at most ${MAX_BULK} items`);
+  }
+  const names: string[] = [];
+  for (const n of rawNames) {
+    if (typeof n !== 'string') throw new ValidationError('each name must be a string');
+    const trimmed = n.trim();
+    if (!trimmed) throw new ValidationError('names cannot be empty strings');
+    if (trimmed.length > MAX_NAME_LEN) throw new ValidationError(`name too long (max ${MAX_NAME_LEN})`);
+    names.push(trimmed);
+  }
+
+  const access = await verifyBinAccess(binId, userId);
+  if (!access) throw new NotFoundError('Bin not found');
+
+  await requireMemberOrAbove(access.locationId, userId, 'add to shopping list');
+
+  const inserted = await withTransaction(async (txQuery) => {
+    const rows: Array<{ id: string; name: string }> = [];
+    for (const name of names) {
+      const id = generateUuid();
+      await txQuery(
+        `INSERT INTO shopping_list_items (id, location_id, name, origin_bin_id, created_by, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [id, access.locationId, name, binId, userId, new Date().toISOString()],
+      );
+      rows.push({ id, name });
+    }
+    return rows;
+  });
+
+  // Fetch with JOIN so the client gets the full entry shape in one shot.
+  const placeholders = inserted.map((_, i) => `$${i + 1}`).join(', ');
+  const entries = await query<{
+    id: string;
+    location_id: string;
+    name: string;
+    origin_bin_id: string | null;
+    origin_bin_name: string | null;
+    origin_bin_icon: string | null;
+    origin_bin_color: string | null;
+    origin_bin_deleted_at: string | null;
+    created_by: string;
+    created_by_name: string;
+    created_at: string;
+  }>(
+    `SELECT s.id, s.location_id, s.name, s.origin_bin_id,
+            b.name AS origin_bin_name, b.icon AS origin_bin_icon, b.color AS origin_bin_color,
+            b.deleted_at AS origin_bin_deleted_at,
+            s.created_by, u.display_name AS created_by_name, s.created_at
+     FROM shopping_list_items s
+     LEFT JOIN bins b ON b.id = s.origin_bin_id
+     JOIN users u ON u.id = s.created_by
+     WHERE s.id IN (${placeholders})
+     ORDER BY s.created_at ASC, s.id ASC`,
+    inserted.map((e) => e.id),
+  );
+
+  logRouteActivity(req, {
+    locationId: access.locationId,
+    action: 'create',
+    entityType: 'shopping_list',
+    entityId: binId,
+    entityName: access.name,
+    changes: { added: { old: null, new: names } },
+  });
+
+  const mapped = entries.rows.map((r) => ({
+    id: r.id,
+    location_id: r.location_id,
+    name: r.name,
+    origin_bin_id: r.origin_bin_id,
+    origin_bin_name: r.origin_bin_name,
+    origin_bin_icon: r.origin_bin_icon,
+    origin_bin_color: r.origin_bin_color,
+    origin_bin_trashed: r.origin_bin_deleted_at !== null,
+    created_by: r.created_by,
+    created_by_name: r.created_by_name,
+    created_at: r.created_at,
+  }));
+
+  res.status(201).json({ entries: mapped, count: mapped.length });
+}));
+
+export default binShoppingListRouter;
+
+// ── Location-nested router (mounted at /api/locations) ────────────────
+export const locationShoppingListRouter = Router();
+locationShoppingListRouter.use(authenticate);
+
+// GET /api/locations/:locationId/shopping-list
+locationShoppingListRouter.get(
+  '/:locationId/shopping-list',
+  requireLocationMember('locationId'),
+  asyncHandler(async (req, res) => {
+    const { locationId } = req.params;
+    const userId = req.user!.id;
+
+    const result = await query<{
+      id: string;
+      location_id: string;
+      name: string;
+      origin_bin_id: string | null;
+      origin_bin_name: string | null;
+      origin_bin_icon: string | null;
+      origin_bin_color: string | null;
+      origin_bin_deleted_at: string | null;
+      created_by: string;
+      created_by_name: string;
+      created_at: string;
+    }>(
+      `SELECT s.id, s.location_id, s.name, s.origin_bin_id,
+              b.name AS origin_bin_name, b.icon AS origin_bin_icon, b.color AS origin_bin_color,
+              b.deleted_at AS origin_bin_deleted_at,
+              s.created_by, u.display_name AS created_by_name, s.created_at
+       FROM shopping_list_items s
+       LEFT JOIN bins b ON b.id = s.origin_bin_id
+       JOIN users u ON u.id = s.created_by
+       WHERE s.location_id = $1
+         AND (
+           s.origin_bin_id IS NULL
+           OR b.visibility = 'location'
+           OR (b.visibility = 'private' AND b.created_by = $2)
+         )
+       ORDER BY s.created_at DESC`,
+      [locationId, userId],
+    );
+
+    const rows = result.rows.map((r) => ({
+      id: r.id,
+      location_id: r.location_id,
+      name: r.name,
+      origin_bin_id: r.origin_bin_id,
+      origin_bin_name: r.origin_bin_name,
+      origin_bin_icon: r.origin_bin_icon,
+      origin_bin_color: r.origin_bin_color,
+      origin_bin_trashed: r.origin_bin_deleted_at !== null,
+      created_by: r.created_by,
+      created_by_name: r.created_by_name,
+      created_at: r.created_at,
+    }));
+
+    res.json({ results: rows, count: rows.length });
+  }),
+);
+
+// ── Flat router for entry-level ops (mounted at /api/shopping-list) ──
+export const shoppingListRouter = Router();
+shoppingListRouter.use(authenticate);
+
+// POST /api/shopping-list/:id/purchase — mark bought (+ re-add to origin)
+shoppingListRouter.post('/:id/purchase', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const userId = req.user!.id;
+
+  const entry = await query<{
+    id: string;
+    location_id: string;
+    name: string;
+    origin_bin_id: string | null;
+  }>(
+    'SELECT id, location_id, name, origin_bin_id FROM shopping_list_items WHERE id = $1',
+    [id],
+  );
+  if (entry.rows.length === 0) throw new NotFoundError('Shopping list entry not found');
+
+  const row = entry.rows[0];
+
+  await requireMemberOrAbove(row.location_id, userId, 'mark shopping list item as bought');
+
+  let restored: { binId: string; itemId: string; name: string } | null = null;
+  if (row.origin_bin_id) {
+    const bin = await query<{ id: string; deleted_at: string | null; visibility: string; created_by: string | null }>(
+      'SELECT id, deleted_at, visibility, created_by FROM bins WHERE id = $1',
+      [row.origin_bin_id],
+    );
+    const b = bin.rows[0];
+    const binVisible = b
+      && b.deleted_at === null
+      && (b.visibility === 'location' || b.created_by === userId);
+    if (binVisible) {
+      const posResult = await query<{ max_pos: number | null }>(
+        'SELECT MAX(position) AS max_pos FROM bin_items WHERE bin_id = $1',
+        [row.origin_bin_id],
+      );
+      const nextPos = (posResult.rows[0]?.max_pos ?? -1) + 1;
+      const newItemId = generateUuid();
+      const nowIso = new Date().toISOString();
+      const originBinId = row.origin_bin_id;
+      await withTransaction(async (txQuery) => {
+        await txQuery(
+          `INSERT INTO bin_items (id, bin_id, name, quantity, position, created_at, updated_at)
+           VALUES ($1, $2, $3, NULL, $4, $5, $6)`,
+          [newItemId, originBinId, row.name, nextPos, nowIso, nowIso],
+        );
+        await txQuery(`UPDATE bins SET updated_at = $1 WHERE id = $2`, [nowIso, originBinId]);
+        await txQuery('DELETE FROM shopping_list_items WHERE id = $1', [id]);
+      });
+      restored = { binId: originBinId, itemId: newItemId, name: row.name };
+    } else {
+      // Origin bin is gone/invisible — just delete the entry.
+      await query('DELETE FROM shopping_list_items WHERE id = $1', [id]);
+    }
+  } else {
+    // No origin — just delete the entry.
+    await query('DELETE FROM shopping_list_items WHERE id = $1', [id]);
+  }
+
+  logRouteActivity(req, {
+    locationId: row.location_id,
+    action: 'delete',
+    entityType: 'shopping_list',
+    entityId: id,
+    entityName: row.name,
+    changes: {
+      purchased: {
+        old: row.name,
+        new: restored ? `→ ${restored.binId}` : null,
+      },
+    },
+  });
+
+  if (restored) {
+    logRouteActivity(req, {
+      locationId: row.location_id,
+      action: 'update',
+      entityType: 'bin',
+      entityId: restored.binId,
+      entityName: row.name,
+      changes: { items_added: { old: null, new: [row.name] } },
+    });
+  }
+
+  res.json({ deleted: true, restored });
+}));
+
+// DELETE /api/shopping-list/:id — remove without purchase
+shoppingListRouter.delete('/:id', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const userId = req.user!.id;
+
+  const entry = await query<{ id: string; location_id: string; name: string }>(
+    'SELECT id, location_id, name FROM shopping_list_items WHERE id = $1',
+    [id],
+  );
+  if (entry.rows.length === 0) throw new NotFoundError('Shopping list entry not found');
+
+  const row = entry.rows[0];
+  await requireMemberOrAbove(row.location_id, userId, 'remove shopping list item');
+
+  await query('DELETE FROM shopping_list_items WHERE id = $1', [id]);
+
+  logRouteActivity(req, {
+    locationId: row.location_id,
+    action: 'delete',
+    entityType: 'shopping_list',
+    entityId: id,
+    entityName: row.name,
+    changes: { removed: { old: row.name, new: null } },
+  });
+
+  res.json({ ok: true });
+}));
+
+// POST /api/locations/:locationId/shopping-list — manual add
+locationShoppingListRouter.post(
+  '/:locationId/shopping-list',
+  requireLocationMember('locationId'),
+  asyncHandler(async (req, res) => {
+    const { locationId } = req.params;
+    const userId = req.user!.id;
+    const rawName: unknown = req.body?.name;
+    const rawOriginBinId: unknown = req.body?.originBinId;
+
+    if (typeof rawName !== 'string') throw new ValidationError('name is required');
+    const name = rawName.trim();
+    if (!name) throw new ValidationError('name cannot be empty');
+    if (name.length > MAX_NAME_LEN) throw new ValidationError(`name too long (max ${MAX_NAME_LEN})`);
+
+    let originBinId: string | null = null;
+    if (rawOriginBinId != null && rawOriginBinId !== '') {
+      if (typeof rawOriginBinId !== 'string') throw new ValidationError('originBinId must be a string');
+      const access = await verifyBinAccess(rawOriginBinId, userId);
+      if (!access || access.locationId !== locationId) {
+        throw new NotFoundError('Bin not found');
+      }
+      originBinId = rawOriginBinId;
+    }
+
+    await requireMemberOrAbove(locationId, userId, 'add to shopping list');
+
+    const id = generateUuid();
+    await query(
+      `INSERT INTO shopping_list_items (id, location_id, name, origin_bin_id, created_by, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [id, locationId, name, originBinId, userId, new Date().toISOString()],
+    );
+
+    const result = await query<{
+      id: string;
+      location_id: string;
+      name: string;
+      origin_bin_id: string | null;
+      origin_bin_name: string | null;
+      origin_bin_icon: string | null;
+      origin_bin_color: string | null;
+      origin_bin_deleted_at: string | null;
+      created_by: string;
+      created_by_name: string;
+      created_at: string;
+    }>(
+      `SELECT s.id, s.location_id, s.name, s.origin_bin_id,
+              b.name AS origin_bin_name, b.icon AS origin_bin_icon, b.color AS origin_bin_color,
+              b.deleted_at AS origin_bin_deleted_at,
+              s.created_by, u.display_name AS created_by_name, s.created_at
+       FROM shopping_list_items s
+       LEFT JOIN bins b ON b.id = s.origin_bin_id
+       JOIN users u ON u.id = s.created_by
+       WHERE s.id = $1`,
+      [id],
+    );
+
+    const row = result.rows[0];
+    const entry = {
+      id: row.id,
+      location_id: row.location_id,
+      name: row.name,
+      origin_bin_id: row.origin_bin_id,
+      origin_bin_name: row.origin_bin_name,
+      origin_bin_icon: row.origin_bin_icon,
+      origin_bin_color: row.origin_bin_color,
+      origin_bin_trashed: row.origin_bin_deleted_at !== null,
+      created_by: row.created_by,
+      created_by_name: row.created_by_name,
+      created_at: row.created_at,
+    };
+
+    logRouteActivity(req, {
+      locationId,
+      action: 'create',
+      entityType: 'shopping_list',
+      entityId: id,
+      entityName: name,
+      changes: { added: { old: null, new: name } },
+    });
+
+    res.status(201).json({ entry });
+  }),
+);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,10 @@ const CheckoutsPage = lazyWithRetry(() =>
   import('@/features/checkouts/CheckoutsPage').then((m) => ({ default: m.CheckoutsPage }))
 );
 
+const ShoppingListPage = lazyWithRetry(() =>
+  import('@/features/shopping-list/ShoppingListPage').then((m) => ({ default: m.ShoppingListPage }))
+);
+
 const TrashPage = lazyWithRetry(() =>
   import('@/features/bins/TrashPage').then((m) => ({ default: m.TrashPage }))
 );
@@ -396,6 +400,7 @@ export default function App() {
                 <Route path="/tags" element={<RouteWithBoundary><TagsPage /></RouteWithBoundary>} />
                 <Route path="/items" element={<RouteWithBoundary><ItemsPage /></RouteWithBoundary>} />
                 <Route path="/checkouts" element={<RouteWithBoundary><CheckoutsPage /></RouteWithBoundary>} />
+                <Route path="/shopping-list" element={<RouteWithBoundary><ShoppingListPage /></RouteWithBoundary>} />
                 <Route path="/locations" element={<RouteWithBoundary><AreasPage /></RouteWithBoundary>} />
                 <Route path="/trash" element={<Navigate to="/settings/trash" replace />} />
                 <Route path="/activity" element={<Navigate to="/settings/activity" replace />} />

--- a/src/components/ui/__tests__/toast.test.tsx
+++ b/src/components/ui/__tests__/toast.test.tsx
@@ -1,0 +1,66 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider, useToast } from '../toast';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Captures the live useToast() return so the test body can call methods directly.
+function setupHarness() {
+  const captured: { current: ReturnType<typeof useToast> | null } = { current: null };
+
+  function Harness() {
+    captured.current = useToast();
+    return null;
+  }
+
+  render(
+    <ToastProvider>
+      <Harness />
+    </ToastProvider>,
+  );
+
+  if (!captured.current) throw new Error('useToast() never captured');
+  return captured.current;
+}
+
+describe('updateToast', () => {
+  it('mutates an existing toast message and resets its auto-dismiss timer', () => {
+    const api = setupHarness();
+    let createdId: number | undefined;
+
+    act(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: showToast return type is being widened in this slice
+      createdId = (api.showToast as any)({ message: 'original', duration: 4000 });
+    });
+
+    expect(typeof createdId).toBe('number');
+    expect(screen.getByText('original')).toBeInTheDocument();
+
+    // Advance partway through the original 4000ms window, then update.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    act(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: updateToast is added to the API in this slice
+      (api as any).updateToast(createdId, { message: 'updated' });
+    });
+
+    expect(screen.getByText('updated')).toBeInTheDocument();
+    expect(screen.queryByText('original')).toBeNull();
+
+    // Cross the ORIGINAL 4000ms deadline (total elapsed = 5000ms). The refreshed timer
+    // started at t=3000, so only 2000ms has elapsed on it — toast must still be visible.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText('updated')).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -27,10 +27,14 @@ interface Toast {
 }
 
 interface ToastContextValue {
-  showToast: (toast: Omit<Toast, 'id'>) => void;
+  showToast: (toast: Omit<Toast, 'id'>) => number;
+  updateToast: (id: number, partial: Partial<Omit<Toast, 'id'>>) => void;
 }
 
-const ToastContext = createContext<ToastContextValue>({ showToast: () => {} });
+const ToastContext = createContext<ToastContextValue>({
+  showToast: () => -1,
+  updateToast: () => {},
+});
 
 export function useToast() {
   return useContext(ToastContext);
@@ -44,6 +48,11 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const showToast = useCallback((toast: Omit<Toast, 'id'>) => {
     const id = nextId++;
     setToasts((prev) => [...prev, { ...toast, id }]);
+    return id;
+  }, []);
+
+  const updateToast = useCallback((id: number, partial: Partial<Omit<Toast, 'id'>>) => {
+    setToasts((prev) => prev.map((t) => (t.id === id ? { ...t, ...partial } : t)));
   }, []);
 
   const dismiss = useCallback((id: number) => {
@@ -51,7 +60,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={{ showToast, updateToast }}>
       {children}
       <output aria-live="assertive" aria-atomic="true" className="fixed bottom-[calc(12px+var(--bottom-bar-height)+var(--safe-bottom))] lg:bottom-8 left-1/2 -translate-x-1/2 z-[100] flex flex-col gap-2 pointer-events-none print-hide">
         {toasts.map((toast) => (

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -23,6 +23,7 @@ interface Toast {
   message: string;
   variant?: ToastVariant;
   action?: { label: string; onClick: () => void };
+  secondaryAction?: { label: string; onClick: () => void };
   duration?: number;
 }
 
@@ -101,6 +102,15 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: (id: number)
           className="text-[15px] font-semibold text-[var(--accent)] hover:opacity-80 shrink-0"
         >
           {toast.action.label}
+        </button>
+      )}
+      {toast.secondaryAction && (
+        <button
+          type="button"
+          onClick={toast.secondaryAction.onClick}
+          className="text-[15px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] shrink-0"
+        >
+          {toast.secondaryAction.label}
         </button>
       )}
       <button

--- a/src/features/bins/ItemList.tsx
+++ b/src/features/bins/ItemList.tsx
@@ -245,9 +245,10 @@ function ReadOnlyCheckoutRow({ item, checkout }: { item: BinItem; checkout: Item
 export function ItemList({ items, binId, readOnly, hideWhenEmpty, hideHeader, checkouts = [], onItemsChange, headerExtra, footerSlot }: ItemListProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn>('');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
-  const { showToast } = useToast();
+  const { showToast, updateToast } = useToast();
   const [pendingDeleteIds, setPendingDeleteIds] = useState<Set<string>>(new Set());
   const pendingDeletesRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const deleteBatchRef = useRef<{ toastId: number; ids: Set<string> } | null>(null);
 
   const checkoutMap = useMemo(() => {
     const map = new Map<string, ItemCheckout>();
@@ -376,6 +377,11 @@ export function ItemList({ items, binId, readOnly, hideWhenEmpty, hideHeader, ch
 
     const timerId = setTimeout(() => {
       pendingDeletesRef.current.delete(itemId);
+      const batch = deleteBatchRef.current;
+      if (batch) {
+        batch.ids.delete(itemId);
+        if (batch.ids.size === 0) deleteBatchRef.current = null;
+      }
       const next = itemsRef.current.filter((i) => i.id !== itemId);
       if (onItemsChangeRef.current) {
         onItemsChangeRef.current(next);
@@ -396,21 +402,42 @@ export function ItemList({ items, binId, readOnly, hideWhenEmpty, hideHeader, ch
     }, 5000);
     pendingDeletesRef.current.set(itemId, timerId);
 
-    showToast({
-      message: 'Item removed',
+    // Coalesce into the active batch (if any) so rapid deletes share one toast
+    // with a single Undo. The batch lives as long as any pending delete in it.
+    const isNewBatch = !deleteBatchRef.current;
+    const batch = deleteBatchRef.current ?? { toastId: 0, ids: new Set<string>() };
+    if (isNewBatch) deleteBatchRef.current = batch;
+    batch.ids.add(itemId);
+
+    const undo = () => {
+      const ids = Array.from(batch.ids);
+      for (const id of ids) {
+        const pending = pendingDeletesRef.current.get(id);
+        if (pending != null) {
+          clearTimeout(pending);
+          pendingDeletesRef.current.delete(id);
+        }
+      }
+      batch.ids.clear();
+      if (deleteBatchRef.current === batch) deleteBatchRef.current = null;
+      setPendingDeleteIds((prev) => {
+        const next = new Set(prev);
+        for (const id of ids) next.delete(id);
+        return next;
+      });
+    };
+
+    const count = batch.ids.size;
+    const payload = {
+      message: count === 1 ? 'Item removed' : `${count} items removed`,
       duration: 5500,
-      action: {
-        label: 'Undo',
-        onClick: () => {
-          const pending = pendingDeletesRef.current.get(itemId);
-          if (pending != null) {
-            clearTimeout(pending);
-            pendingDeletesRef.current.delete(itemId);
-            setPendingDeleteIds((prev) => { const next = new Set(prev); next.delete(itemId); return next; });
-          }
-        },
-      },
-    });
+      action: { label: 'Undo', onClick: undo },
+    };
+    if (isNewBatch) {
+      batch.toastId = showToast(payload);
+    } else {
+      updateToast(batch.toastId, payload);
+    }
   }
 
   async function handleCheckout(itemId: string) {

--- a/src/features/bins/ItemList.tsx
+++ b/src/features/bins/ItemList.tsx
@@ -6,6 +6,7 @@ import { SearchInput } from '@/components/ui/search-input';
 import { type SortDirection, SortHeader } from '@/components/ui/sort-header';
 import { useToast } from '@/components/ui/toast';
 import { checkoutItem, returnItem } from '@/features/checkouts/useCheckouts';
+import { addItemsToShoppingList, removeFromShoppingList } from '@/features/shopping-list/useShoppingList';
 import { Events, notify } from '@/lib/eventBus';
 import { parseBareQuantity } from '@/lib/itemQuantities';
 import { cn, relativeTime } from '@/lib/utils';
@@ -428,10 +429,35 @@ export function ItemList({ items, binId, readOnly, hideWhenEmpty, hideHeader, ch
     };
 
     const count = batch.ids.size;
+    const addToList = () => {
+      if (!binId) return;
+      const ids = Array.from(batch.ids);
+      const names = ids
+        .map((itemId) => itemsRef.current.find((i) => i.id === itemId)?.name)
+        .filter((n): n is string => !!n);
+      if (names.length === 0) return;
+      void addItemsToShoppingList(binId, names)
+        .then((entries) => {
+          showToast({
+            message: names.length === 1 ? 'Added to shopping list' : `Added ${names.length} to list`,
+            variant: 'success',
+            action: {
+              label: 'Undo',
+              onClick: () => {
+                void Promise.all(entries.map((e) => removeFromShoppingList(e.id)));
+              },
+            },
+          });
+        })
+        .catch(() => {
+          showToast({ message: 'Failed to add to list', variant: 'error' });
+        });
+    };
     const payload = {
       message: count === 1 ? 'Item removed' : `${count} items removed`,
       duration: 5500,
       action: { label: 'Undo', onClick: undo },
+      secondaryAction: { label: count === 1 ? 'Add to list' : 'Add all to list', onClick: addToList },
     };
     if (isNewBatch) {
       batch.toastId = showToast(payload);

--- a/src/features/bins/__tests__/ItemList.test.tsx
+++ b/src/features/bins/__tests__/ItemList.test.tsx
@@ -6,7 +6,9 @@ import { setItemPageSize } from '../useItemPageSize';
 
 vi.mock('@/lib/api', () => ({ apiFetch: vi.fn() }));
 vi.mock('@/lib/auth', () => ({ useAuth: vi.fn(() => ({ activeLocationId: 'loc-1', token: 'test' })) }));
-vi.mock('@/components/ui/toast', () => ({ useToast: vi.fn(() => ({ showToast: vi.fn() })) }));
+vi.mock('@/components/ui/toast', () => ({
+  useToast: vi.fn(() => ({ showToast: vi.fn(), updateToast: vi.fn() })),
+}));
 vi.mock('@/lib/usePermissions', () => ({
   usePermissions: vi.fn(() => ({ canWrite: true })),
 }));
@@ -21,6 +23,7 @@ vi.mock('../useBins', () => ({
 }));
 
 const { removeItemFromBin } = await import('../useBins');
+const { useToast } = await import('@/components/ui/toast');
 
 const items: BinItem[] = [
   { id: '1', name: 'Hammer', quantity: 2 },
@@ -417,5 +420,51 @@ describe('ItemList pagination', () => {
     render(<ItemList items={makeItems(15)} readOnly />);
     expect(screen.queryByText(/show \d+ more/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/show less/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('ItemList batched delete undo', () => {
+  function deleteItemAt(index: number) {
+    const buttons = screen.getAllByLabelText('Item actions');
+    fireEvent.click(buttons[index]);
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i }));
+  }
+
+  it('coalesces rapid deletes into one updating toast and a single Undo cancels them all', () => {
+    const showToast = vi.fn().mockReturnValue(99);
+    const updateToast = vi.fn();
+    // biome-ignore lint/suspicious/noExplicitAny: vi mock typing
+    (useToast as any).mockReturnValue({ showToast, updateToast });
+
+    const onItemsChange = vi.fn();
+    render(<ItemList items={items} onItemsChange={onItemsChange} />);
+
+    // Each delete removes the row from `displayItems` immediately; subsequent
+    // calls always target the new first item (Hammer → Nails → Screwdriver).
+    deleteItemAt(0);
+    deleteItemAt(0);
+    deleteItemAt(0);
+
+    // First delete fires showToast; subsequent deletes fire updateToast on the same id.
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(updateToast).toHaveBeenCalledTimes(2);
+
+    const lastUpdate = updateToast.mock.calls[updateToast.mock.calls.length - 1];
+    expect(lastUpdate[0]).toBe(99);
+    expect(lastUpdate[1].message).toBe('3 items removed');
+    expect(typeof lastUpdate[1].action.onClick).toBe('function');
+
+    // Undo: invoke the latest batch action.
+    act(() => {
+      lastUpdate[1].action.onClick();
+    });
+
+    // Drain pending commit timers.
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    // No deletes committed — all three were cancelled by the batch undo.
+    expect(onItemsChange).not.toHaveBeenCalled();
   });
 });

--- a/src/features/bins/__tests__/useAutoSaveBin.test.ts
+++ b/src/features/bins/__tests__/useAutoSaveBin.test.ts
@@ -79,7 +79,7 @@ describe('useAutoSaveBin', () => {
 
   it('shows error toast on save failure', async () => {
     const showToast = vi.fn();
-    vi.mocked(useToast).mockReturnValue({ showToast });
+    vi.mocked(useToast).mockReturnValue({ showToast, updateToast: vi.fn() });
     vi.mocked(updateBin).mockRejectedValue(new Error('network'));
     const { result } = renderHook(() => useAutoSaveBin(mockBin));
     await act(async () => { result.current.saveTags(['fail']); });

--- a/src/features/layout/Sidebar.tsx
+++ b/src/features/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Boxes, ClipboardList, LayoutDashboard, LogOut, MapPin, Package, PackageSearch, PanelLeftClose, PanelLeftOpen, Printer, ScanLine, Settings, Tags } from
+import { Boxes, ClipboardList, LayoutDashboard, LogOut, MapPin, Package, PackageSearch, PanelLeftClose, PanelLeftOpen, Printer, ScanLine, Settings, ShoppingCart, Tags } from
   'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { BrandIcon } from '@/components/BrandIcon';
@@ -32,6 +32,7 @@ const manageItems: NavItem[] = [
   { path: '/locations', label: 'Locations', icon: MapPin, termKey: 'Locations' },
   { path: '/items', label: 'Items', icon: ClipboardList },
   { path: '/checkouts', label: 'Checked Out', icon: PackageSearch },
+  { path: '/shopping-list', label: 'Shopping List', icon: ShoppingCart },
   { path: '/tags', label: 'Tags', icon: Tags },
 ];
 

--- a/src/features/shopping-list/ShoppingListPage.tsx
+++ b/src/features/shopping-list/ShoppingListPage.tsx
@@ -1,0 +1,201 @@
+import { Check, ShoppingCart, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Input } from '@/components/ui/input';
+import { PageHeader } from '@/components/ui/page-header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { SkeletonList } from '@/components/ui/skeleton-list';
+import { useToast } from '@/components/ui/toast';
+import { useAuth } from '@/lib/auth';
+import { usePermissions } from '@/lib/usePermissions';
+import { cn } from '@/lib/utils';
+import type { ShoppingListEntry } from '@/types';
+import {
+  addToShoppingList,
+  markAsBought,
+  removeFromShoppingList,
+  useShoppingList,
+} from './useShoppingList';
+
+type Group = {
+  key: string;
+  binName: string | null;
+  binIcon: string | null;
+  binColor: string | null;
+  trashed: boolean;
+  entries: ShoppingListEntry[];
+};
+
+function groupByBin(entries: ShoppingListEntry[]): Group[] {
+  const map = new Map<string, Group>();
+  for (const e of entries) {
+    const key = e.origin_bin_id ?? '__no_origin__';
+    let group = map.get(key);
+    if (!group) {
+      group = {
+        key,
+        binName: e.origin_bin_name,
+        binIcon: e.origin_bin_icon,
+        binColor: e.origin_bin_color,
+        trashed: e.origin_bin_trashed,
+        entries: [],
+      };
+      map.set(key, group);
+    }
+    group.entries.push(e);
+  }
+  const list = Array.from(map.values());
+  list.sort((a, b) => {
+    if (a.key === '__no_origin__') return 1;
+    if (b.key === '__no_origin__') return -1;
+    return (a.binName ?? '').localeCompare(b.binName ?? '');
+  });
+  return list;
+}
+
+export function ShoppingListPage() {
+  const { activeLocationId } = useAuth();
+  const { canWrite } = usePermissions();
+  const { showToast } = useToast();
+  const locationId = activeLocationId ?? null;
+  const { entries, isLoading } = useShoppingList(locationId);
+  const [newName, setNewName] = useState('');
+
+  const groups = useMemo(() => groupByBin(entries), [entries]);
+
+  async function handleAdd() {
+    const name = newName.trim();
+    if (!name || !locationId) return;
+    try {
+      await addToShoppingList(locationId, name);
+      setNewName('');
+    } catch {
+      showToast({ message: 'Failed to add', variant: 'error' });
+    }
+  }
+
+  async function handleBought(entry: ShoppingListEntry) {
+    try {
+      const result = await markAsBought(entry.id);
+      if (result.restored) {
+        showToast({
+          message: `Added back to ${entry.origin_bin_name ?? 'bin'}`,
+          variant: 'success',
+        });
+      } else {
+        showToast({ message: 'Marked bought' });
+      }
+    } catch {
+      showToast({ message: 'Failed to mark bought', variant: 'error' });
+    }
+  }
+
+  async function handleRemove(entry: ShoppingListEntry) {
+    try {
+      await removeFromShoppingList(entry.id);
+    } catch {
+      showToast({ message: 'Failed to remove', variant: 'error' });
+    }
+  }
+
+  const countLabel = entries.length > 0
+    ? `${entries.length} item${entries.length === 1 ? '' : 's'}`
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-6 p-4 lg:p-8">
+      <PageHeader
+        title={countLabel ? `Shopping List — ${countLabel}` : 'Shopping List'}
+        actions={
+          canWrite && locationId ? (
+            <div className="flex gap-2">
+              <Input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void handleAdd();
+                  }
+                }}
+                placeholder="Add an item…"
+                className="w-48 sm:w-64"
+              />
+              <button
+                type="button"
+                onClick={() => void handleAdd()}
+                disabled={!newName.trim()}
+                className="px-4 py-2 rounded-[var(--radius-lg)] bg-[var(--accent)] text-white font-medium disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          ) : undefined
+        }
+      />
+
+      {isLoading ? (
+        <SkeletonList count={3}>
+          {() => <Skeleton className="h-12 w-full rounded-[var(--radius-md)]" />}
+        </SkeletonList>
+      ) : entries.length === 0 ? (
+        <EmptyState
+          icon={ShoppingCart}
+          title="No items on your shopping list"
+          subtitle="When you remove an item from a bin, the undo toast offers an 'Add to list' shortcut. Items you add here also show up."
+        />
+      ) : (
+        <div className="flex flex-col gap-6">
+          {groups.map((group) => (
+            <section key={group.key} className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                {group.key === '__no_origin__' ? (
+                  <span className="ui-eyebrow text-[var(--text-tertiary)]">No origin</span>
+                ) : (
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] text-[13px] font-medium',
+                      group.trashed && 'opacity-60',
+                    )}
+                    style={{ backgroundColor: group.binColor ?? 'transparent' }}
+                  >
+                    {group.binIcon && <span aria-hidden>{group.binIcon}</span>}
+                    <span>{group.binName ?? 'Bin'}</span>
+                    {group.trashed && <span className="text-[11px]">(trashed)</span>}
+                  </span>
+                )}
+              </div>
+              <ul className="flex flex-col divide-y divide-[var(--border-flat)] rounded-[var(--radius-xl)] flat-card overflow-hidden">
+                {group.entries.map((entry) => (
+                  <li key={entry.id} className="flex items-center gap-3 px-4 py-3">
+                    <span className="flex-1 text-[15px]">{entry.name}</span>
+                    {canWrite && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => void handleBought(entry)}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-lg)] bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 text-[13px] font-semibold"
+                        >
+                          <Check className="h-4 w-4" />
+                          Bought
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleRemove(entry)}
+                          aria-label="Remove"
+                          className="p-2 rounded-[var(--radius-md)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/shopping-list/ShoppingListPage.tsx
+++ b/src/features/shopping-list/ShoppingListPage.tsx
@@ -1,13 +1,25 @@
 import { Check, ShoppingCart, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { BinIconBadge } from '@/components/ui/bin-icon-badge';
+import { Button } from '@/components/ui/button';
+import { Crossfade } from '@/components/ui/crossfade';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Highlight } from '@/components/ui/highlight';
 import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/ui/page-header';
+import { SearchInput } from '@/components/ui/search-input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { SkeletonList } from '@/components/ui/skeleton-list';
+import { type SortDirection, SortHeader } from '@/components/ui/sort-header';
+import { Table, TableHeader, TableRow } from '@/components/ui/table';
 import { useToast } from '@/components/ui/toast';
+import { Tooltip } from '@/components/ui/tooltip';
 import { useAuth } from '@/lib/auth';
+import { resolveColor } from '@/lib/colorPalette';
+import { resolveIcon } from '@/lib/iconMap';
+import { useDebounce } from '@/lib/useDebounce';
 import { usePermissions } from '@/lib/usePermissions';
+import { useTableSearchParams } from '@/lib/useTableSearchParams';
 import { cn } from '@/lib/utils';
 import type { ShoppingListEntry } from '@/types';
 import {
@@ -17,40 +29,24 @@ import {
   useShoppingList,
 } from './useShoppingList';
 
-type Group = {
-  key: string;
-  binName: string | null;
-  binIcon: string | null;
-  binColor: string | null;
-  trashed: boolean;
-  entries: ShoppingListEntry[];
-};
+type ShoppingSortColumn = 'alpha' | 'bin';
 
-function groupByBin(entries: ShoppingListEntry[]): Group[] {
-  const map = new Map<string, Group>();
-  for (const e of entries) {
-    const key = e.origin_bin_id ?? '__no_origin__';
-    let group = map.get(key);
-    if (!group) {
-      group = {
-        key,
-        binName: e.origin_bin_name,
-        binIcon: e.origin_bin_icon,
-        binColor: e.origin_bin_color,
-        trashed: e.origin_bin_trashed,
-        entries: [],
-      };
-      map.set(key, group);
+function sortEntries(
+  entries: ShoppingListEntry[],
+  column: ShoppingSortColumn,
+  direction: SortDirection,
+): ShoppingListEntry[] {
+  const sorted = [...entries].sort((a, b) => {
+    if (column === 'bin') {
+      const aKey = a.origin_bin_name ?? '￿';
+      const bKey = b.origin_bin_name ?? '￿';
+      const cmp = aKey.localeCompare(bKey);
+      if (cmp !== 0) return cmp;
+      return a.name.localeCompare(b.name);
     }
-    group.entries.push(e);
-  }
-  const list = Array.from(map.values());
-  list.sort((a, b) => {
-    if (a.key === '__no_origin__') return 1;
-    if (b.key === '__no_origin__') return -1;
-    return (a.binName ?? '').localeCompare(b.binName ?? '');
+    return a.name.localeCompare(b.name);
   });
-  return list;
+  return direction === 'asc' ? sorted : sorted.reverse();
 }
 
 export function ShoppingListPage() {
@@ -59,9 +55,22 @@ export function ShoppingListPage() {
   const { showToast } = useToast();
   const locationId = activeLocationId ?? null;
   const { entries, isLoading } = useShoppingList(locationId);
+  const { search, sortColumn, sortDirection, setSearch, setSort } =
+    useTableSearchParams<ShoppingSortColumn>('alpha');
+  const debouncedSearch = useDebounce(search, 300);
   const [newName, setNewName] = useState('');
 
-  const groups = useMemo(() => groupByBin(entries), [entries]);
+  const visibleEntries = useMemo(() => {
+    const q = debouncedSearch.trim().toLowerCase();
+    const filtered = q
+      ? entries.filter(
+          (e) =>
+            e.name.toLowerCase().includes(q) ||
+            (e.origin_bin_name ?? '').toLowerCase().includes(q),
+        )
+      : entries;
+    return sortEntries(filtered, sortColumn, sortDirection);
+  }, [entries, debouncedSearch, sortColumn, sortDirection]);
 
   async function handleAdd() {
     const name = newName.trim();
@@ -98,17 +107,13 @@ export function ShoppingListPage() {
     }
   }
 
-  const countLabel = entries.length > 0
-    ? `${entries.length} item${entries.length === 1 ? '' : 's'}`
-    : undefined;
-
   return (
-    <div className="flex flex-col gap-6 p-4 lg:p-8">
+    <div className="page-content-wide">
       <PageHeader
-        title={countLabel ? `Shopping List — ${countLabel}` : 'Shopping List'}
+        title="Shopping List"
         actions={
           canWrite && locationId ? (
-            <div className="flex gap-2">
+            <div className="flex items-center gap-2">
               <Input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
@@ -119,83 +124,170 @@ export function ShoppingListPage() {
                   }
                 }}
                 placeholder="Add an item…"
-                className="w-48 sm:w-64"
+                className="max-w-xs"
               />
-              <button
+              <Button
                 type="button"
                 onClick={() => void handleAdd()}
                 disabled={!newName.trim()}
-                className="px-4 py-2 rounded-[var(--radius-lg)] bg-[var(--accent)] text-white font-medium disabled:opacity-50"
               >
                 Add
-              </button>
+              </Button>
             </div>
           ) : undefined
         }
       />
 
-      {isLoading ? (
-        <SkeletonList count={3}>
-          {() => <Skeleton className="h-12 w-full rounded-[var(--radius-md)]" />}
-        </SkeletonList>
-      ) : entries.length === 0 ? (
-        <EmptyState
-          icon={ShoppingCart}
-          title="No items on your shopping list"
-          subtitle="When you remove an item from a bin, the undo toast offers an 'Add to list' shortcut. Items you add here also show up."
+      {(entries.length > 0 || search) && (
+        <SearchInput
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onClear={search ? () => setSearch('') : undefined}
+          placeholder="Search items..."
         />
-      ) : (
-        <div className="flex flex-col gap-6">
-          {groups.map((group) => (
-            <section key={group.key} className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                {group.key === '__no_origin__' ? (
-                  <span className="ui-eyebrow text-[var(--text-tertiary)]">No origin</span>
-                ) : (
-                  <span
-                    className={cn(
-                      'inline-flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] text-[13px] font-medium',
-                      group.trashed && 'opacity-60',
-                    )}
-                    style={{ backgroundColor: group.binColor ?? 'transparent' }}
-                  >
-                    {group.binIcon && <span aria-hidden>{group.binIcon}</span>}
-                    <span>{group.binName ?? 'Bin'}</span>
-                    {group.trashed && <span className="text-[11px]">(trashed)</span>}
-                  </span>
-                )}
+      )}
+
+      <Crossfade
+        isLoading={isLoading && entries.length === 0}
+        skeleton={
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-10 w-full rounded-[var(--radius-sm)]" />
+            <div className="flat-card rounded-[var(--radius-md)] overflow-hidden">
+              <div className="flex items-center gap-3 px-3 py-2 border-b border-[var(--border-subtle)] bg-[var(--bg-hover)]">
+                <Skeleton className="h-4 w-10 flex-[2]" />
+                <Skeleton className="h-4 w-8 flex-1 hidden sm:block" />
+                <Skeleton className="h-4 w-10 shrink-0" />
+                <Skeleton className="h-4 w-10 shrink-0" />
               </div>
-              <ul className="flex flex-col divide-y divide-[var(--border-flat)] rounded-[var(--radius-xl)] flat-card overflow-hidden">
-                {group.entries.map((entry) => (
-                  <li key={entry.id} className="flex items-center gap-3 px-4 py-3">
-                    <span className="flex-1 text-[15px]">{entry.name}</span>
-                    {canWrite && (
+              <SkeletonList count={6} className="gap-0">
+                {(i) => (
+                  <div
+                    className={cn(
+                      'px-3 py-2.5 flex items-center gap-3',
+                      i < 5 && 'border-b border-[var(--border-subtle)]',
+                    )}
+                  >
+                    <Skeleton
+                      className={cn(
+                        'h-4 flex-[2]',
+                        i % 3 === 0 ? 'w-2/3' : i % 3 === 1 ? 'w-1/2' : 'w-3/5',
+                      )}
+                    />
+                    <div className="flex-1 min-w-0 items-center gap-2 hidden sm:flex">
+                      <Skeleton className="h-5 w-5 rounded-[var(--radius-xs)] shrink-0" />
+                      <Skeleton className={cn('h-4', i % 2 === 0 ? 'w-1/2' : 'w-2/5')} />
+                    </div>
+                    <Skeleton className="h-8 w-8 rounded-[var(--radius-sm)] shrink-0" />
+                    <Skeleton className="h-8 w-8 rounded-[var(--radius-sm)] shrink-0" />
+                  </div>
+                )}
+              </SkeletonList>
+            </div>
+          </div>
+        }
+      >
+        {visibleEntries.length === 0 ? (
+          <EmptyState
+            icon={ShoppingCart}
+            title={search ? 'No items match your search' : 'No items on your shopping list'}
+            subtitle={
+              search
+                ? 'Try a different search term'
+                : "When you remove an item from a bin, the undo toast offers an 'Add to list' shortcut. Items you add here also show up."
+            }
+            variant={search ? 'search' : undefined}
+          />
+        ) : (
+          <Table>
+            <TableHeader>
+              <SortHeader
+                label="Item"
+                column="alpha"
+                currentColumn={sortColumn}
+                currentDirection={sortDirection}
+                onSort={setSort}
+                className="flex-[2]"
+              />
+              <SortHeader
+                label="Bin"
+                column="bin"
+                currentColumn={sortColumn}
+                currentDirection={sortDirection}
+                onSort={setSort}
+                className="hidden sm:flex flex-1"
+              />
+              {canWrite && <span className="w-10 shrink-0" />}
+              {canWrite && <span className="w-10 shrink-0" />}
+            </TableHeader>
+
+            {visibleEntries.map((entry) => {
+              const BinIcon = resolveIcon(entry.origin_bin_icon ?? '');
+              const colorPreset = entry.origin_bin_color
+                ? resolveColor(entry.origin_bin_color)
+                : undefined;
+              return (
+                <TableRow key={entry.id} className="cursor-default">
+                  <div className="flex-[2] min-w-0">
+                    <span className="truncate font-medium text-[14px] text-[var(--text-primary)] block">
+                      <Highlight text={entry.name} query={debouncedSearch} />
+                    </span>
+                  </div>
+                  <div
+                    className={cn(
+                      'hidden sm:flex flex-1 min-w-0 items-center gap-2',
+                      entry.origin_bin_trashed && 'opacity-60',
+                    )}
+                  >
+                    {entry.origin_bin_id ? (
                       <>
+                        <BinIconBadge icon={BinIcon} colorPreset={colorPreset} />
+                        <span className="truncate text-[13px] text-[var(--text-tertiary)]">
+                          <Highlight
+                            text={entry.origin_bin_name ?? ''}
+                            query={debouncedSearch}
+                          />
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-[13px] text-[var(--text-tertiary)]">
+                        &mdash;
+                      </span>
+                    )}
+                  </div>
+                  {canWrite && (
+                    <div className="w-10 shrink-0 flex justify-end">
+                      <Tooltip content="Mark bought">
                         <button
                           type="button"
                           onClick={() => void handleBought(entry)}
-                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-lg)] bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 text-[13px] font-semibold"
+                          aria-label={`Mark ${entry.name} bought`}
+                          className="h-9 w-9 rounded-[var(--radius-lg)] flex items-center justify-center text-green-700 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
                         >
                           <Check className="h-4 w-4" />
-                          Bought
                         </button>
+                      </Tooltip>
+                    </div>
+                  )}
+                  {canWrite && (
+                    <div className="w-10 shrink-0 flex justify-end">
+                      <Tooltip content="Remove">
                         <button
                           type="button"
                           onClick={() => void handleRemove(entry)}
-                          aria-label="Remove"
-                          className="p-2 rounded-[var(--radius-md)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                          aria-label={`Remove ${entry.name}`}
+                          className="h-9 w-9 rounded-[var(--radius-lg)] flex items-center justify-center text-[var(--text-tertiary)] hover:bg-[var(--bg-active)] transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]"
                         >
                           <X className="h-4 w-4" />
                         </button>
-                      </>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
-        </div>
-      )}
+                      </Tooltip>
+                    </div>
+                  )}
+                </TableRow>
+              );
+            })}
+          </Table>
+        )}
+      </Crossfade>
     </div>
   );
 }

--- a/src/features/shopping-list/__tests__/useShoppingList.test.ts
+++ b/src/features/shopping-list/__tests__/useShoppingList.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Events, notify } from '@/lib/eventBus';
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+}));
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({ token: 'test-token', user: { id: 'u1' } }),
+}));
+
+import { apiFetch } from '@/lib/api';
+import {
+  addItemsToShoppingList,
+  addToShoppingList,
+  markAsBought,
+  removeFromShoppingList,
+  useShoppingList,
+} from '../useShoppingList';
+
+const mockedApiFetch = apiFetch as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockedApiFetch.mockReset();
+});
+
+describe('useShoppingList', () => {
+  it('fetches entries for a location', async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      results: [
+        {
+          id: 'e1', location_id: 'loc1', name: 'Milk',
+          origin_bin_id: 'b1', origin_bin_name: 'Pantry',
+          origin_bin_icon: '', origin_bin_color: '',
+          origin_bin_trashed: false,
+          created_by: 'u1', created_by_name: 'Me',
+          created_at: '2026-04-22T00:00:00Z',
+        },
+      ],
+      count: 1,
+    });
+
+    const { result } = renderHook(() => useShoppingList('loc1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].name).toBe('Milk');
+    expect(mockedApiFetch).toHaveBeenCalledWith('/api/locations/loc1/shopping-list');
+  });
+
+  it('refetches on SHOPPING_LIST event', async () => {
+    mockedApiFetch.mockResolvedValue({ results: [], count: 0 });
+
+    const { result } = renderHook(() => useShoppingList('loc1'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      notify(Events.SHOPPING_LIST);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not fetch when locationId is null', async () => {
+    const { result } = renderHook(() => useShoppingList(null));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.entries).toEqual([]);
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('mutations', () => {
+  it('addItemsToShoppingList hits bulk endpoint', async () => {
+    mockedApiFetch.mockResolvedValueOnce({ entries: [{ id: 'e1', name: 'Milk' }], count: 1 });
+
+    const result = await addItemsToShoppingList('bin1', ['Milk']);
+
+    expect(result).toHaveLength(1);
+    expect(mockedApiFetch).toHaveBeenCalledWith('/api/bins/bin1/shopping-list', {
+      method: 'POST',
+      body: { names: ['Milk'] },
+    });
+  });
+
+  it('addToShoppingList hits manual endpoint', async () => {
+    mockedApiFetch.mockResolvedValueOnce({ entry: { id: 'e1', name: 'Milk' } });
+
+    await addToShoppingList('loc1', 'Milk', 'bin1');
+
+    expect(mockedApiFetch).toHaveBeenCalledWith('/api/locations/loc1/shopping-list', {
+      method: 'POST',
+      body: { name: 'Milk', originBinId: 'bin1' },
+    });
+  });
+
+  it('markAsBought returns restored payload', async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      deleted: true,
+      restored: { binId: 'b1', itemId: 'i1', name: 'Milk' },
+    });
+
+    const res = await markAsBought('e1');
+
+    expect(res.restored?.binId).toBe('b1');
+    expect(mockedApiFetch).toHaveBeenCalledWith('/api/shopping-list/e1/purchase', {
+      method: 'POST',
+    });
+  });
+
+  it('removeFromShoppingList deletes', async () => {
+    mockedApiFetch.mockResolvedValueOnce({ ok: true });
+
+    await removeFromShoppingList('e1');
+
+    expect(mockedApiFetch).toHaveBeenCalledWith('/api/shopping-list/e1', { method: 'DELETE' });
+  });
+});

--- a/src/features/shopping-list/useShoppingList.ts
+++ b/src/features/shopping-list/useShoppingList.ts
@@ -1,0 +1,61 @@
+import { apiFetch } from '@/lib/api';
+import { Events, notify } from '@/lib/eventBus';
+import { useListData } from '@/lib/useListQuery';
+import type { ShoppingListEntry } from '@/types';
+
+export function useShoppingList(locationId: string | null) {
+  const { data, isLoading } = useListData<ShoppingListEntry>(
+    locationId ? `/api/locations/${locationId}/shopping-list` : null,
+    [Events.SHOPPING_LIST],
+  );
+  return { entries: data, isLoading };
+}
+
+export async function addItemsToShoppingList(
+  binId: string,
+  names: string[],
+): Promise<ShoppingListEntry[]> {
+  const result = await apiFetch<{ entries: ShoppingListEntry[]; count: number }>(
+    `/api/bins/${binId}/shopping-list`,
+    { method: 'POST', body: { names } },
+  );
+  notify(Events.SHOPPING_LIST);
+  return result.entries;
+}
+
+export async function addToShoppingList(
+  locationId: string,
+  name: string,
+  originBinId?: string | null,
+): Promise<ShoppingListEntry> {
+  const body: { name: string; originBinId?: string | null } = { name };
+  if (originBinId) body.originBinId = originBinId;
+  const result = await apiFetch<{ entry: ShoppingListEntry }>(
+    `/api/locations/${locationId}/shopping-list`,
+    { method: 'POST', body },
+  );
+  notify(Events.SHOPPING_LIST);
+  return result.entry;
+}
+
+export async function markAsBought(id: string): Promise<{
+  deleted: true;
+  restored: { binId: string; itemId: string; name: string } | null;
+}> {
+  const result = await apiFetch<{
+    deleted: true;
+    restored: { binId: string; itemId: string; name: string } | null;
+  }>(`/api/shopping-list/${id}/purchase`, { method: 'POST' });
+  notify(Events.SHOPPING_LIST);
+  if (result.restored) notify(Events.BINS);
+  return result;
+}
+
+export async function removeFromShoppingList(id: string): Promise<void> {
+  await apiFetch(`/api/shopping-list/${id}`, { method: 'DELETE' });
+  notify(Events.SHOPPING_LIST);
+}
+
+export function notifyShoppingListChanged() {
+  notify(Events.SHOPPING_LIST);
+}

--- a/src/lib/eventBus.ts
+++ b/src/lib/eventBus.ts
@@ -13,6 +13,7 @@ export const Events = {
   CHECKOUTS: 'checkouts-changed',
   BIN_USAGE: 'bin-usage-changed',
   ATTACHMENTS: 'attachments-changed',
+  SHOPPING_LIST: 'shopping-list-changed',
 } as const;
 
 export type EventName = (typeof Events)[keyof typeof Events];

--- a/src/lib/qrConfig.ts
+++ b/src/lib/qrConfig.ts
@@ -18,7 +18,7 @@ export interface AuthStatusConfig {
 
 let cached: QrConfig = { qrPayloadMode: 'app' };
 let selfHostedCached = true; // default true (safe: hides cloud-only UI until confirmed)
-let attachmentsEnabledCached = false; // default false — feature is hidden until server confirms
+let attachmentsEnabledCached = true; // default true — feature is on unless server opts out
 let authStatusCached: AuthStatusConfig = {
   registrationMode: 'open',
   registrationEnabled: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,3 +353,17 @@ export interface UsageDay {
 }
 
 export type UsageGranularity = 'daily' | 'weekly' | 'monthly';
+
+export interface ShoppingListEntry {
+  id: string;
+  location_id: string;
+  name: string;
+  origin_bin_id: string | null;
+  origin_bin_name: string | null;
+  origin_bin_icon: string | null;
+  origin_bin_color: string | null;
+  origin_bin_trashed: boolean;
+  created_by: string;
+  created_by_name: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

- Adds shopping list API and client integration (prior commits)
- Refactors `ShoppingListPage` from a grouped bin-section layout to a flat sortable table matching `ItemsPage` and `TagsPage` conventions
- Search via `useTableSearchParams`, debounced filter on item name and bin name
- Sort by item name (alpha) or bin name with `SortHeader`
- `Crossfade` loading state with a skeleton that mirrors the table structure
- `BinIconBadge` in the Bin column; trashed bins rendered at 60% opacity
- Icon-only action buttons (check / X) in `w-10` columns with `Tooltip` labels
- `Button` component for the Add action; semantic CSS tokens throughout

## Test plan

- [ ] Add an item manually via the header input (Enter key and Add button)
- [ ] Verify item appears in the flat table
- [ ] Mark an item as bought — toast shows "Added back to [bin]" if restored, else "Marked bought"
- [ ] Remove an item — row disappears
- [ ] Search filters by item name and bin name
- [ ] Sort by Item and Bin columns; direction toggles correctly
- [ ] Empty state shown when list is empty or search yields no results
- [ ] Viewer role hides the Add input and action buttons