### PR TITLE
feat: dismissable upgrade prompts

### DIFF
--- a/src/ee/UpgradePrompt.tsx
+++ b/src/ee/UpgradePrompt.tsx
@@ -1,6 +1,7 @@
-import { ArrowUpRight } from 'lucide-react';
+import { ArrowUpRight, X } from 'lucide-react';
 import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
 import { usePlan } from '@/lib/usePlan';
+import { useUserPreferences } from '@/lib/userPreferences';
 import { cn, focusRing } from '@/lib/utils';
 import type { CheckoutAction } from '@/types';
 
@@ -12,17 +13,48 @@ interface UpgradePromptProps {
   // is POST so the JWT lands in the request body, not the URL.
   upgradeAction: CheckoutAction | null;
   className?: string;
+  // When set, renders an X dismiss button. Clicking it appends `dismissKey`
+  // to the user's `dismissed_upgrade_prompts` preference; the component
+  // returns null on subsequent renders for that user.
+  dismissKey?: string;
 }
 
-export function UpgradePrompt({ feature, description, upgradeAction, className }: UpgradePromptProps) {
+export function UpgradePrompt({ feature, description, upgradeAction, className, dismissKey }: UpgradePromptProps) {
   const { isFree, isPlus, isLocked } = usePlan();
+  const { preferences, updatePreferences } = useUserPreferences();
   const isActiveFreeOrPlus = (isFree || isPlus) && !isLocked;
+
+  if (dismissKey && preferences.dismissed_upgrade_prompts.includes(dismissKey)) {
+    return null;
+  }
+
+  function handleDismiss() {
+    if (!dismissKey) return;
+    updatePreferences((prev) => {
+      if (prev.dismissed_upgrade_prompts.includes(dismissKey)) return {};
+      return { dismissed_upgrade_prompts: [...prev.dismissed_upgrade_prompts, dismissKey] };
+    });
+  }
 
   return (
     <div className={cn(
-      'flat-card rounded-[var(--radius-lg)] flex items-center justify-between gap-4 px-5 py-4',
-      className
+      'flat-card rounded-[var(--radius-lg)] flex items-center justify-between gap-4 px-5 py-4 relative',
+      dismissKey && 'pr-10',
+      className,
     )}>
+      {dismissKey && (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className={cn(
+            'absolute top-2 right-2 inline-flex items-center justify-center h-7 w-7 rounded-[var(--radius-sm)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors',
+            focusRing,
+          )}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
       <div>
         <p className="text-[15px] font-semibold text-[var(--text-primary)]">
           {isActiveFreeOrPlus

--- a/src/ee/__tests__/UpgradePrompt.test.tsx
+++ b/src/ee/__tests__/UpgradePrompt.test.tsx
@@ -77,4 +77,22 @@ describe('UpgradePrompt', () => {
       dismissed_upgrade_prompts: ['attachments'],
     });
   });
+
+  it('returns null when dismissKey is already in dismissed_upgrade_prompts', () => {
+    (useUserPreferences as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      preferences: { dismissed_upgrade_prompts: ['attachments'] },
+      isLoading: false,
+      updatePreferences: vi.fn(),
+    });
+
+    const { container } = render(
+      <UpgradePrompt
+        feature="Document Attachments"
+        upgradeAction={null}
+        dismissKey="attachments"
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/src/ee/__tests__/UpgradePrompt.test.tsx
+++ b/src/ee/__tests__/UpgradePrompt.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/userPreferences', () => ({
+  useUserPreferences: vi.fn(() => ({
+    preferences: { dismissed_upgrade_prompts: [] as string[] },
+    isLoading: false,
+    updatePreferences: vi.fn(),
+  })),
+}));
+
+vi.mock('@/lib/usePlan', () => ({
+  usePlan: vi.fn(() => ({
+    isFree: false,
+    isPlus: true,
+    isLocked: false,
+  })),
+}));
+
+import { UpgradePrompt } from '../UpgradePrompt';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UpgradePrompt', () => {
+  it('renders an X dismiss button when dismissKey is provided', () => {
+    render(
+      <UpgradePrompt
+        feature="Document Attachments"
+        upgradeAction={null}
+        dismissKey="attachments"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Dismiss/i })).toBeInTheDocument();
+  });
+});

