### PR TITLE
Harden admin seed with recovery paths and per-env controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,16 @@
 # AI_ENCRYPTION_KEY=                 # Separate key for AI API key encryption at rest (falls back to JWT_SECRET if unset)
 # REGISTRATION_MODE=open             # open | invite (require location invite code) | closed (no sign-ups)
 
+# ── Initial Admin Account ─────────────────────
+# Seeded on first boot when no admin user exists. Applied once, then ignored.
+# ADMIN_EMAIL=                        # Email for the seeded admin (recommended — default is non-deliverable)
+# ADMIN_PASSWORD=                     # Password for the seeded admin (random + printed to stdout if unset)
+# ADMIN_PASSWORD_FILE=                # Read ADMIN_PASSWORD from a file (for Docker/K8s secrets)
+#
+# Recovery envs — set for one boot, then remove:
+# ADMIN_PASSWORD_RESET=false         # true + ADMIN_PASSWORD → rewrite the existing admin's password
+# ADMIN_RESEED=false                 # true → seed an additional admin even when one already exists
+
 # ─── Database Engine ────────────────────────────
 # Set DATABASE_URL for PostgreSQL, or use DATABASE_PATH for SQLite (default).
 # The engine choice is permanent — it cannot be changed after initial setup.

--- a/server/src/db/__tests__/init.test.ts
+++ b/server/src/db/__tests__/init.test.ts
@@ -66,6 +66,9 @@ vi.mock('../../lib/config.js', () => ({
     databasePath: ':memory:',
     databaseUrl: null as string | null,
     adminPassword: null as string | null,
+    adminEmail: null as string | null,
+    adminPasswordReset: false,
+    adminReseed: false,
     bcryptRounds: 12,
   },
 }));
