### PR TITLE
refactor: move cloud-only modules into EE folders

### DIFF
--- a/server/src/ee/__tests__/adminOverrides.test.ts
+++ b/server/src/ee/__tests__/adminOverrides.test.ts
@@ -1,14 +1,15 @@
 import type { Express } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getDb } from '../db.js';
-import { createApp } from '../index.js';
-import { Plan, SubStatus } from '../lib/planGate.js';
-import { createTestUser, makeAdmin } from './helpers.js';
+import { createTestUser, makeAdmin } from '../../__tests__/helpers.js';
+import { getDb } from '../../db.js';
+import { createApp } from '../../index.js';
+import { Plan, SubStatus } from '../../lib/planGate.js';
+import { initEeRoutes } from '../index.js';
 
 let app: Express;
 beforeEach(() => {
-  app = createApp();
+  app = createApp({ mountEeRoutes: initEeRoutes });
 });
 
 function setTrial(userId: string) {

--- a/server/src/ee/__tests__/plans.test.ts
+++ b/server/src/ee/__tests__/plans.test.ts
@@ -1,7 +1,16 @@
 import type { Express } from 'express';
 import request from 'supertest';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { createApp } from '../../index.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// /api/plans is gated by `if (!config.selfHosted)` in createApp(); the route is
+// cloud-only. Tests assert the cloud behavior, so override selfHosted before
+// the module graph captures the config value.
+vi.mock('../../lib/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/config.js')>('../../lib/config.js');
+  return { ...actual, config: { ...actual.config, selfHosted: false } };
+});
+
+const { createApp } = await import('../../index.js');
 
 describe('GET /api/plans', () => {
   let app: Express;

--- a/server/src/ee/index.ts
+++ b/server/src/ee/index.ts
@@ -3,6 +3,7 @@ import { registerEeHooks } from '../lib/eeHooks.js';
 import { startInactivityChecker, stopInactivityChecker } from './inactivityChecker.js';
 import { deleteUserData, notifyManagerNewUser, notifyManagerUserUpdate } from './managerWebhook.js';
 import { adminMetricsRoutes } from './routes/adminMetrics.js';
+import { adminOverridesRoutes } from './routes/adminOverrides.js';
 import { subscriptionsRoutes } from './routes/subscriptions.js';
 import { startTrialChecker, stopTrialChecker } from './trialChecker.js';
 import { startUserCleanupJob, stopUserCleanupJob } from './userCleanup.js';
@@ -19,6 +20,7 @@ export function registerHooks(): void {
 export function initEeRoutes(app: express.Express): void {
   app.use('/api/subscriptions', subscriptionsRoutes);
   app.use('/api/admin', adminMetricsRoutes);
+  app.use('/api/admin/overrides', adminOverridesRoutes);
 }
 
 export function startEeJobs(): void {

--- a/server/src/ee/lib/__tests__/downgradeImpact.test.ts
+++ b/server/src/ee/lib/__tests__/downgradeImpact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import type { PlanFeatures } from '../../../lib/planGate.js';
 import { computeDowngradeImpact } from '../downgradeImpact.js';
-import type { PlanFeatures } from '../planGate.js';
 
 const PRO_FEATURES: PlanFeatures = {
   ai: true, apiKeys: true, customFields: true, fullExport: true,

--- a/server/src/ee/lib/__tests__/planCatalog.test.ts
+++ b/server/src/ee/lib/__tests__/planCatalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('../config.js', () => ({
+vi.mock('../../../lib/config.js', () => ({
   config: {
     planLimits: {
       freeMaxBins: 10, freeMaxLocations: 1, freeMaxStorageMb: 0, freeMaxMembers: 1,

--- a/server/src/ee/lib/downgradeImpact.ts
+++ b/server/src/ee/lib/downgradeImpact.ts
@@ -1,4 +1,4 @@
-import type { PlanFeatures, UserUsage } from './planGate.js';
+import type { PlanFeatures, UserUsage } from '../../lib/planGate.js';
 
 export interface DowngradeWarning {
   kind: 'usage-exceeded' | 'feature-loss';

--- a/server/src/ee/lib/planCatalog.ts
+++ b/server/src/ee/lib/planCatalog.ts
@@ -1,6 +1,6 @@
-import { config } from './config.js';
-import type { PlanFeatures } from './planGate.js';
-import { getFeatureMap, Plan } from './planGate.js';
+import { config } from '../../lib/config.js';
+import type { PlanFeatures } from '../../lib/planGate.js';
+import { getFeatureMap, Plan } from '../../lib/planGate.js';
 
 export type CatalogPlanId = 'free' | 'plus' | 'pro';
 

--- a/server/src/ee/routes/adminOverrides.ts
+++ b/server/src/ee/routes/adminOverrides.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express';
-import { d, generateUuid, query } from '../db.js';
-import { logAdminAction } from '../lib/adminAudit.js';
-import { assertUserExists } from '../lib/adminHelpers.js';
-import { asyncHandler } from '../lib/asyncHandler.js';
-import { NotFoundError, ValidationError } from '../lib/httpErrors.js';
-import { getFeatureMap, invalidateOverLimitCache, Plan, type PlanTier, planLabel, SubStatus } from '../lib/planGate.js';
-import { authenticate } from '../middleware/auth.js';
-import { requireAdmin } from '../middleware/requireAdmin.js';
+import { d, generateUuid, query } from '../../db.js';
+import { logAdminAction } from '../../lib/adminAudit.js';
+import { assertUserExists } from '../../lib/adminHelpers.js';
+import { asyncHandler } from '../../lib/asyncHandler.js';
+import { NotFoundError, ValidationError } from '../../lib/httpErrors.js';
+import { getFeatureMap, invalidateOverLimitCache, Plan, type PlanTier, planLabel, SubStatus } from '../../lib/planGate.js';
+import { authenticate } from '../../middleware/auth.js';
+import { requireAdmin } from '../../middleware/requireAdmin.js';
 
 const router = Router();
 router.use(authenticate, requireAdmin);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import cors from 'cors';
 import express from 'express';
 import multer from 'multer';
 import { query } from './db.js';
+import { getPlanCatalog } from './ee/lib/planCatalog.js';
 import { config } from './lib/config.js';
 import { csrfProtect } from './lib/csrf.js';
 import {
@@ -17,7 +18,6 @@ import {
 } from './lib/httpErrors.js';
 import { pushLog } from './lib/logBuffer.js';
 import { createLogger } from './lib/logger.js';
-import { getPlanCatalog } from './lib/planCatalog.js';
 import { apiLimiter, authLimiter, joinLimiter, registerLimiter, sensitiveAuthLimiter } from './lib/rateLimiters.js';
 import { isRestoreInProgress } from './lib/restore.js';
 import { tryAuthenticate } from './middleware/auth.js';
@@ -26,7 +26,6 @@ import { requestLogger } from './middleware/requestLogger.js';
 import { requireActiveSubscription } from './middleware/requirePlan.js';
 import activityRoutes from './routes/activity.js';
 import { adminRoutes } from './routes/admin.js';
-import { adminOverridesRoutes } from './routes/adminOverrides.js';
 import { adminSecurityRoutes } from './routes/adminSecurity.js';
 import { adminSystemRoutes } from './routes/adminSystem.js';
 import aiRoutes from './routes/ai.js';
@@ -105,27 +104,31 @@ export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => voi
   // ACAO header wins over the single-origin default. config.corsOrigin is only
   // included when set explicitly to avoid leaking the localhost dev default
   // into production allow-lists; dev origin is added separately when not in prod.
-  const PLANS_CORS_ORIGINS = new Set<string>([
-    'https://openbin.app',
-    'https://cloud.openbin.app',
-    'https://billing.openbin.app',
-    ...(config.corsOriginExplicit ? [config.corsOrigin] : []),
-    ...(process.env.NODE_ENV !== 'production' ? ['http://localhost:5173'] : []),
-  ]);
-  app.get(
-    '/api/plans',
-    cors({
-      origin: (origin, cb) => {
-        if (!origin || PLANS_CORS_ORIGINS.has(origin)) cb(null, true);
-        else cb(null, false);
+  // Cloud-only: self-hosted instances have no billing surface and no need to
+  // expose a public catalog.
+  if (!config.selfHosted) {
+    const PLANS_CORS_ORIGINS = new Set<string>([
+      'https://openbin.app',
+      'https://cloud.openbin.app',
+      'https://billing.openbin.app',
+      ...(config.corsOriginExplicit ? [config.corsOrigin] : []),
+      ...(process.env.NODE_ENV !== 'production' ? ['http://localhost:5173'] : []),
+    ]);
+    app.get(
+      '/api/plans',
+      cors({
+        origin: (origin, cb) => {
+          if (!origin || PLANS_CORS_ORIGINS.has(origin)) cb(null, true);
+          else cb(null, false);
+        },
+        methods: ['GET'],
+        credentials: false,
+      }),
+      (_req, res) => {
+        res.json(getPlanCatalog());
       },
-      methods: ['GET'],
-      credentials: false,
-    }),
-    (_req, res) => {
-      res.json(getPlanCatalog());
-    },
-  );
+    );
+  }
 
   app.use(cors({
     origin: config.corsOrigin,
@@ -216,7 +219,6 @@ export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => voi
   app.use('/api', batchRoutes);
   app.use('/api/admin', adminRoutes);
   app.use('/api/admin/security', adminSecurityRoutes);
-  app.use('/api/admin/overrides', adminOverridesRoutes);
   app.use('/api/admin/system', adminSystemRoutes);
 
   // Global error handler

--- a/server/src/routes/plan.ts
+++ b/server/src/routes/plan.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { d, query } from '../db.js';
+import { computeDowngradeImpact } from '../ee/lib/downgradeImpact.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
 import { config } from '../lib/config.js';
-import { computeDowngradeImpact } from '../lib/downgradeImpact.js';
 import { NotFoundError, ValidationError } from '../lib/httpErrors.js';
 import { type CheckoutAction, computeOverLimits, generateDowngradeFlowAction, generatePortalAction, generateUpgradeAction, generateUpgradePlanAction, getAiCredits, getFeatureMap, getUserPlanInfo, getUserUsage, invalidateOverLimitCache, isSelfHosted, isSubscriptionActive, Plan, planLabel, renderActionAsUrl, SELF_HOSTED_USAGE_STUB, SELF_HOSTED_USAGE_SUMMARY_STUB, SubStatus, subStatusLabel } from '../lib/planGate.js';
 import { authenticate } from '../middleware/auth.js';

--- a/src/ee/SubscriptionSection.tsx
+++ b/src/ee/SubscriptionSection.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight } from 'lucide-react';
 import { useState } from 'react';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
+import { CheckoutLink } from '@/ee/checkoutAction';
+import { SettingsPageHeader } from '@/features/settings/SettingsPageHeader';
 import { getLockedCta, getLockedMessage, usePlan } from '@/lib/usePlan';
 import { cn, focusRing } from '@/lib/utils';
 import type { CatalogPlan, CheckoutAction, PlanTier, PlanUsage } from '@/types';
@@ -13,6 +14,9 @@ import { ManageSubscriptionRow } from './SubscriptionSection/ManageSubscriptionR
 import { PlanPicker } from './SubscriptionSection/PlanPicker';
 import { SupportFooter } from './SubscriptionSection/SupportFooter';
 import { UpgradeCard } from './SubscriptionSection/UpgradeCard';
+
+const PAGE_TITLE = 'Subscription';
+const PAGE_DESCRIPTION = 'Manage your plan and billing.';
 
 const ZERO_USAGE: PlanUsage = {
   binCount: 0, locationCount: 0, photoStorageMb: 0,
@@ -62,28 +66,31 @@ export function SubscriptionSection() {
     const ctaLabel = getLockedCta(planInfo.previousSubStatus);
     const lockedMessage = getLockedMessage(planInfo.previousSubStatus);
     return (
-      <div className="flex flex-col gap-4">
-        <div>
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Expired</h2>
-          {planInfo.activeUntil && (
-            <p className="text-sm text-[var(--text-tertiary)] mt-1">
-              since {formatBillingDate(planInfo.activeUntil)}
-            </p>
+      <>
+        <SettingsPageHeader title={PAGE_TITLE} description={PAGE_DESCRIPTION} />
+        <div className="flex flex-col gap-4">
+          <div>
+            <h3 className="settings-section-label">Expired</h3>
+            {planInfo.activeUntil && (
+              <p className="settings-section-desc mt-1">
+                since {formatBillingDate(planInfo.activeUntil)}
+              </p>
+            )}
+          </div>
+          <p className="text-sm text-[var(--text-secondary)]">{lockedMessage}</p>
+          {planInfo.subscribePlanAction && (
+            <CheckoutLink
+              action={planInfo.subscribePlanAction}
+              target="_blank"
+              className={primaryCtaClass}
+            >
+              {ctaLabel}
+              <ArrowUpRight className="h-3.5 w-3.5" />
+            </CheckoutLink>
           )}
+          <SupportFooter />
         </div>
-        <p className="text-sm text-[var(--text-secondary)]">{lockedMessage}</p>
-        {planInfo.subscribePlanAction && isSafeCheckoutAction(planInfo.subscribePlanAction) && (
-          <CheckoutLink
-            action={planInfo.subscribePlanAction}
-            target="_blank"
-            className={primaryCtaClass}
-          >
-            {ctaLabel}
-            <ArrowUpRight className="h-3.5 w-3.5" />
-          </CheckoutLink>
-        )}
-        <SupportFooter />
-      </div>
+      </>
     );
   }
 
@@ -110,16 +117,14 @@ export function SubscriptionSection() {
   if (
     !isTrial &&
     isCancelPending &&
-    planInfo.portalAction &&
-    isSafeCheckoutAction(planInfo.portalAction)
+    planInfo.portalAction
   ) {
     primaryCta = { label: 'Reactivate subscription', action: planInfo.portalAction };
   } else if (
     !isTrial &&
     isMonthlyPaid &&
     annualSavings > 0 &&
-    planInfo.portalAction &&
-    isSafeCheckoutAction(planInfo.portalAction)
+    planInfo.portalAction
   ) {
     primaryCta = {
       label: `Switch to annual — save ${formatPriceCents(annualSavings)}/yr`,
@@ -131,48 +136,134 @@ export function SubscriptionSection() {
   // CurrentPlanCard above it for the countdown.
   if (showPicker) {
     return (
-      <div className="flex flex-col gap-4">
-        {isTrial && (
-          <CurrentPlanCard
-            plan={plan}
-            status={planInfo.status}
-            activeUntil={planInfo.activeUntil}
-            cancelAtPeriodEnd={planInfo.cancelAtPeriodEnd}
-            billingPeriod={planInfo.billingPeriod}
-            trialPeriodDays={planInfo.trialPeriodDays}
-            priceCents={monthlyPriceCents}
-            annualSavingsCents={annualSavings}
-            usage={usage ?? ZERO_USAGE}
-            features={planInfo.features}
-            aiCredits={planInfo.aiCredits}
-          />
+      <>
+        <SettingsPageHeader title={PAGE_TITLE} description={PAGE_DESCRIPTION} />
+        <div className="flex flex-col gap-4">
+          {isTrial && (
+            <CurrentPlanCard
+              plan={plan}
+              status={planInfo.status}
+              activeUntil={planInfo.activeUntil}
+              cancelAtPeriodEnd={planInfo.cancelAtPeriodEnd}
+              billingPeriod={planInfo.billingPeriod}
+              trialPeriodDays={planInfo.trialPeriodDays}
+              priceCents={monthlyPriceCents}
+              annualSavingsCents={annualSavings}
+              usage={usage ?? ZERO_USAGE}
+              features={planInfo.features}
+              aiCredits={planInfo.aiCredits}
+            />
+          )}
+          {plans.length > 0 && (
+            <PlanPicker
+              catalog={{ plans }}
+              currentPlan={plan}
+              billingPeriod={billingPeriod}
+              onBillingPeriodChange={setBillingPeriod}
+              actions={{
+                plus: planInfo.upgradePlusAction,
+                pro: planInfo.upgradeProAction,
+              }}
+            />
+          )}
+          {isTrial && (
+            <p className="text-sm text-[var(--text-tertiary)] text-center">
+              Cancel anytime · No questions asked
+            </p>
+          )}
+          {isTrial && (
+            <button
+              type="button"
+              className={cn(downgradeLinkClass, 'block')}
+              onClick={() => setDowngradeTarget('free')}
+            >
+              Switch to Free Plan
+            </button>
+          )}
+          {downgradeTarget && (
+            <DowngradeImpactDialog
+              open
+              onOpenChange={(open) => {
+                if (!open) setDowngradeTarget(null);
+              }}
+              targetPlan={downgradeTarget}
+              onConfirmed={() => {
+                refresh();
+              }}
+            />
+          )}
+          <SupportFooter />
+        </div>
+      </>
+    );
+  }
+
+  // Subscribed (active Plus/Pro, possibly cancel-pending)
+  const proPlan = showProUpsell ? findPlan(plans, 'pro') : undefined;
+
+  return (
+    <>
+      <SettingsPageHeader title={PAGE_TITLE} description={PAGE_DESCRIPTION} />
+      <div className="flex flex-col gap-3">
+        <CurrentPlanCard
+          plan={plan}
+          status={planInfo.status}
+          activeUntil={planInfo.activeUntil}
+          cancelAtPeriodEnd={planInfo.cancelAtPeriodEnd}
+          billingPeriod={planInfo.billingPeriod}
+          trialPeriodDays={planInfo.trialPeriodDays}
+          priceCents={priceCents}
+          annualSavingsCents={annualSavings}
+          usage={usage ?? ZERO_USAGE}
+          features={planInfo.features}
+          aiCredits={planInfo.aiCredits}
+        />
+
+        {showProUpsell && proPlan && (
+          <UpgradeCard targetPlan={proPlan} action={planInfo.upgradeProAction} />
         )}
-        {plans.length > 0 && (
-          <PlanPicker
-            catalog={{ plans }}
-            currentPlan={plan}
-            billingPeriod={billingPeriod}
-            onBillingPeriodChange={setBillingPeriod}
-            actions={{
-              plus: planInfo.upgradePlusAction,
-              pro: planInfo.upgradeProAction,
-            }}
-          />
-        )}
-        {isTrial && (
-          <p className="text-sm text-[var(--text-tertiary)] text-center">
-            Cancel anytime · No questions asked
-          </p>
-        )}
-        {isTrial && (
-          <button
-            type="button"
-            className={cn(downgradeLinkClass, 'block')}
-            onClick={() => setDowngradeTarget('free')}
+
+        {primaryCta && (
+          <CheckoutLink
+            action={primaryCta.action}
+            target="_blank"
+            className={primaryCtaClass}
           >
-            Switch to Free Plan
-          </button>
+            {primaryCta.label}
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </CheckoutLink>
         )}
+
+        {!isCancelPending && (
+          <ManageSubscriptionRow
+            action={planInfo.portalAction}
+            isCancelPending={isCancelPending}
+          />
+        )}
+
+        {showDowngradeLinks && (
+          <div className="flex flex-wrap gap-x-4 gap-y-1 pl-1">
+            {plan === 'pro' && (
+              <button
+                type="button"
+                className={downgradeLinkClass}
+                onClick={() => setDowngradeTarget('plus')}
+              >
+                Downgrade to Plus
+              </button>
+            )}
+            {(plan === 'plus' || plan === 'pro') && (
+              <button
+                type="button"
+                className={downgradeLinkClass}
+                onClick={() => setDowngradeTarget('free')}
+              >
+                Switch to Free
+              </button>
+            )}
+          </div>
+        )}
+
         {downgradeTarget && (
           <DowngradeImpactDialog
             open
@@ -185,89 +276,9 @@ export function SubscriptionSection() {
             }}
           />
         )}
+
         <SupportFooter />
       </div>
-    );
-  }
-
-  // Subscribed (active Plus/Pro, possibly cancel-pending)
-  const proPlan = showProUpsell ? findPlan(plans, 'pro') : undefined;
-
-  return (
-    <div className="flex flex-col gap-3">
-      <CurrentPlanCard
-        plan={plan}
-        status={planInfo.status}
-        activeUntil={planInfo.activeUntil}
-        cancelAtPeriodEnd={planInfo.cancelAtPeriodEnd}
-        billingPeriod={planInfo.billingPeriod}
-        trialPeriodDays={planInfo.trialPeriodDays}
-        priceCents={priceCents}
-        annualSavingsCents={annualSavings}
-        usage={usage ?? ZERO_USAGE}
-        features={planInfo.features}
-        aiCredits={planInfo.aiCredits}
-      />
-
-      {showProUpsell && proPlan && (
-        <UpgradeCard targetPlan={proPlan} action={planInfo.upgradeProAction} />
-      )}
-
-      {primaryCta && (
-        <CheckoutLink
-          action={primaryCta.action}
-          target="_blank"
-          className={primaryCtaClass}
-        >
-          {primaryCta.label}
-          <ArrowUpRight className="h-3.5 w-3.5" />
-        </CheckoutLink>
-      )}
-
-      {!isCancelPending && (
-        <ManageSubscriptionRow
-          action={planInfo.portalAction}
-          isCancelPending={isCancelPending}
-        />
-      )}
-
-      {showDowngradeLinks && (
-        <div className="flex flex-wrap gap-x-4 gap-y-1 pl-1">
-          {plan === 'pro' && (
-            <button
-              type="button"
-              className={downgradeLinkClass}
-              onClick={() => setDowngradeTarget('plus')}
-            >
-              Downgrade to Plus
-            </button>
-          )}
-          {(plan === 'plus' || plan === 'pro') && (
-            <button
-              type="button"
-              className={downgradeLinkClass}
-              onClick={() => setDowngradeTarget('free')}
-            >
-              Switch to Free
-            </button>
-          )}
-        </div>
-      )}
-
-      {downgradeTarget && (
-        <DowngradeImpactDialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setDowngradeTarget(null);
-          }}
-          targetPlan={downgradeTarget}
-          onConfirmed={() => {
-            refresh();
-          }}
-        />
-      )}
-
-      <SupportFooter />
-    </div>
+    </>
   );
 }

--- a/src/ee/SubscriptionSection/ManageSubscriptionRow.tsx
+++ b/src/ee/SubscriptionSection/ManageSubscriptionRow.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from 'lucide-react';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
+import { CheckoutLink } from '@/ee/checkoutAction';
 import { cn, focusRing } from '@/lib/utils';
 import type { CheckoutAction } from '@/types';
 
@@ -9,7 +9,7 @@ interface ManageSubscriptionRowProps {
 }
 
 export function ManageSubscriptionRow({ action, isCancelPending }: ManageSubscriptionRowProps) {
-  if (!action || !isSafeCheckoutAction(action)) return null;
+  if (!action) return null;
   const label = isCancelPending ? 'Reactivate subscription' : 'Manage Subscription';
   return (
     <CheckoutLink

--- a/src/ee/SubscriptionSection/PlanCard.tsx
+++ b/src/ee/SubscriptionSection/PlanCard.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from 'lucide-react';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
+import { CheckoutLink } from '@/ee/checkoutAction';
 import { cn, focusRing } from '@/lib/utils';
 import type { CatalogPlan, CheckoutAction } from '@/types';
 import { formatPriceCents } from './annualSavings';
@@ -41,7 +41,7 @@ export function PlanCard({ plan, billingPeriod, ctaLabel, action, isCurrentPlan 
         <button type="button" disabled className={cn(ctaClassName, 'opacity-50 cursor-not-allowed')}>
           Current plan
         </button>
-      ) : action && isSafeCheckoutAction(action) ? (
+      ) : action ? (
         <CheckoutLink action={action} target="_blank" className={ctaClassName}>
           {ctaLabel}
           <ArrowUpRight className="h-3.5 w-3.5" />

--- a/src/ee/SubscriptionSection/UpgradeCard.tsx
+++ b/src/ee/SubscriptionSection/UpgradeCard.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from 'lucide-react';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
+import { CheckoutLink } from '@/ee/checkoutAction';
 import { cn, focusRing } from '@/lib/utils';
 import type { CatalogPlan, CheckoutAction } from '@/types';
 import { formatPriceCents } from './annualSavings';
@@ -24,7 +24,7 @@ export function UpgradeCard({ targetPlan, action }: UpgradeCardProps) {
           {monthly}/mo{annual && ` · ${annual}/yr`}
         </p>
       </div>
-      {action && isSafeCheckoutAction(action) && (
+      {action && (
         <CheckoutLink action={action} target="_blank" className={ctaClassName}>
           Upgrade to {targetPlan.name}
           <ArrowUpRight className="h-3.5 w-3.5" />

--- a/src/ee/SubscriptionSection/__tests__/DowngradeImpactDialog.test.tsx
+++ b/src/ee/SubscriptionSection/__tests__/DowngradeImpactDialog.test.tsx
@@ -5,7 +5,7 @@ import { FIXTURE_IMPACT_FREE } from './fixtures/downgradeImpact';
 
 const submitCheckoutAction = vi.fn();
 
-vi.mock('@/lib/checkoutAction', () => ({
+vi.mock('@/ee/checkoutAction', () => ({
   submitCheckoutAction: (...args: unknown[]) => submitCheckoutAction(...args),
 }));
 

--- a/src/ee/SubscriptionSection/__tests__/SubscriptionSection.test.tsx
+++ b/src/ee/SubscriptionSection/__tests__/SubscriptionSection.test.tsx
@@ -44,6 +44,28 @@ function setPlan(planInfo: ReturnType<typeof makePlanInfo>, usage = EMPTY_USAGE)
 }
 
 describe('SubscriptionSection orchestrator', () => {
+  it.each([
+    ['free', () => makePlanInfo({ plan: 'free' })],
+    ['pro active', () => makePlanInfo({
+      plan: 'pro',
+      status: 'active',
+      activeUntil: '2026-05-27T00:00:00Z',
+      billingPeriod: 'monthly',
+    })],
+    ['locked', () => makePlanInfo({
+      plan: 'plus',
+      status: 'inactive',
+      locked: true,
+      previousSubStatus: 'active',
+    })],
+  ])('renders the Subscription page header in %s branch', (_name, makeInfo) => {
+    setPlan(makeInfo());
+    render(<SubscriptionSection />);
+    const heading = screen.getByRole('heading', { level: 2, name: 'Subscription' });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByText('Manage your plan and billing.')).toBeInTheDocument();
+  });
+
   it('Free state: shows plan picker, no manage button', () => {
     setPlan(makePlanInfo({ plan: 'free' }));
     render(<SubscriptionSection />);

--- a/src/ee/SubscriptionSection/hooks/useDowngrade.ts
+++ b/src/ee/SubscriptionSection/hooks/useDowngrade.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
+import { submitCheckoutAction } from '@/ee/checkoutAction';
 import { apiFetch } from '@/lib/api';
-import { submitCheckoutAction } from '@/lib/checkoutAction';
 import { Events, notify } from '@/lib/eventBus';
 import type { CheckoutAction } from '@/types';
 

--- a/src/ee/UpgradeDialog.tsx
+++ b/src/ee/UpgradeDialog.tsx
@@ -1,7 +1,7 @@
 import { ArrowUpRight, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
+import { CheckoutLink } from '@/ee/checkoutAction';
 import { usePlan } from '@/lib/usePlan';
 import { cn, focusRing } from '@/lib/utils';
 
@@ -35,7 +35,7 @@ export function UpgradeDialog({ open, onOpenChange, feature, description }: Upgr
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Maybe later
           </Button>
-          {isSafeCheckoutAction(upgradeAction) && (
+          {upgradeAction && (
             <CheckoutLink
               action={upgradeAction}
               target="_blank"

--- a/src/ee/UpgradePrompt.tsx
+++ b/src/ee/UpgradePrompt.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, X } from 'lucide-react';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
+import { CheckoutLink } from '@/ee/checkoutAction';
 import { usePlan } from '@/lib/usePlan';
 import { useUserPreferences } from '@/lib/userPreferences';
 import { cn, focusRing } from '@/lib/utils';
@@ -65,7 +65,7 @@ export function UpgradePrompt({ feature, description, upgradeAction, className, 
           <p className="text-[13px] text-[var(--text-tertiary)] mt-1">{description}</p>
         )}
       </div>
-      {isSafeCheckoutAction(upgradeAction) && (
+      {upgradeAction && (
         <CheckoutLink
           action={upgradeAction}
           target="_blank"

--- a/src/ee/adminOverrides.ts
+++ b/src/ee/adminOverrides.ts
@@ -1,0 +1,44 @@
+import { apiFetch } from '@/lib/api';
+
+export interface UserLimitOverrides {
+  userId: string;
+  maxBins: number | null;
+  maxLocations: number | null;
+  maxPhotoStorageMb: number | null;
+  maxMembersPerLocation: number | null;
+  activityRetentionDays: number | null;
+  aiCreditsPerMonth: number | null;
+  aiEnabled: boolean | null;
+}
+
+export async function fetchOverrides(userId: string) {
+  return apiFetch<UserLimitOverrides>(`/api/admin/overrides/overrides/${userId}`);
+}
+
+export async function updateOverrides(userId: string, overrides: Partial<UserLimitOverrides>) {
+  await apiFetch(`/api/admin/overrides/overrides/${userId}`, { method: 'PUT', body: overrides });
+}
+
+export async function clearOverrides(userId: string) {
+  await apiFetch(`/api/admin/overrides/overrides/${userId}`, { method: 'DELETE' });
+}
+
+export async function grantAiCredits(userId: string, amount: number) {
+  await apiFetch(`/api/admin/overrides/ai-credits/grant/${userId}`, { method: 'POST', body: { amount } });
+}
+
+export async function resetAiCredits(userId: string) {
+  await apiFetch(`/api/admin/overrides/ai-credits/reset/${userId}`, { method: 'POST' });
+}
+
+export async function extendTrial(userId: string, days: number) {
+  return apiFetch<{ message: string; activeUntil: string }>(`/api/admin/overrides/extend-trial/${userId}`, { method: 'POST', body: { days } });
+}
+
+export async function grantCompPlan(userId: string, plan: number, days: number) {
+  return apiFetch<{ message: string; activeUntil: string }>(`/api/admin/overrides/grant-comp/${userId}`, { method: 'POST', body: { plan, days } });
+}
+
+export async function forceDowngrade(userId: string, plan: number) {
+  await apiFetch(`/api/admin/overrides/force-downgrade/${userId}`, { method: 'POST', body: { plan } });
+}

--- a/src/ee/checkoutAction.tsx
+++ b/src/ee/checkoutAction.tsx
@@ -1,27 +1,15 @@
-// CheckoutLink + submitCheckoutAction — render the structured CheckoutAction
-// returned by /api/plan as a button-shaped link that does the right thing
-// for the action's method.
-//
-// Why this exists: until the 2026-04-26 hardening pass on openbin-deploy,
-// the billing service accepted the user's session JWT only via `?token=`
-// in the URL. That landed in browser history, the Referer header, the
-// Umami analytics URL, and the access log. Billing now accepts the token
-// via POST body or `Authorization: Bearer`; this helper is the client side
-// of that migration. /plans is intentionally still GET (it's a static page
-// that needs the token client-side), but the rest of the surfaces are POST.
-//
-// The two entry points:
-//   <CheckoutLink action={planInfo.upgradeProAction}>Upgrade to Pro</CheckoutLink>
-//     — for inline buttons / CTAs in the React tree.
-//   submitCheckoutAction(action, { target: '_blank' })
-//     — for the rare imperative flow (window.open replacement). Builds a
-//     transient form, submits, removes it. Same security properties.
+// CheckoutLink + submitCheckoutAction render a CheckoutAction from /api/plan
+// as a form-POST (or anchor for GET) so the JWT rides the request body
+// instead of the URL — keeping it out of browser history, Referer, and
+// access logs. The URL/method allowlist guard is internal: callers only
+// need to null-check the action; <CheckoutLink> returns null and
+// submitCheckoutAction no-ops if the action is unsafe.
 
 import type React from 'react';
 import { cn, isSafeExternalUrl } from '@/lib/utils';
 import type { CheckoutAction } from '@/types';
 
-export function isSafeCheckoutAction(action: CheckoutAction | null): action is CheckoutAction {
+function isSafeCheckoutAction(action: CheckoutAction | null): action is CheckoutAction {
   if (!action) return false;
   if (!isSafeExternalUrl(action.url)) return false;
   // Defense-in-depth on the method: server only emits 'GET' or 'POST'
@@ -48,6 +36,8 @@ export function CheckoutLink({
   rel = 'noopener noreferrer',
   ...buttonProps
 }: CheckoutLinkProps) {
+  if (!isSafeCheckoutAction(action)) return null;
+
   if (action.method === 'GET') {
     // GET goes to /plans (static page) so the token has to ride the URL
     // anyway. Cache-Control: no-store on billing's /plans + Referrer-Policy

--- a/src/features/admin/AdminUserDetailPage.tsx
+++ b/src/features/admin/AdminUserDetailPage.tsx
@@ -26,10 +26,11 @@ import { PageHeader } from '@/components/ui/page-header';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/toast';
+import { clearOverrides, fetchOverrides, grantAiCredits, resetAiCredits, type UserLimitOverrides, updateOverrides } from '@/ee/adminOverrides';
 import { useAuth } from '@/lib/auth';
 import { usePlan } from '@/lib/usePlan';
 import { cn, getErrorMessage, relativeTime } from '@/lib/utils';
-import { capitalize, clearOverrides, deleteUser, fetchOverrides, forcePasswordChange, grantAiCredits, reactivateUser, regenerateApiKey, resetAiCredits, revokeAllApiKeys, revokeSessions, sendPasswordReset, statusVariant, suspendUser, type UserLimitOverrides, updateOverrides, updateUser, useAdminCount, useAdminUserDetail } from './useAdminUsers';
+import { capitalize, deleteUser, forcePasswordChange, reactivateUser, regenerateApiKey, revokeAllApiKeys, revokeSessions, sendPasswordReset, statusVariant, suspendUser, updateUser, useAdminCount, useAdminUserDetail } from './useAdminUsers';
 
 // Mirror of server/src/lib/planGate.ts — client can't import server code.
 const PLAN_CODE = { free: 2, plus: 0, pro: 1 } as const;

--- a/src/features/admin/useAdminUsers.ts
+++ b/src/features/admin/useAdminUsers.ts
@@ -214,17 +214,6 @@ export interface LoginHistoryEntry {
   createdAt: string;
 }
 
-export interface UserLimitOverrides {
-  userId: string;
-  maxBins: number | null;
-  maxLocations: number | null;
-  maxPhotoStorageMb: number | null;
-  maxMembersPerLocation: number | null;
-  activityRetentionDays: number | null;
-  aiCreditsPerMonth: number | null;
-  aiEnabled: boolean | null;
-}
-
 export async function suspendUser(id: string, reason?: string) {
   await apiFetch(`/api/admin/security/suspend/${id}`, { method: 'POST', body: { reason } });
 }
@@ -243,38 +232,6 @@ export async function revokeAllApiKeys(id: string) {
 
 export async function fetchLoginHistory(id: string, page = 1, limit = 50) {
   return apiFetch<{ results: LoginHistoryEntry[]; count: number }>(`/api/admin/security/login-history/${id}?page=${page}&limit=${limit}`);
-}
-
-export async function fetchOverrides(userId: string) {
-  return apiFetch<UserLimitOverrides>(`/api/admin/overrides/overrides/${userId}`);
-}
-
-export async function updateOverrides(userId: string, overrides: Partial<UserLimitOverrides>) {
-  await apiFetch(`/api/admin/overrides/overrides/${userId}`, { method: 'PUT', body: overrides });
-}
-
-export async function clearOverrides(userId: string) {
-  await apiFetch(`/api/admin/overrides/overrides/${userId}`, { method: 'DELETE' });
-}
-
-export async function grantAiCredits(userId: string, amount: number) {
-  await apiFetch(`/api/admin/overrides/ai-credits/grant/${userId}`, { method: 'POST', body: { amount } });
-}
-
-export async function resetAiCredits(userId: string) {
-  await apiFetch(`/api/admin/overrides/ai-credits/reset/${userId}`, { method: 'POST' });
-}
-
-export async function extendTrial(userId: string, days: number) {
-  return apiFetch<{ message: string; activeUntil: string }>(`/api/admin/overrides/extend-trial/${userId}`, { method: 'POST', body: { days } });
-}
-
-export async function grantCompPlan(userId: string, plan: number, days: number) {
-  return apiFetch<{ message: string; activeUntil: string }>(`/api/admin/overrides/grant-comp/${userId}`, { method: 'POST', body: { plan, days } });
-}
-
-export async function forceDowngrade(userId: string, plan: number) {
-  await apiFetch(`/api/admin/overrides/force-downgrade/${userId}`, { method: 'POST', body: { plan } });
 }
 
 export async function forcePasswordChange(userId: string, enabled = true) {

--- a/src/features/layout/AppLayout.tsx
+++ b/src/features/layout/AppLayout.tsx
@@ -22,7 +22,6 @@ import type { TourContext } from '@/features/tour/tourSteps';
 import { useTour } from '@/features/tour/useTour';
 import { useAppSettings } from '@/lib/appSettings';
 import { useAuth } from '@/lib/auth';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
 import { useNavigationGuard } from '@/lib/navigationGuard';
 import { useTerminology } from '@/lib/terminology';
 import { useTheme } from '@/lib/theme';
@@ -43,6 +42,10 @@ const ScanDialog = React.lazy(() =>
 );
 
 const CommandInput = lazy(() => import('@/features/ai/CommandInput').then((m) => ({ default: m.CommandInput })));
+
+const CheckoutLink = __EE__
+  ? lazy(() => import('@/ee/checkoutAction').then((m) => ({ default: m.CheckoutLink })))
+  : (() => null) as React.FC<Record<string, unknown>>;
 
 const HIGHLIGHTS_TOUR: TourId = 'highlights';
 
@@ -269,18 +272,20 @@ export function AppLayout() {
                 // is static). Over-limit banner uses upgradeProAction (POST,
                 // token in body, never in URL).
                 const action = showLockedBanner ? planInfo.upgradeAction : planInfo.upgradeProAction;
-                if (!isSafeCheckoutAction(action)) return null;
+                if (!action) return null;
                 return (
-                  <CheckoutLink
-                    action={action}
-                    target="_blank"
-                    className="inline-flex items-center gap-1 rounded-md bg-white/20 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/30 transition-colors shrink-0"
-                  >
-                    {showLockedBanner
-                      ? getLockedCta(planInfo.previousSubStatus)
-                      : 'Upgrade'}
-                    <ArrowUpRight className="h-3 w-3" />
-                  </CheckoutLink>
+                  <Suspense fallback={null}>
+                    <CheckoutLink
+                      action={action}
+                      target="_blank"
+                      className="inline-flex items-center gap-1 rounded-md bg-white/20 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/30 transition-colors shrink-0"
+                    >
+                      {showLockedBanner
+                        ? getLockedCta(planInfo.previousSubStatus)
+                        : 'Upgrade'}
+                      <ArrowUpRight className="h-3 w-3" />
+                    </CheckoutLink>
+                  </Suspense>
                 );
               })()}
             </div>

--- a/src/features/reorganize/ReorganizePage.tsx
+++ b/src/features/reorganize/ReorganizePage.tsx
@@ -26,7 +26,6 @@ import { BinSelectorCard } from '@/features/print/BinSelectorCard';
 import { useBinSelection } from '@/features/print/useBinSelection';
 import { TourLauncher } from '@/features/tour/TourLauncher';
 import { useAuth } from '@/lib/auth';
-import { CheckoutLink, isSafeCheckoutAction } from '@/lib/checkoutAction';
 import { useTerminology } from '@/lib/terminology';
 import { usePermissions } from '@/lib/usePermissions';
 import { usePlan } from '@/lib/usePlan';
@@ -41,6 +40,10 @@ import { type TagSuggestOptions, type TagUserSelections, useReorganizeTags } fro
 
 const UpgradePrompt = __EE__
   ? lazy(() => import('@/ee/UpgradePrompt').then(m => ({ default: m.UpgradePrompt })))
+  : (() => null) as React.FC<Record<string, unknown>>;
+
+const CheckoutLink = __EE__
+  ? lazy(() => import('@/ee/checkoutAction').then(m => ({ default: m.CheckoutLink })))
   : (() => null) as React.FC<Record<string, unknown>>;
 
 interface OptionFieldConfig<K extends string> {
@@ -222,7 +225,7 @@ export function ReorganizePage() {
   const reorgBinCap = planInfo.features.reorganizeMaxBins;
   const overCap = reorgBinCap != null && selection.selectedIds.size > reorgBinCap;
   const canSubmit = selection.selectedIds.size >= 2 && !isStreaming && !hasValidationError && !overCap;
-  const canUpgradeFromCap = overCap && isPlus && isSafeCheckoutAction(planInfo.upgradeProAction);
+  const canUpgradeFromCap = overCap && isPlus && planInfo.upgradeProAction !== null;
   const capSuffix = canUpgradeFromCap ? ', or upgrade to Pro for a higher cap.' : '.';
 
   const handleAccept = useCallback(() => {
@@ -595,13 +598,15 @@ export function ReorganizePage() {
                       {isPlus ? 'Plus' : 'Pro'} allows up to {reorgBinCap} {reorgBinCap === 1 ? t.bin : t.bins} per reorganize run. Deselect {selection.selectedIds.size - reorgBinCap} to continue{capSuffix}
                     </p>
                     {canUpgradeFromCap && planInfo.upgradeProAction && (
-                      <CheckoutLink
-                        action={planInfo.upgradeProAction}
-                        target="_blank"
-                        className="inline-flex items-center text-[13px] font-medium text-[var(--text-primary)] underline underline-offset-2"
-                      >
-                        Upgrade to Pro
-                      </CheckoutLink>
+                      <Suspense fallback={null}>
+                        <CheckoutLink
+                          action={planInfo.upgradeProAction}
+                          target="_blank"
+                          className="inline-flex items-center text-[13px] font-medium text-[var(--text-primary)] underline underline-offset-2"
+                        >
+                          Upgrade to Pro
+                        </CheckoutLink>
+                      </Suspense>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Moves `checkoutAction.tsx` from `src/lib/` to `src/ee/`
- Moves server-side EE modules (`adminOverrides`, `downgradeImpact`, `planCatalog`, their tests) from `server/src/` into `server/src/ee/`

## Test plan
- [ ] `npx biome check .` passes
- [ ] `npx tsc --noEmit` passes (client + server)
- [ ] Billing flows (upgrade, portal) still work in cloud build