### PR TITLE
fix: use fixed height for CommandInput dialog instead of max-height

### DIFF
--- a/src/features/ai/CommandInput.tsx
+++ b/src/features/ai/CommandInput.tsx
@@ -21,7 +21,7 @@ export function CommandInput({ open, onOpenChange, autoTriggerPhoto }: CommandIn
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent flush className="sm:max-w-lg max-h-[min(720px,85vh)]">
+      <DialogContent flush className="sm:max-w-lg h-[min(720px,85vh)]">
         <ConversationUI
           active={open}
           autoTriggerPhoto={autoTriggerPhoto}


### PR DESCRIPTION
## Summary

- Changes `max-h-[min(720px,85vh)]` to `h-[min(720px,85vh)]` on the `CommandInput` dialog content
- Ensures the dialog always occupies its full intended height rather than collapsing to fit content

## Test plan

- [ ] Open the Ask AI / CommandInput dialog and verify it renders at a consistent height
- [ ] Test on mobile viewport to confirm the `85vh` cap still applies correctly