@@ -99,9 +102,18 @@ vi.mock('../migrations/runner.js', () => ({
 vi.resetModules();
 
 const { initialize, getEngine } = await import('../init.js');
-const { config } = await import('../../lib/config.js');
+const { config: frozenConfig } = await import('../../lib/config.js');
 const { setDialect } = await import('../dialect.js');
 const { initPostgres, createPostgresEngine } = await import('../postgres.js');
+
+const config = frozenConfig as unknown as {
+  dbEngine: 'sqlite' | 'postgres';
+  databaseUrl: string | null;
+  adminPassword: string | null;
+  adminEmail: string | null;
+  adminPasswordReset: boolean;
+  adminReseed: boolean;
+};
 
 // ---------------------------------------------------------------------------
 // Reset between tests — clear module-level `engine` by re-importing
@@ -119,8 +131,12 @@ beforeEach(async () => {
   regetEngine = mod.getEngine;
 
   // Default: sqlite mode with successful engine lock
-  (config as { dbEngine: string }).dbEngine = 'sqlite';
-  (config as { databaseUrl: string | null }).databaseUrl = null;
+  config.dbEngine = 'sqlite';
+  config.databaseUrl = null;
+  config.adminPassword = null;
+  config.adminEmail = null;
+  config.adminPasswordReset = false;
+  config.adminReseed = false;
   h.mockSqliteEngine.query.mockResolvedValue({ rows: [], rowCount: 0 });
   h.mockPgEngine.query.mockResolvedValue({ rows: [], rowCount: 0 });
   h.mockPgPool.query.mockResolvedValue({ rows: [] });
@@ -149,7 +165,7 @@ describe('getEngine', () => {
 
 describe('initialize', () => {
   it('selects sqlite when config.dbEngine is sqlite', async () => {
-    (config as { dbEngine: string }).dbEngine = 'sqlite';
+    config.dbEngine = 'sqlite';
 
     const engine = await reinitialize();
 
@@ -158,8 +174,8 @@ describe('initialize', () => {
   });
 
   it('selects postgres when config.dbEngine is postgres', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = 'postgres://localhost/test';
+    config.dbEngine = 'postgres';
+    config.databaseUrl = 'postgres://localhost/test';
 
     const engine = await reinitialize();
 
@@ -168,7 +184,7 @@ describe('initialize', () => {
   });
 
   it('is idempotent on second call', async () => {
-    (config as { dbEngine: string }).dbEngine = 'sqlite';
+    config.dbEngine = 'sqlite';
 
     const first = await reinitialize();
     const second = await reinitialize();
@@ -221,15 +237,15 @@ describe('enforceEngineLock', () => {
 
 describe('runPostgresInit', () => {
   it('throws without DATABASE_URL', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = null;
+    config.dbEngine = 'postgres';
+    config.databaseUrl = null;
 
     await expect(reinitialize()).rejects.toThrow('DATABASE_URL is required for PostgreSQL mode');
   });
 
   it('calls initPostgres with connection string', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = 'postgres://localhost/test';
+    config.dbEngine = 'postgres';
+    config.databaseUrl = 'postgres://localhost/test';
 
     await reinitialize();
 
@@ -237,8 +253,8 @@ describe('runPostgresInit', () => {
   });
 
   it('attempts pg_trgm extension creation', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = 'postgres://localhost/test';
+    config.dbEngine = 'postgres';
+    config.databaseUrl = 'postgres://localhost/test';
 
     await reinitialize();
 
@@ -246,8 +262,8 @@ describe('runPostgresInit', () => {
   });
 
   it('warns on pg_trgm failure but continues', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = 'postgres://localhost/test';
+    config.dbEngine = 'postgres';
+    config.databaseUrl = 'postgres://localhost/test';
     h.mockPgPool.query
       .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] }) // SELECT 1
       .mockRejectedValueOnce(new Error('pg_trgm not available')) // CREATE EXTENSION
@@ -260,8 +276,8 @@ describe('runPostgresInit', () => {
   });
 
   it('loads schema in a transaction (BEGIN/COMMIT)', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = 'postgres://localhost/test';
+    config.dbEngine = 'postgres';
+    config.databaseUrl = 'postgres://localhost/test';
 
     await reinitialize();
 
@@ -271,8 +287,8 @@ describe('runPostgresInit', () => {
   });
 
   it('rolls back on schema failure', async () => {
-    (config as { dbEngine: string }).dbEngine = 'postgres';
-    (config as { databaseUrl: string | null }).databaseUrl = 'postgres://localhost/test';
+    config.dbEngine = 'postgres';
+    config.databaseUrl = 'postgres://localhost/test';
 
     let callCount = 0;
     h.mockPgPool.query.mockImplementation(async (sql: string) => {
@@ -287,5 +303,103 @@ describe('runPostgresInit', () => {
 
     const calls = h.mockPgPool.query.mock.calls.map((c: unknown[]) => c[0]);
     expect(calls).toContain('ROLLBACK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedAdminUser — admin hardening
+// ---------------------------------------------------------------------------
+
+describe('seedAdminUser', () => {
+  function getSeedCalls(): string[] {
+    return h.mockSqliteEngine.query.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((sql: unknown): sql is string => typeof sql === 'string');
+  }
+
+  it('checks for any admin (not a specific email)', async () => {
+    h.mockSqliteEngine.query
+      .mockResolvedValueOnce({ rows: [{ id: '1', email: 'other@example.com' }], rowCount: 1 }) // existing admin
+      .mockResolvedValueOnce({ rows: [{ value: 'sqlite' }], rowCount: 1 }); // engine lock
+
+    await reinitialize();
+
+    const selectCall = getSeedCalls().find((sql) => sql.includes('is_admin = TRUE'));
+    expect(selectCall).toBeDefined();
+    // No INSERT should happen because an admin already exists
+    const insertCall = getSeedCalls().find((sql) => sql.includes('INSERT INTO users'));
+    expect(insertCall).toBeUndefined();
+  });
+
+  it('inserts with ON CONFLICT (email) DO NOTHING', async () => {
+    h.mockSqliteEngine.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // seed SELECT — no admin
+      .mockResolvedValueOnce({ rows: [{ id: 'new-admin' }], rowCount: 1 }) // seed INSERT RETURNING
+      .mockResolvedValueOnce({ rows: [{ value: 'sqlite' }], rowCount: 1 }); // engine lock
+
+    await reinitialize();
+
+    const insertCall = getSeedCalls().find((sql) => sql.includes('INSERT INTO users'));
+    expect(insertCall).toMatch(/ON CONFLICT\s*\(email\)\s*DO NOTHING/);
+    expect(insertCall).toMatch(/RETURNING id/);
+  });
+
+  it('rotates the admin password when ADMIN_PASSWORD_RESET=true and ADMIN_PASSWORD set', async () => {
+    config.adminPassword = 'new-secret';
+    config.adminPasswordReset = true;
+    h.mockSqliteEngine.query.mockResolvedValueOnce({
+      rows: [{ id: 'existing-id', email: 'admin@example.com' }],
+      rowCount: 1,
+    });
+
+    await reinitialize();
+
+    const updateCall = h.mockSqliteEngine.query.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('UPDATE users SET password_hash'),
+    );
+    expect(updateCall).toBeDefined();
+    // UPDATE should target the existing admin id
+    expect(updateCall?.[1]).toEqual(['$2b$12$mockhash', 'existing-id']);
+  });
+
+  it('ignores ADMIN_PASSWORD_RESET when ADMIN_PASSWORD is unset', async () => {
+    config.adminPasswordReset = true;
+    h.mockSqliteEngine.query.mockResolvedValueOnce({
+      rows: [{ id: 'existing-id', email: 'admin@example.com' }],
+      rowCount: 1,
+    });
+
+    await reinitialize();
+
+    const updateCall = h.mockSqliteEngine.query.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('UPDATE users SET password_hash'),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('still creates an additional admin when ADMIN_RESEED=true', async () => {
+    config.adminReseed = true;
+    h.mockSqliteEngine.query
+      .mockResolvedValueOnce({ rows: [{ id: 'one', email: 'a@b.co' }], rowCount: 1 }) // existing admin
+      .mockResolvedValueOnce({ rows: [{ id: 'two' }], rowCount: 1 }) // INSERT RETURNING
+      .mockResolvedValueOnce({ rows: [{ value: 'sqlite' }], rowCount: 1 }); // engine lock
+
+    await reinitialize();
+
+    const insertCall = getSeedCalls().find((sql) => sql.includes('INSERT INTO users'));
+    expect(insertCall).toBeDefined();
+  });
+
+  it('does not INSERT when admin exists and ADMIN_RESEED is false', async () => {
+    config.adminReseed = false;
+    h.mockSqliteEngine.query.mockResolvedValueOnce({
+      rows: [{ id: 'one', email: 'admin@example.com' }],
+      rowCount: 1,
+    });
+
+    await reinitialize();
+
+    const insertCall = getSeedCalls().find((sql) => sql.includes('INSERT INTO users'));
+    expect(insertCall).toBeUndefined();
   });
 });

--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -25,28 +25,84 @@ const ADMIN_ACTIVE_UNTIL_MS = 1000 * 365 * 24 * 60 * 60 * 1000;
 
 async function seedAdminUser(eng: DatabaseEngine): Promise<void> {
   const adminEmail = config.adminEmail || 'admin@openbin.local';
-  const { rows } = await eng.query('SELECT 1 FROM users WHERE email = $1', [adminEmail]);
-  if (rows.length === 0) {
-    const providedPassword = config.adminPassword;
-    const plaintext = providedPassword || crypto.randomBytes(12).toString('base64url');
-    const hash = await bcrypt.hash(plaintext, config.bcryptRounds);
 
-    await eng.query(
-      `INSERT INTO users (id, email, password_hash, display_name, is_admin, plan, sub_status, active_until)
-       VALUES ($1, $2, $3, 'Admin', TRUE, 1, 1, $4)`,
-      [crypto.randomUUID(), adminEmail, hash, new Date(Date.now() + ADMIN_ACTIVE_UNTIL_MS).toISOString()],
-    );
+  const { rows: existingAdmins } = await eng.query<{ id: string; email: string }>(
+    'SELECT id, email FROM users WHERE is_admin = TRUE LIMIT 1',
+  );
+  const existingAdmin = existingAdmins[0] ?? null;
 
-    if (providedPassword) {
-      log.info(`Initial admin account created for ${adminEmail}`);
-    } else {
-      console.log('========================================');
-      console.log('  Initial admin credentials:');
-      console.log(`    Email: ${adminEmail}`);
-      console.log(`    Password: ${plaintext}`);
-      console.log('  Save this password — it will not be shown again.');
-      console.log('========================================');
+  // Recovery path: rotate the existing admin's password from ADMIN_PASSWORD.
+  if (config.adminPasswordReset && existingAdmin) {
+    if (!config.adminPassword) {
+      log.warn('ADMIN_PASSWORD_RESET=true but ADMIN_PASSWORD is not set — ignoring.');
+      return;
     }
+    const hash = await bcrypt.hash(config.adminPassword, config.bcryptRounds);
+    await eng.query('UPDATE users SET password_hash = $1 WHERE id = $2', [hash, existingAdmin.id]);
+    log.warn(
+      `Admin password reset for ${existingAdmin.email}. ` +
+        'Remove ADMIN_PASSWORD_RESET=true from the environment to prevent a reset on every boot.',
+    );
+    return;
+  }
+  if (config.adminPasswordReset && !existingAdmin) {
+    log.warn('ADMIN_PASSWORD_RESET=true but no admin user exists yet — proceeding with normal seed.');
+  }
+
+  if (existingAdmin && !config.adminReseed) {
+    if (config.adminPassword) {
+      log.warn(
+        'Admin user already exists; ADMIN_PASSWORD is ignored on subsequent boots. ' +
+          'To rotate the admin password, set ADMIN_PASSWORD_RESET=true (with ADMIN_PASSWORD) for one boot.',
+      );
+    }
+    if (config.adminEmail && config.adminEmail !== existingAdmin.email) {
+      log.warn(
+        `ADMIN_EMAIL (${config.adminEmail}) differs from the existing admin (${existingAdmin.email}); ` +
+          'change the admin email through the admin UI instead.',
+      );
+    }
+    return;
+  }
+
+  if (existingAdmin && config.adminReseed) {
+    log.warn('ADMIN_RESEED=true — seeding an additional admin alongside the existing one.');
+  }
+
+  if (!config.adminEmail) {
+    log.warn(
+      `ADMIN_EMAIL is not set; seeding default '${adminEmail}'. ` +
+        'Password-reset emails sent to this address will bounce. Set ADMIN_EMAIL to a deliverable address.',
+    );
+  }
+
+  const providedPassword = config.adminPassword;
+  const plaintext = providedPassword || crypto.randomBytes(12).toString('base64url');
+  const hash = await bcrypt.hash(plaintext, config.bcryptRounds);
+
+  // ON CONFLICT (email) DO NOTHING guards against a rare startup race (e.g. rolling restart).
+  const { rows: inserted } = await eng.query<{ id: string }>(
+    `INSERT INTO users (id, email, password_hash, display_name, is_admin, plan, sub_status, active_until)
+     VALUES ($1, $2, $3, 'Admin', TRUE, 1, 1, $4)
+     ON CONFLICT (email) DO NOTHING
+     RETURNING id`,
+    [crypto.randomUUID(), adminEmail, hash, new Date(Date.now() + ADMIN_ACTIVE_UNTIL_MS).toISOString()],
+  );
+
+  if (inserted.length === 0) {
+    log.info(`Admin user at ${adminEmail} already exists — skipping seed.`);
+    return;
+  }
+
+  if (providedPassword) {
+    log.info(`Initial admin account created for ${adminEmail}`);
+  } else {
+    console.log('========================================');
+    console.log('  Initial admin credentials:');
+    console.log(`    Email: ${adminEmail}`);
+    console.log(`    Password: ${plaintext}`);
+    console.log('  Save this password — it will not be shown again.');
+    console.log('========================================');
   }
 }
 
@@ -125,10 +181,7 @@ async function runSqliteInit(): Promise<DatabaseEngine> {
   runSqliteMigrations(db, migrations);
 
   const sqliteEngine = createSqliteEngine();
-
-  // Seed default admin account — idempotent
   await seedAdminUser(sqliteEngine);
-
   return sqliteEngine;
 }
 
@@ -180,10 +233,7 @@ async function runPostgresInit(): Promise<DatabaseEngine> {
   await runPostgresMigrations(pool, migrations);
 
   const pgEngine = createPostgresEngine();
-
-  // Seed default admin account — idempotent
   await seedAdminUser(pgEngine);
-
   return pgEngine;
 }
 

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -31,6 +31,25 @@ function clamp(value: number, min: number, max: number, fallback: number): numbe
 
 const photoStoragePath = process.env.PHOTO_STORAGE_PATH || './uploads';
 
+function readSecretFile(envPath: string | undefined): string | null {
+  if (!envPath) return null;
+  try {
+    return fs.readFileSync(envPath, 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveAdminPassword(): string | null {
+  return process.env.ADMIN_PASSWORD || readSecretFile(process.env.ADMIN_PASSWORD_FILE);
+}
+
+function resolveAdminEmail(): string | null {
+  const raw = process.env.ADMIN_EMAIL;
+  if (!raw) return null;
+  return raw.trim().toLowerCase() || null;
+}
+
 function resolveJwtSecret(): string {
   if (process.env.JWT_SECRET) return process.env.JWT_SECRET;
 
@@ -59,8 +78,10 @@ export const config = Object.freeze({
   corsOriginExplicit: !!process.env.CORS_ORIGIN,
 
   // Auth
-  adminPassword: process.env.ADMIN_PASSWORD || null,
-  adminEmail: process.env.ADMIN_EMAIL || null,
+  adminPassword: resolveAdminPassword(),
+  adminEmail: resolveAdminEmail(),
+  adminPasswordReset: parseBool(process.env.ADMIN_PASSWORD_RESET, false),
+  adminReseed: parseBool(process.env.ADMIN_RESEED, false),
   jwtSecret: resolveJwtSecret(),
   accessTokenExpiresIn: '15m',
   refreshTokenMaxDays: 7,


### PR DESCRIPTION
## Summary

Replaces the brittle initial-admin-seed with a version designed to survive the common self-hosted mishaps (forgotten passwords, accidental deletes, duplicate admins) and to support Docker/K8s secret files on the cloud side.

- **`ADMIN_PASSWORD_FILE`** — read the seed password from a file (Docker/K8s secrets convention).
- **`ADMIN_PASSWORD_RESET=true`** — one-boot recovery: rewrites the existing admin's password from `ADMIN_PASSWORD`, logs a warning to remove the flag.
- **`ADMIN_RESEED=true`** — creates an additional admin alongside the existing one (for rare recovery scenarios).
- Seed existence check now matches *any* admin row (`is_admin = TRUE`) instead of a specific email — stops duplicate admins when `ADMIN_EMAIL` changes between boots.
- INSERT uses `ON CONFLICT (email) DO NOTHING RETURNING id` — tolerates concurrent startup races (rolling restarts, HA).
- `ADMIN_EMAIL` is trimmed and lowercased at config load.
- Warnings emitted when: default `admin@openbin.local` is in use, `ADMIN_PASSWORD` is ignored on subsequent boots, `ADMIN_EMAIL` differs from the existing admin.
- Credentials banner prints to stdout only when the password was auto-generated.

## Context

Follow-up to the security audit. These are items 1, 2, 4, 5, 7, 9, 10, 11 from the "edge cases around admin seed" discussion — the must-do and worth-doing fixes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `src/db/__tests__/init.test.ts` — 19/19 passing (6 new tests covering reset, reseed, ON CONFLICT, existence-by-is_admin)
- [x] Full server suite passes (1270 tests)
- [ ] Manual: first boot with `ADMIN_PASSWORD` unset → random password logged once
- [ ] Manual: first boot with `ADMIN_PASSWORD` set → no password in stdout
- [ ] Manual: `ADMIN_PASSWORD_FILE=/tmp/pw` + file exists → password read from file
- [ ] Manual: second boot with `ADMIN_PASSWORD` still set → warning, no reset
- [ ] Manual: `ADMIN_PASSWORD_RESET=true` + `ADMIN_PASSWORD` → password rotated, warning to remove the flag
- [ ] Manual: change `ADMIN_EMAIL` on second boot → no duplicate admin, warning logged