### PR TITLE
feat: add photo capture guidance with tips, help sheet, and coachmark

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,11 +52,14 @@ function DialogContent({
   children,
   className,
   fullScreenMobile,
+  centered,
   flush,
 }: {
   children: React.ReactNode;
   className?: string;
   fullScreenMobile?: boolean;
+  /** Float centered on mobile instead of anchoring as a bottom sheet. Ignored with fullScreenMobile. */
+  centered?: boolean;
   /** Skip the default padded scroll wrapper so the caller can own the flex layout (e.g. chat shell). */
   flush?: boolean;
 }) {
@@ -77,7 +80,12 @@ function DialogContent({
   return (
     <DialogContext.Provider value={{ open, onOpenChange, titleId }}>
       <DialogPortalContext.Provider value={portalNode}>
-        <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center">
+        <div
+          className={cn(
+            'fixed inset-0 z-[60] flex justify-center',
+            centered && !fullScreenMobile ? 'items-center' : 'items-end sm:items-center',
+          )}
+        >
           {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay dismisses dialog on click */}
           <div
             role="presentation"
@@ -94,7 +102,9 @@ function DialogContent({
               'relative z-[60] w-full sm:max-w-md flat-heavy',
               fullScreenMobile
                 ? 'rounded-none sm:rounded-[var(--radius-xl)] h-[100dvh] sm:h-auto sm:max-h-[85vh]'
-                : 'rounded-t-[var(--radius-xl)] sm:rounded-[var(--radius-xl)] mx-0 sm:mx-4 max-h-[70vh] sm:max-h-[85vh]',
+                : centered
+                  ? 'rounded-[var(--radius-xl)] mx-4 max-h-[85vh]'
+                  : 'rounded-t-[var(--radius-xl)] sm:rounded-[var(--radius-xl)] mx-0 sm:mx-4 max-h-[70vh] sm:max-h-[85vh]',
               'overflow-hidden flex flex-col',
               'transition-all duration-200',
               className

--- a/src/features/capture/CapturePage.tsx
+++ b/src/features/capture/CapturePage.tsx
@@ -1,9 +1,11 @@
-import { Camera, Check, RotateCcw, SwitchCamera } from 'lucide-react';
+import { Camera, Check, RotateCcw, SwitchCamera, X } from 'lucide-react';
 import { useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
+import { cn, focusRing } from '@/lib/utils';
 import { CapturePageBulkGroup } from './CapturePageBulkGroup';
 import { getCapturedReturnTarget, setCapturedPhotos } from './capturedPhotos';
+import { FirstRunCoachmark, HelpButton } from './guidance/CameraGuidance';
 import type { CapturedPhoto } from './useCapture';
 import { useCapture } from './useCapture';
 
@@ -82,34 +84,38 @@ function CapturePageLegacy({ binId }: { binId?: string }) {
     navigate(-1);
   }, [binId, photos, navigate]);
 
+  const handleClose = useCallback(() => {
+    if (photos.length > 0 && !binId) {
+      const ok = window.confirm(
+        `Discard ${photos.length} photo${photos.length === 1 ? '' : 's'}?`,
+      );
+      if (!ok) return;
+    }
+    navigate(-1);
+  }, [photos.length, binId, navigate]);
+
   const hasCamera = !!navigator.mediaDevices?.getUserMedia;
+  const photoCountLabel = `${photos.length} photo${photos.length === 1 ? '' : 's'}`;
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-black">
-      {/* Video element — always rendered so ref is available when startCamera fires */}
-      <div className="flex-1 relative overflow-hidden">
-        <video
-          ref={videoRef}
-          playsInline
-          muted
-          className="h-full w-full object-cover"
-        />
-        {isStreaming && photos.length > 0 && (
-          <div className="absolute top-4 right-4 bg-black/60 px-2.5 py-1 rounded-[var(--radius-md)] text-white text-[13px] font-medium">
-            {photos.length} photo{photos.length !== 1 ? 's' : ''}
-          </div>
-        )}
-      </div>
+      {/* Video fills viewport; all UI layers on top */}
+      <video
+        ref={videoRef}
+        playsInline
+        muted
+        className="absolute inset-0 h-full w-full object-cover"
+      />
 
       {/* Overlay: start screen or error (covers video when not streaming) */}
       {!isStreaming && (
-        <div className="absolute inset-0 z-10 bg-[var(--bg-base)] flex flex-col items-center justify-center gap-5 px-6">
+        <div className="absolute inset-0 z-20 bg-[var(--bg-base)] flex flex-col items-center justify-center gap-5 px-6">
           {!hasCamera ? (
             <>
               <Camera className="h-16 w-16 text-[var(--text-tertiary)]" />
-              <p className="text-[17px] font-semibold text-[var(--text-primary)] text-center">
+              <h2 className="text-[17px] font-semibold text-[var(--text-primary)] text-center">
                 Camera not available
-              </p>
+              </h2>
               <p className="text-[14px] text-[var(--text-secondary)] text-center max-w-sm">
                 Your browser does not support camera access. Make sure you are using HTTPS.
               </p>
@@ -133,9 +139,9 @@ function CapturePageLegacy({ binId }: { binId?: string }) {
           ) : (
             <>
               <Camera className="h-16 w-16 text-[var(--accent)] opacity-80" />
-              <p className="text-[17px] font-semibold text-[var(--text-primary)]">
+              <h2 className="text-[17px] font-semibold text-[var(--text-primary)]">
                 Ready to capture
-              </p>
+              </h2>
               <p className="text-[14px] text-[var(--text-secondary)] text-center max-w-sm">
                 Tap the button below to start the camera and take photos.
               </p>
@@ -150,35 +156,90 @@ function CapturePageLegacy({ binId }: { binId?: string }) {
         </div>
       )}
 
-      {/* Bottom controls — only when streaming */}
+      <FirstRunCoachmark isStreaming={isStreaming} />
+
       {isStreaming && (
         <>
-          {/* Thumbnail strip */}
-          {photos.length > 0 && (
-            <div className="flex gap-1.5 px-3 py-2 overflow-x-auto">
-              {photos.map((photo) => (
-                <div key={photo.id} className="relative h-12 w-12 flex-shrink-0">
-                  <img
-                    src={photo.thumbnailUrl}
-                    alt=""
-                    className="h-full w-full rounded-[var(--radius-sm)] object-cover"
-                  />
-                  <StatusBadge photo={photo} onRetry={() => retryUpload(photo.id)} />
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Control bar */}
+          {/* Top bar */}
           <div
-            className="flex items-center justify-between px-8 py-4"
+            className="relative z-10 flex items-center justify-between px-3 py-2 bg-black/50"
+            style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top, 0.5rem))' }}
+          >
+            <button
+              type="button"
+              onClick={handleClose}
+              className={cn(
+                focusRing,
+                'h-8 w-8 flex items-center justify-center text-white/90 hover:text-white focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
+              aria-label="Close"
+            >
+              <X className="h-5 w-5" />
+            </button>
+
+            <div
+              aria-live="polite"
+              className="text-[11px] font-medium text-white/90 tracking-wide"
+            >
+              {photoCountLabel}
+            </div>
+
+            <HelpButton className="bg-transparent hover:bg-white/10" />
+          </div>
+
+          {/* Viewfinder */}
+          <div className="flex-1 relative flex items-center justify-center">
+            <div className="absolute inset-4 border border-dashed border-white/40 pointer-events-none">
+              <div className="absolute -top-px -left-px h-4 w-4 border-t-2 border-l-2 border-[var(--accent)]" />
+              <div className="absolute -top-px -right-px h-4 w-4 border-t-2 border-r-2 border-[var(--accent)]" />
+              <div className="absolute -bottom-px -left-px h-4 w-4 border-b-2 border-l-2 border-[var(--accent)]" />
+              <div className="absolute -bottom-px -right-px h-4 w-4 border-b-2 border-r-2 border-[var(--accent)]" />
+            </div>
+            {photos.length === 0 && (
+              <p className="relative text-[13px] text-white/55 font-medium text-center px-6">
+                tap shutter to capture
+              </p>
+            )}
+          </div>
+
+          {/* Thumbnail strip */}
+          <div
+            className="relative z-10 bg-black/50 overflow-x-auto overflow-y-hidden"
+            style={{ minHeight: 56 }}
+          >
+            {photos.length === 0 ? (
+              <div className="px-3 py-3 text-[12px] text-white/40 italic">
+                No photos yet
+              </div>
+            ) : (
+              <ul className="flex items-center gap-[2px] px-3 py-2">
+                {photos.map((photo) => (
+                  <li key={photo.id} className="relative h-11 w-11 flex-shrink-0">
+                    <img
+                      src={photo.thumbnailUrl}
+                      alt=""
+                      className="h-full w-full rounded-[var(--radius-sm)] object-cover"
+                    />
+                    <StatusBadge photo={photo} onRetry={() => retryUpload(photo.id)} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Bottom controls */}
+          <div
+            className="relative z-10 flex items-center justify-between px-4 pt-2 pb-4 bg-black/50"
             style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom, 1rem))' }}
           >
             <button
               type="button"
               onClick={flipCamera}
-              className="h-11 w-11 flex items-center justify-center text-white/80 hover:text-white transition-colors"
               aria-label="Flip camera"
+              className={cn(
+                focusRing,
+                'w-[54px] h-11 flex items-center justify-center text-white/80 hover:text-white transition-colors focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
             >
               <SwitchCamera className="h-6 w-6" />
             </button>
@@ -186,16 +247,28 @@ function CapturePageLegacy({ binId }: { binId?: string }) {
             <button
               type="button"
               onClick={() => capture()}
-              className="h-[68px] w-[68px] rounded-[50%] border-[3px] border-white flex items-center justify-center active:scale-95 transition-transform"
               aria-label="Take photo"
+              className={cn(
+                focusRing,
+                'h-[54px] w-[54px] rounded-[50%] border-[3px] border-white flex items-center justify-center active:scale-95 transition-transform relative focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
             >
-              <div className="h-[56px] w-[56px] rounded-[50%] bg-white" />
+              <div className="h-[42px] w-[42px] rounded-[50%] bg-white" />
+              {photos.length === 0 && (
+                <div
+                  aria-hidden="true"
+                  className="absolute -inset-1 rounded-[50%] ring-[3px] ring-[var(--accent)]"
+                />
+              )}
             </button>
 
             <button
               type="button"
               onClick={handleDone}
-              className="text-[15px] font-semibold text-white/80 hover:text-white transition-colors"
+              className={cn(
+                focusRing,
+                'w-[54px] text-[13px] font-semibold text-white hover:text-white/90 focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+              )}
             >
               Done
             </button>

--- a/src/features/capture/CapturePageBulkGroup.tsx
+++ b/src/features/capture/CapturePageBulkGroup.tsx
@@ -1,8 +1,10 @@
-import { Check, Images, X } from 'lucide-react';
+import { Camera, Check, Images, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
 import { cn, focusRing } from '@/lib/utils';
 import { setCapturedPhotos, setCapturedReturnTarget } from './capturedPhotos';
+import { FirstRunCoachmark, HelpButton } from './guidance/CameraGuidance';
 import { useCaptureGrouping } from './useCaptureGrouping';
 
 const LONG_PRESS_MS = 500;
@@ -169,53 +171,33 @@ export function CapturePageBulkGroup() {
         <div className="absolute inset-0 z-20 flex flex-col bg-[var(--bg-base)] items-center justify-center gap-5 px-6">
           {!hasCamera ? (
             <>
+              <Camera className="h-16 w-16 text-[var(--text-tertiary)]" />
               <h2 className="text-[17px] font-semibold text-[var(--text-primary)] text-center">
                 Camera not available
               </h2>
               <p className="text-[14px] text-[var(--text-secondary)] text-center max-w-sm">
                 Your browser does not support camera access. Make sure you are using HTTPS.
               </p>
-              <button
-                type="button"
-                onClick={() => navigate(-1)}
-                className={cn(
-                  focusRing,
-                  'px-4 py-2 text-[14px] border border-[var(--border-flat)] rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
-                )}
-              >
+              <Button variant="outline" onClick={() => navigate(-1)}>
                 Go Back
-              </button>
+              </Button>
             </>
           ) : error ? (
             <>
+              <Camera className="h-16 w-16 text-[var(--destructive)] opacity-60" />
               <p className="text-[15px] text-[var(--text-primary)] text-center max-w-sm font-medium">
                 {error}
               </p>
               <div className="flex gap-3">
-                <button
-                  type="button"
-                  onClick={() => navigate(-1)}
-                  className={cn(
-                    focusRing,
-                    'px-4 py-2 text-[14px] border border-[var(--border-flat)] rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
-                  )}
-                >
+                <Button variant="outline" onClick={() => navigate(-1)}>
                   Go Back
-                </button>
-                <button
-                  type="button"
-                  onClick={() => startCamera()}
-                  className={cn(
-                    focusRing,
-                    'px-4 py-2 text-[14px] bg-[var(--accent)] text-white rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
-                  )}
-                >
-                  Try Again
-                </button>
+                </Button>
+                <Button onClick={() => startCamera()}>Try Again</Button>
               </div>
             </>
           ) : (
             <>
+              <Camera className="h-16 w-16 text-[var(--accent)] opacity-80" />
               <h2 className="text-[17px] font-semibold text-[var(--text-primary)]">
                 Ready to capture
               </h2>
@@ -223,31 +205,17 @@ export function CapturePageBulkGroup() {
                 Tap the button below to start the camera and take photos.
               </p>
               <div className="flex gap-3">
-                <button
-                  type="button"
-                  onClick={() => navigate(-1)}
-                  className={cn(
-                    focusRing,
-                    'px-4 py-2 text-[14px] border border-[var(--border-flat)] rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
-                  )}
-                >
+                <Button variant="outline" onClick={() => navigate(-1)}>
                   Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={() => startCamera()}
-                  className={cn(
-                    focusRing,
-                    'px-4 py-2 text-[14px] bg-[var(--accent)] text-white rounded-[var(--radius-md)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]',
-                  )}
-                >
-                  Start Camera
-                </button>
+                </Button>
+                <Button onClick={() => startCamera()}>Start Camera</Button>
               </div>
             </>
           )}
         </div>
       )}
+
+      <FirstRunCoachmark isStreaming={isStreaming} />
 
       {isStreaming && (
         <>
@@ -275,17 +243,20 @@ export function CapturePageBulkGroup() {
               Bin #{currentGroup + 1} · {photosInCurrentGroup} {photoLabel}
             </div>
 
-            <button
-              type="button"
-              onClick={handleLibrary}
-              className={cn(
-                focusRing,
-                'h-8 w-8 flex items-center justify-center text-white/90 hover:text-white focus-visible:ring-offset-2 focus-visible:ring-offset-black',
-              )}
-              aria-label="Open photo library"
-            >
-              <Images className="h-5 w-5" />
-            </button>
+            <div className="flex items-center gap-2">
+              <HelpButton className="bg-transparent hover:bg-white/10" />
+              <button
+                type="button"
+                onClick={handleLibrary}
+                className={cn(
+                  focusRing,
+                  'h-8 w-8 flex items-center justify-center text-white/90 hover:text-white focus-visible:ring-offset-2 focus-visible:ring-offset-black',
+                )}
+                aria-label="Open photo library"
+              >
+                <Images className="h-5 w-5" />
+              </button>
+            </div>
 
             <input
               ref={fileInputRef}

--- a/src/features/capture/__tests__/CapturePageBulkGroup.test.tsx
+++ b/src/features/capture/__tests__/CapturePageBulkGroup.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CapturePageBulkGroup } from '../CapturePageBulkGroup';
 import { takeCapturedPhotos } from '../capturedPhotos';
+import { PHOTO_TIPS_SEEN_KEY } from '../guidance/tips';
 
 // Mock the grouping hook to drive the UI deterministically
 const mockHook = {
@@ -27,6 +28,9 @@ vi.mock('../useCaptureGrouping', () => ({
 }));
 
 beforeEach(() => {
+  // Keep the first-run photo-tips coachmark dismissed so its <li> entries
+  // don't contaminate strip-scoped listitem assertions below.
+  localStorage.setItem(PHOTO_TIPS_SEEN_KEY, 'true');
   mockHook.photos = [];
   mockHook.currentGroup = 0;
   mockHook.photosInCurrentGroup = 0;

--- a/src/features/capture/guidance/CameraGuidance.tsx
+++ b/src/features/capture/guidance/CameraGuidance.tsx
@@ -1,0 +1,60 @@
+import { HelpCircle } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { cn, focusRing } from '@/lib/utils';
+import { HelpSheet } from './HelpSheet';
+import { PHOTO_TIPS_SEEN_KEY } from './tips';
+
+function readSeenFlag(): boolean {
+	try {
+		return localStorage.getItem(PHOTO_TIPS_SEEN_KEY) === 'true';
+	} catch {
+		return false;
+	}
+}
+
+function writeSeenFlag() {
+	try {
+		localStorage.setItem(PHOTO_TIPS_SEEN_KEY, 'true');
+	} catch {
+		// Storage blocked (Safari private mode etc.) — silently ignore.
+	}
+}
+
+export function FirstRunCoachmark({ isStreaming }: { isStreaming: boolean }) {
+	const [shouldShow, setShouldShow] = useState(false);
+
+	useEffect(() => {
+		if (!isStreaming) return;
+		if (readSeenFlag()) return;
+		setShouldShow(true);
+	}, [isStreaming]);
+
+	const handleDismiss = useCallback(() => {
+		writeSeenFlag();
+		setShouldShow(false);
+	}, []);
+
+	if (!isStreaming) return null;
+	return <HelpSheet isOpen={shouldShow} onClose={handleDismiss} />;
+}
+
+export function HelpButton({ className }: { className?: string }) {
+	const [isOpen, setIsOpen] = useState(false);
+	return (
+		<>
+			<button
+				type="button"
+				aria-label="Photo tips"
+				onClick={() => setIsOpen(true)}
+				className={cn(
+					focusRing,
+					'h-8 w-8 flex items-center justify-center text-white/90 hover:text-white rounded-[50%]',
+					className,
+				)}
+			>
+				<HelpCircle className="h-5 w-5" aria-hidden="true" />
+			</button>
+			<HelpSheet isOpen={isOpen} onClose={() => setIsOpen(false)} />
+		</>
+	);
+}

--- a/src/features/capture/guidance/HelpSheet.tsx
+++ b/src/features/capture/guidance/HelpSheet.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { CAMERA_TIPS } from './tips';
+
+interface HelpSheetProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function HelpSheet({ isOpen, onClose }: HelpSheetProps) {
+	return (
+		<Dialog open={isOpen} onOpenChange={(next) => { if (!next) onClose(); }}>
+			<DialogContent className="max-w-sm" centered>
+				<DialogHeader>
+					<DialogTitle>Photo tips</DialogTitle>
+				</DialogHeader>
+				<ul className="flex flex-col gap-3">
+					{CAMERA_TIPS.map((tip) => {
+						const Icon = tip.icon;
+						return (
+							<li key={tip.id} className="flex items-center gap-3">
+								<span
+									aria-hidden="true"
+									className="w-8 flex items-center justify-center text-[var(--text-secondary)] shrink-0"
+								>
+									<Icon className="h-5 w-5" strokeWidth={2} />
+								</span>
+								<p className="text-[15px] leading-snug text-[var(--text-primary)]">
+									{tip.headline}
+								</p>
+							</li>
+						);
+					})}
+				</ul>
+				<DialogFooter>
+					<Button
+						variant="default"
+						size="lg"
+						onClick={onClose}
+						className="w-full sm:w-auto"
+					>
+						Got it
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/capture/guidance/__tests__/CameraGuidance.test.tsx
+++ b/src/features/capture/guidance/__tests__/CameraGuidance.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FirstRunCoachmark, HelpButton } from '../CameraGuidance';
+import { CAMERA_TIPS, PHOTO_TIPS_SEEN_KEY } from '../tips';
+
+const FIRST_TIP = CAMERA_TIPS[0].headline;
+
+beforeEach(() => {
+	localStorage.clear();
+});
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe('FirstRunCoachmark', () => {
+	it('renders nothing when not streaming', () => {
+		const { container } = render(<FirstRunCoachmark isStreaming={false} />);
+		expect(container.textContent).toBe('');
+	});
+
+	it('shows the tip sheet when streaming begins and the seen flag is absent', () => {
+		render(<FirstRunCoachmark isStreaming />);
+		expect(screen.getByText(FIRST_TIP)).toBeTruthy();
+		expect(screen.getByRole('button', { name: /got it/i })).toBeTruthy();
+	});
+
+	it('does not show the tip sheet when the seen flag is already set', () => {
+		localStorage.setItem(PHOTO_TIPS_SEEN_KEY, 'true');
+		render(<FirstRunCoachmark isStreaming />);
+		expect(screen.queryByText(FIRST_TIP)).toBeNull();
+	});
+
+	it('sets the seen flag when the primary button is clicked', () => {
+		render(<FirstRunCoachmark isStreaming />);
+		fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+		expect(localStorage.getItem(PHOTO_TIPS_SEEN_KEY)).toBe('true');
+	});
+});
+
+describe('HelpButton', () => {
+	it('renders a button that opens the help sheet', () => {
+		render(<HelpButton />);
+		expect(screen.queryByText('Photo tips')).toBeNull();
+		fireEvent.click(screen.getByRole('button', { name: /photo tips/i }));
+		expect(screen.getByText('Photo tips')).toBeTruthy();
+	});
+
+	it('applies the className prop to the button', () => {
+		render(<HelpButton className="custom-class" />);
+		const btn = screen.getByRole('button', { name: /photo tips/i });
+		expect(btn.className).toContain('custom-class');
+	});
+});

--- a/src/features/capture/guidance/__tests__/HelpSheet.test.tsx
+++ b/src/features/capture/guidance/__tests__/HelpSheet.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HelpSheet } from '../HelpSheet';
+import { CAMERA_TIPS } from '../tips';
+
+describe('HelpSheet', () => {
+	it('does not render its content when closed', () => {
+		render(<HelpSheet isOpen={false} onClose={() => {}} />);
+		expect(screen.queryByText(/Photo tips/i)).toBeNull();
+	});
+
+	it('renders the title and every tip headline on a single page when open', () => {
+		render(<HelpSheet isOpen onClose={() => {}} />);
+		expect(screen.getByText('Photo tips')).toBeTruthy();
+		for (const tip of CAMERA_TIPS) {
+			expect(screen.getByText(tip.headline)).toBeTruthy();
+		}
+	});
+
+	it('calls onClose when the primary button is clicked', () => {
+		const onClose = vi.fn();
+		render(<HelpSheet isOpen onClose={onClose} />);
+		fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('calls onClose when Escape is pressed', () => {
+		const onClose = vi.fn();
+		render(<HelpSheet isOpen onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalled();
+	});
+});

--- a/src/features/capture/guidance/__tests__/tips.test.ts
+++ b/src/features/capture/guidance/__tests__/tips.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { CAMERA_TIPS } from '../tips';
+
+describe('CAMERA_TIPS', () => {
+	it('has exactly 4 tips in the documented order', () => {
+		expect(CAMERA_TIPS).toHaveLength(4);
+		expect(CAMERA_TIPS.map((t) => t.id)).toEqual([
+			'visibility',
+			'light',
+			'angles',
+			'labels',
+		]);
+	});
+
+	it('gives every tip an icon and a non-empty headline', () => {
+		for (const tip of CAMERA_TIPS) {
+			expect(typeof tip.icon).toBe('object');
+			expect(tip.headline.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('keeps every headline on a single line', () => {
+		for (const tip of CAMERA_TIPS) {
+			expect(tip.headline).not.toContain('\n');
+		}
+	});
+});

--- a/src/features/capture/guidance/tips.ts
+++ b/src/features/capture/guidance/tips.ts
@@ -1,0 +1,16 @@
+import { Eye, Images, Lightbulb, type LucideIcon, ScanSearch } from 'lucide-react';
+
+export interface CameraTip {
+	id: "visibility" | "light" | "angles" | "labels";
+	icon: LucideIcon;
+	headline: string;
+}
+
+export const CAMERA_TIPS: CameraTip[] = [
+	{ id: "visibility", icon: Eye, headline: "Open the bin so contents are visible" },
+	{ id: "light", icon: Lightbulb, headline: "Use bright, even light" },
+	{ id: "angles", icon: Images, headline: "Take 2–3 angles" },
+	{ id: "labels", icon: ScanSearch, headline: "Get close to labels" },
+];
+
+export const PHOTO_TIPS_SEEN_KEY = "openbin-photo-tips-seen";


### PR DESCRIPTION
## Summary
- Adds a tip data module with contextual shooting tips for the capture flow
- Introduces a `CameraGuidance` orchestrator with a dismissible `HelpSheet` and first-run coachmark, replacing the old `CoachmarkCarousel`
- Mounts guidance in both `CapturePage` (legacy) and `CapturePageBulkGroup`
- Adds a `centered` prop to `DialogContent` so the help sheet floats centered on mobile instead of anchoring as a bottom sheet

## Test Plan
- [ ] Open capture page on mobile — first-run coachmark appears
- [ ] Dismiss coachmark — does not reappear on reload
- [ ] Tap help icon — HelpSheet opens centered on mobile, standard on desktop
- [ ] All 56 capture tests pass (`npx vitest run src/features/capture`)