### PR TITLE
fix: route new-bin camera photos to form, not bulk flow

### DIFF
--- a/src/features/bins/BinCreateDialog.tsx
+++ b/src/features/bins/BinCreateDialog.tsx
@@ -22,9 +22,11 @@ interface BinCreateDialogProps {
   onOpenChange: (open: boolean) => void;
   prefillName?: string;
   allTags?: string[];
+  initialPhotos?: File[] | null;
+  onInitialPhotosConsumed?: () => void;
 }
 
-export function BinCreateDialog({ open, onOpenChange, prefillName, allTags: allTagsProp }: BinCreateDialogProps) {
+export function BinCreateDialog({ open, onOpenChange, prefillName, allTags: allTagsProp, initialPhotos, onInitialPhotosConsumed }: BinCreateDialogProps) {
   const { activeLocationId } = useAuth();
   const t = useTerminology();
   const allTagsFetched = useAllTagsFetch(allTagsProp !== undefined);
@@ -116,6 +118,8 @@ export function BinCreateDialog({ open, onOpenChange, prefillName, allTags: allT
                 onCancel={() => handleOpenChange(false)}
                 prefillName={prefillName}
                 allTags={allTags}
+                initialPhotos={initialPhotos}
+                onInitialPhotosConsumed={onInitialPhotosConsumed}
               />
             )
           )}

--- a/src/features/bins/BinCreateForm.tsx
+++ b/src/features/bins/BinCreateForm.tsx
@@ -13,7 +13,7 @@ import { useAiProviderSetup } from '@/features/ai/useAiProviderSetup';
 import { useAiSettings } from '@/features/ai/useAiSettings';
 import { AreaPicker } from '@/features/areas/AreaPicker';
 import { useAreaList } from '@/features/areas/useAreas';
-import { getCapturedReturnTarget, hasCapturedPhotos, setCapturedReturnTarget, takeCapturedPhotos } from '@/features/capture/capturedPhotos';
+import { setCapturedReturnTarget } from '@/features/capture/capturedPhotos';
 import { useAiEnabled } from '@/lib/aiToggle';
 import { isRecordingSupported } from '@/lib/audioRecorder';
 import { getSecondaryColorInfo, setSecondaryColor } from '@/lib/cardStyle';
@@ -64,6 +64,8 @@ interface BinCreateFormProps {
   allTags?: string[];
   header?: React.ReactNode | ((state: { name: string; color: string; items: BinItem[]; tags: string[]; icon: string; cardStyle: string; areaName: string }) => React.ReactNode);
   className?: string;
+  initialPhotos?: File[] | null;
+  onInitialPhotosConsumed?: () => void;
 }
 
 export function BinCreateForm({
@@ -78,6 +80,8 @@ export function BinCreateForm({
   allTags,
   header,
   className,
+  initialPhotos,
+  onInitialPhotosConsumed,
 }: BinCreateFormProps) {
   const t = useTerminology();
   const { areas } = useAreaList(locationId);
@@ -210,17 +214,14 @@ export function BinCreateForm({
     }
   }, [photos.length]);
 
+  const initialPhotosConsumedRef = useRef(false);
   useEffect(() => {
-    function checkCapturedPhotos() {
-      if (hasCapturedPhotos() && getCapturedReturnTarget() === 'bin-create') {
-        const { files } = takeCapturedPhotos();
-        addPhotosFromFiles(files);
-      }
-    }
-    checkCapturedPhotos();
-    window.addEventListener('focus', checkCapturedPhotos);
-    return () => window.removeEventListener('focus', checkCapturedPhotos);
-  }, [addPhotosFromFiles]);
+    if (initialPhotosConsumedRef.current) return;
+    if (!initialPhotos || initialPhotos.length === 0) return;
+    initialPhotosConsumedRef.current = true;
+    addPhotosFromFiles(initialPhotos);
+    onInitialPhotosConsumed?.();
+  }, [initialPhotos, addPhotosFromFiles, onInitialPhotosConsumed]);
 
   function handleUndoAiField(field: 'name' | 'items') {
     if (!preAiValues.current) return;

--- a/src/features/bins/BinListDialogs.tsx
+++ b/src/features/bins/BinListDialogs.tsx
@@ -15,6 +15,8 @@ import type { BulkDialog } from './useBulkDialogs';
 interface BinListDialogsProps {
   createOpen: boolean;
   setCreateOpen: (v: boolean) => void;
+  createInitialPhotos: File[] | null;
+  onCreateInitialPhotosConsumed: () => void;
   filterOpen: boolean;
   setFilterOpen: (v: boolean) => void;
   saveViewOpen: boolean;
@@ -35,6 +37,7 @@ interface BinListDialogsProps {
 
 export function BinListDialogs({
   createOpen, setCreateOpen,
+  createInitialPhotos, onCreateInitialPhotosConsumed,
   filterOpen, setFilterOpen,
   saveViewOpen, setSaveViewOpen,
   allTags, areas,
@@ -47,6 +50,8 @@ export function BinListDialogs({
       <BinCreateDialog
         open={createOpen}
         onOpenChange={setCreateOpen}
+        initialPhotos={createInitialPhotos}
+        onInitialPhotosConsumed={onCreateInitialPhotosConsumed}
         allTags={allTags}
       />
       <BinFilterDialog

--- a/src/features/bins/BinListPage.tsx
+++ b/src/features/bins/BinListPage.tsx
@@ -58,7 +58,7 @@ export function BinListPage() {
   const { search, setSearch, debouncedSearch, sort, setSort, sortDir, setSortDir, filters, setFilters, page, setPage, clearAll } = useBinSearchParams();
 
   const [createOpen, setCreateOpen] = useState(false);
-  useReopenCreateOnCapture(setCreateOpen);
+  useReopenCreateOnCapture(useCallback(() => setCreateOpen(true), []));
   const [filterOpen, setFilterOpen] = useState(false);
   const tourCtx = useTourContext();
 

--- a/src/features/bins/BinListPage.tsx
+++ b/src/features/bins/BinListPage.tsx
@@ -19,7 +19,6 @@ import { useToast } from '@/components/ui/toast';
 import { Tooltip } from '@/components/ui/tooltip';
 import { setCommandSelectedBinIds } from '@/features/ai/commandSelectedBins';
 import { useAreaList } from '@/features/areas/useAreas';
-import { useReopenCreateOnCapture } from '@/features/capture/useAutoOpenOnCapture';
 import { useScanDialog } from '@/features/qrcode/ScanDialogContext';
 import { useTagStyle } from '@/features/tags/useTagStyle';
 import { getCommandInputRef, useTourContext } from '@/features/tour/TourProvider';
@@ -39,6 +38,7 @@ import { BinTableView } from './BinTableView';
 import { buildBinBulkActions } from './buildBinBulkActions';
 import { DeleteBinDialog } from './DeleteBinDialog';
 import { SearchBarOverflowMenu } from './SearchBarOverflowMenu';
+import { useBinCreateFromCapture } from './useBinCreateFromCapture';
 import { useBinSearchParams } from './useBinSearchParams';
 import { countActiveFilters, type SortOption, updateBin, useAllTags, usePaginatedBinList } from './useBins';
 import { useBulkActions } from './useBulkActions';
@@ -57,23 +57,8 @@ export function BinListPage() {
   const location = useLocation();
   const { search, setSearch, debouncedSearch, sort, setSort, sortDir, setSortDir, filters, setFilters, page, setPage, clearAll } = useBinSearchParams();
 
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createInitialPhotos, setCreateInitialPhotos] = useState<File[] | null>(null);
-
-  const handleReopenCreate = useCallback((photos: File[]) => {
-    setCreateInitialPhotos(photos.length > 0 ? photos : null);
-    setCreateOpen(true);
-  }, []);
-  useReopenCreateOnCapture(handleReopenCreate);
-
-  const handleCreateOpenChange = useCallback((v: boolean) => {
-    if (!v) setCreateInitialPhotos(null);
-    setCreateOpen(v);
-  }, []);
-
-  const handleCreateInitialPhotosConsumed = useCallback(() => {
-    setCreateInitialPhotos(null);
-  }, []);
+  const { createOpen, setCreateOpen, createInitialPhotos, onCreateInitialPhotosConsumed } =
+    useBinCreateFromCapture();
   const [filterOpen, setFilterOpen] = useState(false);
   const tourCtx = useTourContext();
 
@@ -87,7 +72,7 @@ export function BinListPage() {
       tourCtx?.tour.start();
     }
     if (state) window.history.replaceState({}, '');
-  }, [location.state, tourCtx]);
+  }, [location.state, tourCtx, setCreateOpen]);
 
   const { activeLocationId } = useAuth();
   const prevLocationRef = useRef(activeLocationId);
@@ -378,9 +363,9 @@ export function BinListPage() {
       )}
 
       <BinListDialogs
-        createOpen={createOpen} setCreateOpen={handleCreateOpenChange}
+        createOpen={createOpen} setCreateOpen={setCreateOpen}
         createInitialPhotos={createInitialPhotos}
-        onCreateInitialPhotosConsumed={handleCreateInitialPhotosConsumed}
+        onCreateInitialPhotosConsumed={onCreateInitialPhotosConsumed}
         filterOpen={filterOpen} setFilterOpen={setFilterOpen}
         saveViewOpen={saveViewOpen} setSaveViewOpen={setSaveViewOpen}
         allTags={allTags}

--- a/src/features/bins/BinListPage.tsx
+++ b/src/features/bins/BinListPage.tsx
@@ -58,7 +58,22 @@ export function BinListPage() {
   const { search, setSearch, debouncedSearch, sort, setSort, sortDir, setSortDir, filters, setFilters, page, setPage, clearAll } = useBinSearchParams();
 
   const [createOpen, setCreateOpen] = useState(false);
-  useReopenCreateOnCapture(useCallback(() => setCreateOpen(true), []));
+  const [createInitialPhotos, setCreateInitialPhotos] = useState<File[] | null>(null);
+
+  const handleReopenCreate = useCallback((photos: File[]) => {
+    setCreateInitialPhotos(photos.length > 0 ? photos : null);
+    setCreateOpen(true);
+  }, []);
+  useReopenCreateOnCapture(handleReopenCreate);
+
+  const handleCreateOpenChange = useCallback((v: boolean) => {
+    if (!v) setCreateInitialPhotos(null);
+    setCreateOpen(v);
+  }, []);
+
+  const handleCreateInitialPhotosConsumed = useCallback(() => {
+    setCreateInitialPhotos(null);
+  }, []);
   const [filterOpen, setFilterOpen] = useState(false);
   const tourCtx = useTourContext();
 
@@ -363,7 +378,9 @@ export function BinListPage() {
       )}
 
       <BinListDialogs
-        createOpen={createOpen} setCreateOpen={setCreateOpen}
+        createOpen={createOpen} setCreateOpen={handleCreateOpenChange}
+        createInitialPhotos={createInitialPhotos}
+        onCreateInitialPhotosConsumed={handleCreateInitialPhotosConsumed}
         filterOpen={filterOpen} setFilterOpen={setFilterOpen}
         saveViewOpen={saveViewOpen} setSaveViewOpen={setSaveViewOpen}
         allTags={allTags}

--- a/src/features/bins/__tests__/BinCreateForm.test.tsx
+++ b/src/features/bins/__tests__/BinCreateForm.test.tsx
@@ -1,0 +1,192 @@
+import { act, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAddPhotosFromFiles = vi.fn();
+
+vi.mock('../usePhotoAnalysis', () => ({
+  usePhotoAnalysis: () => ({
+    fileInputRef: { current: null },
+    photos: [] as File[],
+    photoPreviews: [] as string[],
+    analyzing: false,
+    analyzeError: null,
+    handlePhotoSelect: vi.fn(),
+    handleRemovePhoto: vi.fn(),
+    addPhotosFromFiles: mockAddPhotosFromFiles,
+    handleAnalyze: vi.fn(),
+    handleReanalyze: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/ai/useAiSettings', () => ({
+  useAiSettings: () => ({ settings: null, isLoading: false }),
+}));
+
+vi.mock('@/features/ai/useAiProviderSetup', () => ({
+  useAiProviderSetup: () => ({ configured: false }),
+}));
+
+vi.mock('@/lib/aiToggle', () => ({
+  useAiEnabled: () => ({ aiEnabled: false }),
+}));
+
+vi.mock('@/features/areas/useAreas', () => ({
+  useAreaList: () => ({ areas: [] }),
+  buildAreaTree: () => [],
+  flattenAreaTree: () => [],
+  getAreaPath: () => '',
+  notifyAreasChanged: () => {},
+}));
+
+vi.mock('../useCustomFields', () => ({
+  useCustomFields: () => ({ fields: [] }),
+}));
+
+vi.mock('../useQuickAdd', () => ({
+  useQuickAdd: () => ({
+    value: '',
+    setValue: vi.fn(),
+    saving: false,
+    state: 'input',
+    expandedText: '',
+    setExpandedText: vi.fn(),
+    checked: new Map(),
+    structuredItems: null,
+    isStructuring: false,
+    structureError: null,
+    selectedCount: 0,
+    handleAdd: vi.fn(),
+    handlePaste: vi.fn(),
+    handleAiClick: vi.fn(),
+    handleExpandedKeyDown: vi.fn(),
+    handleExtractClick: vi.fn(),
+    toggleChecked: vi.fn(),
+    handleConfirmAdd: vi.fn(),
+    backToExpanded: vi.fn(),
+    cancelExpanded: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/useDictation', () => ({
+  useDictation: () => ({
+    state: 'idle',
+    transcript: '',
+    error: null,
+    duration: 0,
+    structuredItems: null,
+    start: vi.fn(),
+    stop: vi.fn(),
+    cancel: vi.fn(),
+    confirm: vi.fn(),
+    editTranscript: vi.fn(),
+    submitEditedTranscript: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/audioRecorder', () => ({
+  isRecordingSupported: () => false,
+}));
+
+vi.mock('@/lib/terminology', () => ({
+  useTerminology: () => ({
+    bin: 'bin', bins: 'bins', Bin: 'Bin', Bins: 'Bins',
+    location: 'location', locations: 'locations', Location: 'Location', Locations: 'Locations',
+    area: 'area', areas: 'areas', Area: 'Area', Areas: 'Areas',
+  }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    user: null,
+    token: null,
+    activeLocationId: 'loc-1',
+    demoMode: false,
+    loading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshSession: vi.fn(),
+    setActiveLocationId: vi.fn(),
+    updateUser: vi.fn(),
+    deleteAccount: vi.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// If additional mocks are required due to import graph (e.g., InlineAiSetup pulls more),
+// add them here — minimum surface only. The goal is to render the form's mount effect.
+
+import { BinCreateForm } from '../BinCreateForm';
+
+function renderForm(props: Partial<React.ComponentProps<typeof BinCreateForm>> = {}) {
+  const onSubmit = vi.fn();
+  const defaults: React.ComponentProps<typeof BinCreateForm> = {
+    mode: 'full',
+    locationId: 'loc-1',
+    onSubmit,
+    ...props,
+  };
+  return render(
+    <MemoryRouter>
+      <BinCreateForm {...defaults} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockAddPhotosFromFiles.mockClear();
+});
+
+describe('BinCreateForm initialPhotos seeding', () => {
+  it('seeds photos once when mounted with initialPhotos', () => {
+    const files = [
+      new File(['a'], 'a.jpg', { type: 'image/jpeg' }),
+      new File(['b'], 'b.jpg', { type: 'image/jpeg' }),
+    ];
+    const onInitialPhotosConsumed = vi.fn();
+
+    renderForm({ initialPhotos: files, onInitialPhotosConsumed });
+
+    expect(mockAddPhotosFromFiles).toHaveBeenCalledTimes(1);
+    expect(mockAddPhotosFromFiles).toHaveBeenCalledWith(files);
+    expect(onInitialPhotosConsumed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-seed when re-rendered with the same prop reference', () => {
+    const files = [new File(['a'], 'a.jpg', { type: 'image/jpeg' })];
+    const onInitialPhotosConsumed = vi.fn();
+    const { rerender } = renderForm({ initialPhotos: files, onInitialPhotosConsumed });
+
+    act(() => {
+      rerender(
+        <MemoryRouter>
+          <BinCreateForm
+            mode="full"
+            locationId="loc-1"
+            onSubmit={vi.fn()}
+            initialPhotos={files}
+            onInitialPhotosConsumed={onInitialPhotosConsumed}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(mockAddPhotosFromFiles).toHaveBeenCalledTimes(1);
+    expect(onInitialPhotosConsumed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when initialPhotos is null', () => {
+    const onInitialPhotosConsumed = vi.fn();
+    renderForm({ initialPhotos: null, onInitialPhotosConsumed });
+    expect(mockAddPhotosFromFiles).not.toHaveBeenCalled();
+    expect(onInitialPhotosConsumed).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when initialPhotos is an empty array', () => {
+    const onInitialPhotosConsumed = vi.fn();
+    renderForm({ initialPhotos: [], onInitialPhotosConsumed });
+    expect(mockAddPhotosFromFiles).not.toHaveBeenCalled();
+    expect(onInitialPhotosConsumed).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bins/__tests__/BinCreateForm.test.tsx
+++ b/src/features/bins/__tests__/BinCreateForm.test.tsx
@@ -153,11 +153,14 @@ describe('BinCreateForm initialPhotos seeding', () => {
     expect(onInitialPhotosConsumed).toHaveBeenCalledTimes(1);
   });
 
-  it('does not re-seed when re-rendered with the same prop reference', () => {
+  it('does not re-seed when re-rendered with a fresh onInitialPhotosConsumed reference', () => {
+    // A new inline callback reference each render changes the effect's dep array
+    // and would re-fire without the ref guard. This test exercises that guard.
     const files = [new File(['a'], 'a.jpg', { type: 'image/jpeg' })];
-    const onInitialPhotosConsumed = vi.fn();
-    const { rerender } = renderForm({ initialPhotos: files, onInitialPhotosConsumed });
+    const consumed1 = vi.fn();
+    const { rerender } = renderForm({ initialPhotos: files, onInitialPhotosConsumed: consumed1 });
 
+    const consumed2 = vi.fn();
     act(() => {
       rerender(
         <MemoryRouter>
@@ -166,14 +169,15 @@ describe('BinCreateForm initialPhotos seeding', () => {
             locationId="loc-1"
             onSubmit={vi.fn()}
             initialPhotos={files}
-            onInitialPhotosConsumed={onInitialPhotosConsumed}
+            onInitialPhotosConsumed={consumed2}
           />
         </MemoryRouter>,
       );
     });
 
     expect(mockAddPhotosFromFiles).toHaveBeenCalledTimes(1);
-    expect(onInitialPhotosConsumed).toHaveBeenCalledTimes(1);
+    expect(consumed1).toHaveBeenCalledTimes(1);
+    expect(consumed2).not.toHaveBeenCalled();
   });
 
   it('does nothing when initialPhotos is null', () => {

--- a/src/features/bins/useBinCreateFromCapture.ts
+++ b/src/features/bins/useBinCreateFromCapture.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react';
+import { useReopenCreateOnCapture } from '@/features/capture/useAutoOpenOnCapture';
+
+export interface BinCreateFromCaptureState {
+  createOpen: boolean;
+  setCreateOpen: (v: boolean) => void;
+  createInitialPhotos: File[] | null;
+  onCreateInitialPhotosConsumed: () => void;
+}
+
+export function useBinCreateFromCapture(): BinCreateFromCaptureState {
+  const [createOpen, setCreateOpenRaw] = useState(false);
+  const [createInitialPhotos, setCreateInitialPhotos] = useState<File[] | null>(null);
+
+  useReopenCreateOnCapture(useCallback((photos: File[]) => {
+    setCreateInitialPhotos(photos.length > 0 ? photos : null);
+    setCreateOpenRaw(true);
+  }, []));
+
+  const setCreateOpen = useCallback((v: boolean) => {
+    if (!v) setCreateInitialPhotos(null);
+    setCreateOpenRaw(v);
+  }, []);
+
+  const onCreateInitialPhotosConsumed = useCallback(() => {
+    setCreateInitialPhotos(null);
+  }, []);
+
+  return { createOpen, setCreateOpen, createInitialPhotos, onCreateInitialPhotosConsumed };
+}

--- a/src/features/capture/__tests__/useReopenCreateOnCapture.test.tsx
+++ b/src/features/capture/__tests__/useReopenCreateOnCapture.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getCapturedReturnTarget,
+  hasCapturedPhotos,
+  setCapturedPhotos,
+  setCapturedReturnTarget,
+  takeCapturedPhotos,
+} from '../capturedPhotos';
+import { useReopenCreateOnCapture } from '../useAutoOpenOnCapture';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter initialEntries={['/bins']}>{children}</MemoryRouter>;
+}
+
+afterEach(() => {
+  takeCapturedPhotos(); // reset module state between tests
+});
+
+describe('useReopenCreateOnCapture', () => {
+  it('invokes the callback with files and clears module state when target is bin-create', () => {
+    const file = new File(['x'], 'capture-1.jpg', { type: 'image/jpeg' });
+    setCapturedPhotos([file]);
+    setCapturedReturnTarget('bin-create');
+    const onReopen = vi.fn();
+
+    renderHook(() => useReopenCreateOnCapture(onReopen), { wrapper });
+
+    expect(onReopen).toHaveBeenCalledTimes(1);
+    expect(onReopen).toHaveBeenCalledWith([file]);
+    expect(hasCapturedPhotos()).toBe(false);
+    expect(getCapturedReturnTarget()).toBe(null);
+  });
+
+  it('invokes the callback with [] when target is bin-create but no photos pending (cancel path)', () => {
+    setCapturedReturnTarget('bin-create');
+    const onReopen = vi.fn();
+
+    renderHook(() => useReopenCreateOnCapture(onReopen), { wrapper });
+
+    expect(onReopen).toHaveBeenCalledTimes(1);
+    expect(onReopen).toHaveBeenCalledWith([]);
+  });
+
+  it('does not invoke the callback when target is bulk-add', () => {
+    setCapturedPhotos([new File(['x'], 'a.jpg')]);
+    setCapturedReturnTarget('bulk-add');
+    const onReopen = vi.fn();
+
+    renderHook(() => useReopenCreateOnCapture(onReopen), { wrapper });
+
+    expect(onReopen).not.toHaveBeenCalled();
+    expect(hasCapturedPhotos()).toBe(true); // unchanged
+    expect(getCapturedReturnTarget()).toBe('bulk-add');
+  });
+
+  it('does not invoke the callback when target is null', () => {
+    const onReopen = vi.fn();
+    renderHook(() => useReopenCreateOnCapture(onReopen), { wrapper });
+    expect(onReopen).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/capture/useAutoOpenOnCapture.ts
+++ b/src/features/capture/useAutoOpenOnCapture.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getCapturedReturnTarget, hasCapturedPhotos, setCapturedReturnTarget } from './capturedPhotos';
+import { getCapturedReturnTarget, hasCapturedPhotos, takeCapturedPhotos } from './capturedPhotos';
 
 /** Auto-open the AI command dialog when returning from camera capture with pending photos. */
 export function useAutoOpenOnCapture(
@@ -16,14 +16,15 @@ export function useAutoOpenOnCapture(
   }, [aiEnabled, setCommandOpen, pathname]);
 }
 
-/** Auto-open the bin create dialog when returning from camera capture (even if cancelled with no photos). */
-export function useReopenCreateOnCapture(setCreateOpen: (v: boolean) => void): void {
+/** Reopen the bin-create dialog when returning from camera capture, seeding any captured photos. */
+export function useReopenCreateOnCapture(
+  onReopen: (photos: File[]) => void,
+): void {
   const { pathname } = useLocation();
   useEffect(() => {
-    if (getCapturedReturnTarget() === 'bin-create') {
-      setCapturedReturnTarget(null);
-      setCreateOpen(true);
-    }
+    if (getCapturedReturnTarget() !== 'bin-create') return;
+    const { files } = takeCapturedPhotos();
+    onReopen(files);
   // biome-ignore lint/correctness/useExhaustiveDependencies: pathname triggers re-check on navigation back from camera
-  }, [setCreateOpen, pathname]);
+  }, [onReopen, pathname]);
 }

--- a/src/features/dashboard/DashboardDialogs.tsx
+++ b/src/features/dashboard/DashboardDialogs.tsx
@@ -37,6 +37,8 @@ const DeleteBinDialog = lazy(() =>
 interface DashboardDialogsProps {
   createOpen: boolean;
   setCreateOpen: (v: boolean) => void;
+  createInitialPhotos: File[] | null;
+  onCreateInitialPhotosConsumed: () => void;
   bulk: { isOpen: (d: BulkDialog) => boolean; open: (d: BulkDialog) => void; close: () => void };
   selectedIds: Set<string>;
   clearSelection: () => void;
@@ -55,6 +57,7 @@ interface DashboardDialogsProps {
 
 export function DashboardDialogs({
   createOpen, setCreateOpen,
+  createInitialPhotos, onCreateInitialPhotosConsumed,
   bulk, selectedIds, clearSelection,
   allTags, selectable, isAdmin, canWrite,
   bulkDelete, bulkPinToggle, bulkDuplicate, pinLabel, isBusy,
@@ -97,7 +100,13 @@ export function DashboardDialogs({
     <>
       {createMounted && (
         <Suspense fallback={null}>
-          <BinCreateDialog open={createOpen} onOpenChange={setCreateOpen} allTags={allTags} />
+          <BinCreateDialog
+            open={createOpen}
+            onOpenChange={setCreateOpen}
+            initialPhotos={createInitialPhotos}
+            onInitialPhotosConsumed={onCreateInitialPhotosConsumed}
+            allTags={allTags}
+          />
         </Suspense>
       )}
 

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { BarChart3, Bookmark, ChevronRight, Inbox, MapPin, Package, Pin, Plus, Printer, QrCode, ScanLine, Sparkles } from 'lucide-react';
-import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { SavedViewChips } from '@/components/saved-view-chips';
@@ -12,11 +12,11 @@ import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/toast';
 import { Tooltip } from '@/components/ui/tooltip';
 import { BinCard } from '@/features/bins/BinCard';
+import { useBinCreateFromCapture } from '@/features/bins/useBinCreateFromCapture';
 import { buildViewSearchParams } from '@/features/bins/useBinSearchParams';
 import { useAllTags } from '@/features/bins/useBins';
 import { useBulkActions } from '@/features/bins/useBulkActions';
 import { useBulkDialogs } from '@/features/bins/useBulkDialogs';
-import { useReopenCreateOnCapture } from '@/features/capture/useAutoOpenOnCapture';
 import { useScanDialog } from '@/features/qrcode/ScanDialogContext';
 import { getCommandInputRef } from '@/features/tour/TourProvider';
 import { useAiEnabled } from '@/lib/aiToggle';
@@ -58,23 +58,8 @@ export function DashboardPage() {
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, 300);
   const { views: savedViews } = useSavedViews();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createInitialPhotos, setCreateInitialPhotos] = useState<File[] | null>(null);
-
-  const handleReopenCreate = useCallback((photos: File[]) => {
-    setCreateInitialPhotos(photos.length > 0 ? photos : null);
-    setCreateOpen(true);
-  }, []);
-  useReopenCreateOnCapture(handleReopenCreate);
-
-  const handleCreateOpenChange = useCallback((v: boolean) => {
-    if (!v) setCreateInitialPhotos(null);
-    setCreateOpen(v);
-  }, []);
-
-  const handleCreateInitialPhotosConsumed = useCallback(() => {
-    setCreateInitialPhotos(null);
-  }, []);
+  const { createOpen, setCreateOpen, createInitialPhotos, onCreateInitialPhotosConsumed } =
+    useBinCreateFromCapture();
 
   const { isAdmin, canWrite, canCreateBin } = usePermissions();
   const allTags = useAllTags();
@@ -375,9 +360,9 @@ export function DashboardPage() {
       </Crossfade>
 
       <DashboardDialogs
-        createOpen={createOpen} setCreateOpen={handleCreateOpenChange}
+        createOpen={createOpen} setCreateOpen={setCreateOpen}
         createInitialPhotos={createInitialPhotos}
-        onCreateInitialPhotosConsumed={handleCreateInitialPhotosConsumed}
+        onCreateInitialPhotosConsumed={onCreateInitialPhotosConsumed}
         bulk={bulk} selectedIds={selectedIds} clearSelection={clearSelection}
         allTags={allTags} selectable={selectable} isAdmin={isAdmin} canWrite={canWrite}
         bulkDelete={bulkDelete} bulkPinToggle={bulkPinToggle} bulkDuplicate={bulkDuplicate}

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -59,7 +59,22 @@ export function DashboardPage() {
   const debouncedSearch = useDebounce(search, 300);
   const { views: savedViews } = useSavedViews();
   const [createOpen, setCreateOpen] = useState(false);
-  useReopenCreateOnCapture(useCallback(() => setCreateOpen(true), []));
+  const [createInitialPhotos, setCreateInitialPhotos] = useState<File[] | null>(null);
+
+  const handleReopenCreate = useCallback((photos: File[]) => {
+    setCreateInitialPhotos(photos.length > 0 ? photos : null);
+    setCreateOpen(true);
+  }, []);
+  useReopenCreateOnCapture(handleReopenCreate);
+
+  const handleCreateOpenChange = useCallback((v: boolean) => {
+    if (!v) setCreateInitialPhotos(null);
+    setCreateOpen(v);
+  }, []);
+
+  const handleCreateInitialPhotosConsumed = useCallback(() => {
+    setCreateInitialPhotos(null);
+  }, []);
 
   const { isAdmin, canWrite, canCreateBin } = usePermissions();
   const allTags = useAllTags();
@@ -360,7 +375,9 @@ export function DashboardPage() {
       </Crossfade>
 
       <DashboardDialogs
-        createOpen={createOpen} setCreateOpen={setCreateOpen}
+        createOpen={createOpen} setCreateOpen={handleCreateOpenChange}
+        createInitialPhotos={createInitialPhotos}
+        onCreateInitialPhotosConsumed={handleCreateInitialPhotosConsumed}
         bulk={bulk} selectedIds={selectedIds} clearSelection={clearSelection}
         allTags={allTags} selectable={selectable} isAdmin={isAdmin} canWrite={canWrite}
         bulkDelete={bulkDelete} bulkPinToggle={bulkPinToggle} bulkDuplicate={bulkDuplicate}

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { BarChart3, Bookmark, ChevronRight, Inbox, MapPin, Package, Pin, Plus, Printer, QrCode, ScanLine, Sparkles } from 'lucide-react';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { SavedViewChips } from '@/components/saved-view-chips';
@@ -59,7 +59,7 @@ export function DashboardPage() {
   const debouncedSearch = useDebounce(search, 300);
   const { views: savedViews } = useSavedViews();
   const [createOpen, setCreateOpen] = useState(false);
-  useReopenCreateOnCapture(setCreateOpen);
+  useReopenCreateOnCapture(useCallback(() => setCreateOpen(true), []));
 
   const { isAdmin, canWrite, canCreateBin } = usePermissions();
   const allTags = useAllTags();


### PR DESCRIPTION
## Summary

- When the user clicked the Camera button inside `BinCreateDialog`, captured photos landed in the AI "Create from Photos" bulk flow instead of on the new-bin form. Two pathname-triggered hooks (`useReopenCreateOnCapture` on the route page, `useAutoOpenOnCapture` on `AppLayout`) raced on shared module state in `capturedPhotos.ts` — the route-page hook nulled `returnTarget` first, then the layout hook saw `null + pending photos` and opened the bulk dialog.
- Fix: `useReopenCreateOnCapture` now takes `(photos: File[]) => void` and consumes the module bridge atomically via `takeCapturedPhotos()`, handing the files directly to the caller. Files thread down as `initialPhotos` prop through `*Dialogs` → `BinCreateDialog` → `BinCreateForm`, where a ref-guarded mount effect seeds them into `usePhotoAnalysis` exactly once.
- Extracted the route-page wiring (state + callbacks) into `useBinCreateFromCapture` to avoid byte-identical duplication between `BinListPage` and `DashboardPage`. Bulk-add flow is unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean (client + server)
- [x] `npx biome check .` at baseline (70 warnings, 8 infos — same as main)
- [x] `npx vitest run` — 1413/1413 pass, including 4 new hook tests and 4 new form tests (ref guard exercised with fresh callback identity)
- [ ] Manual smoke on \`npm run dev:all\`:
  - [ ] Dashboard → `+ New bin` → Camera → take 1-2 photos → Done. Dialog reopens with photos attached; no "Create from Photos" dialog.
  - [ ] Bulk regression: capture launched from AI command → "Create from Photos" bulk flow still works.
  - [ ] Cancel path: `+ New bin` → Camera → close without capturing. Dialog reopens empty, no bulk dialog.