--- a/src/ee/__tests__/UpgradePrompt.test.tsx
+++ b/src/ee/__tests__/UpgradePrompt.test.tsx
@@ -35,4 +35,15 @@ describe('UpgradePrompt', () => {
 
     expect(screen.getByRole('button', { name: /Dismiss/i })).toBeInTheDocument();
   });
+
+  it('does not render the X button when dismissKey is omitted', () => {
+    render(
+      <UpgradePrompt
+        feature="Document Attachments"
+        upgradeAction={null}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /Dismiss/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/ee/__tests__/UpgradePrompt.test.tsx
+++ b/src/ee/__tests__/UpgradePrompt.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/usePlan', () => ({
   })),
 }));
 
+import { useUserPreferences } from '@/lib/userPreferences';
 import { UpgradePrompt } from '../UpgradePrompt';
 
 beforeEach(() => {
@@ -45,5 +46,35 @@ describe('UpgradePrompt', () => {
     );
 
     expect(screen.queryByRole('button', { name: /Dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it('appends dismissKey to dismissed_upgrade_prompts when X is clicked', async () => {
+    const updatePreferences = vi.fn();
+    (useUserPreferences as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      preferences: { dismissed_upgrade_prompts: [] as string[] },
+      isLoading: false,
+      updatePreferences,
+    });
+
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+
+    render(
+      <UpgradePrompt
+        feature="Document Attachments"
+        upgradeAction={null}
+        dismissKey="attachments"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Dismiss/i }));
+
+    expect(updatePreferences).toHaveBeenCalledTimes(1);
+    // updatePreferences was called with a function. Invoke it with a fake
+    // previous-state to assert the resulting patch.
+    const call = updatePreferences.mock.calls[0][0] as (prev: { dismissed_upgrade_prompts: string[] }) => { dismissed_upgrade_prompts?: string[] };
+    expect(call({ dismissed_upgrade_prompts: [] })).toEqual({
+      dismissed_upgrade_prompts: ['attachments'],
+    });
   });
 });

--- a/src/features/bins/BinDetailFilesTab.tsx
+++ b/src/features/bins/BinDetailFilesTab.tsx
@@ -67,6 +67,7 @@ export function BinDetailFilesTab({ binId, photos, canEdit }: BinDetailFilesTabP
                 feature="Document Attachments"
                 description="Upload PDFs, spreadsheets, and other files to bins."
                 upgradeAction={planInfo.upgradeAction}
+                dismissKey="attachments"
               />
             </Suspense>
           )}

--- a/src/features/settings/sections/AccountSection.tsx
+++ b/src/features/settings/sections/AccountSection.tsx
@@ -506,6 +506,7 @@ export function AccountSection() {
                 feature="API Keys"
                 description="Create API keys to integrate with external tools."
                 upgradeAction={planInfo.upgradeAction}
+                dismissKey="apiKeys"
               />
             </Suspense>
           </SettingsSection>

--- a/src/lib/userPreferences.tsx
+++ b/src/lib/userPreferences.tsx
@@ -23,6 +23,7 @@ export interface UserPreferences {
   usage_tracking_view: boolean;
   usage_tracking_modify: boolean;
   usage_granularity: 'daily' | 'weekly' | 'monthly';
+  dismissed_upgrade_prompts: string[];
 }
 
 export const DEFAULT_PREFERENCES: UserPreferences = {
@@ -47,6 +48,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   usage_tracking_view: false,
   usage_tracking_modify: true,
   usage_granularity: 'daily',
+  dismissed_upgrade_prompts: [],
 };
 
 const PREFERENCES_EVENT = 'user-preferences-changed';


### PR DESCRIPTION
## Summary
- Adds `dismissed_upgrade_prompts` field to user preferences to persist dismissed state
- Adds `dismissKey` prop to `UpgradePrompt` with an X button that saves the key on click
- Wires up dismissal in `BinDetailFilesTab` (attachments) and `AccountSection` (API keys)

## Test Plan
- [ ] Dismiss the attachments upgrade prompt in bin detail → confirm it stays dismissed on revisit
- [ ] Dismiss the API keys upgrade prompt in account settings → confirm it stays dismissed
- [ ] Upgrade prompts without a `dismissKey` should have no X button (regression test covers this)