### PR TITLE
feat: switch billing cadence from monthly to quarterly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,9 +68,9 @@
 
 # ── Plan Pricing (cloud only — must match Stripe Dashboard) ──
 # All prices in minor units (cents/USD). Used by GET /api/plans.
-# PLAN_PRICE_PLUS_MONTHLY=500          # $5/month
+# PLAN_PRICE_PLUS_QUARTERLY=1500       # $15/quarter
 # PLAN_PRICE_PLUS_ANNUAL=5000          # $50/year
-# PLAN_PRICE_PRO_MONTHLY=1000          # $10/month
+# PLAN_PRICE_PRO_QUARTERLY=3000        # $30/quarter
 # PLAN_PRICE_PRO_ANNUAL=10000          # $100/year
 
 # ── Backups ───────────────────────────────────

--- a/server/src/__tests__/planGate.test.ts
+++ b/server/src/__tests__/planGate.test.ts
@@ -399,7 +399,7 @@ describe('getUserPlanInfo()', () => {
   it('maps snake_case DB columns to camelCase', async () => {
     const activeUntil = '2027-01-01T00:00:00.000Z';
     vi.mocked(query).mockResolvedValue({
-      rows: [{ plan: Plan.PLUS, sub_status: SubStatus.TRIAL, active_until: activeUntil, email: null, previous_sub_status: SubStatus.ACTIVE, cancel_at_period_end: '2027-02-01T00:00:00.000Z', billing_period: 'monthly' }],
+      rows: [{ plan: Plan.PLUS, sub_status: SubStatus.TRIAL, active_until: activeUntil, email: null, previous_sub_status: SubStatus.ACTIVE, cancel_at_period_end: '2027-02-01T00:00:00.000Z', billing_period: 'quarterly' }],
       rowCount: 1,
     });
     const result = await getUserPlanInfo('user-id');
@@ -409,7 +409,7 @@ describe('getUserPlanInfo()', () => {
     expect(result?.email).toBeNull();
     expect(result?.previousSubStatus).toBe(SubStatus.ACTIVE);
     expect(result?.cancelAtPeriodEnd).toBe('2027-02-01T00:00:00.000Z');
-    expect(result?.billingPeriod).toBe('monthly');
+    expect(result?.billingPeriod).toBe('quarterly');
   });
 
   it('queries with the correct SQL and userId', async () => {

--- a/server/src/__tests__/subscriptions.test.ts
+++ b/server/src/__tests__/subscriptions.test.ts
@@ -346,7 +346,7 @@ describe('POST /api/subscriptions/callback', () => {
       status: 1,  // SubStatus.ACTIVE
       activeUntil: '2026-05-27T00:00:00Z',
       cancelAtPeriodEnd: '2026-05-27T00:00:00Z',
-      billingPeriod: 'monthly',
+      billingPeriod: 'quarterly',
     });
 
     const res = await request(app)
@@ -360,7 +360,7 @@ describe('POST /api/subscriptions/callback', () => {
       [user.id],
     );
     expect(row.rows[0].cancel_at_period_end).toBe('2026-05-27T00:00:00Z');
-    expect(row.rows[0].billing_period).toBe('monthly');
+    expect(row.rows[0].billing_period).toBe('quarterly');
   });
 
   it('clears cancelAtPeriodEnd when payload omits it (subscription resumed)', async () => {
@@ -370,7 +370,7 @@ describe('POST /api/subscriptions/callback', () => {
       userId: user.id, plan: 0, status: 1,
       activeUntil: '2026-05-27T00:00:00Z',
       cancelAtPeriodEnd: '2026-05-27T00:00:00Z',
-      billingPeriod: 'monthly',
+      billingPeriod: 'quarterly',
     });
     await request(app).post('/api/subscriptions/callback').set('Authorization', `Bearer ${token1}`).send({});
 
@@ -378,7 +378,7 @@ describe('POST /api/subscriptions/callback', () => {
     const token2 = await makeSubToken({
       userId: user.id, plan: 0, status: 1,
       activeUntil: '2026-06-27T00:00:00Z',
-      billingPeriod: 'monthly',
+      billingPeriod: 'quarterly',
       // no cancelAtPeriodEnd
     });
     const res = await request(app).post('/api/subscriptions/callback').set('Authorization', `Bearer ${token2}`).send({});
@@ -395,7 +395,7 @@ describe('POST /api/subscriptions/callback', () => {
     const { user } = await createTestUser(app);
     const token = await makeSubToken({
       userId: user.id, plan: 0, status: 1, activeUntil: '2026-05-27T00:00:00Z',
-      billingPeriod: 'quarterly',
+      billingPeriod: 'monthly',
     });
     const res = await request(app).post('/api/subscriptions/callback').set('Authorization', `Bearer ${token}`).send({});
     expect(res.status).toBe(422);  // ValidationError

--- a/server/src/db/migrations/0011_clear_legacy_monthly_billing_period.ts
+++ b/server/src/db/migrations/0011_clear_legacy_monthly_billing_period.ts
@@ -1,0 +1,20 @@
+import type Database from 'better-sqlite3';
+import type pg from 'pg';
+import type { Migration } from './types.js';
+
+// Defensive cleanup migration. The codebase no longer accepts
+// billing_period = 'monthly' anywhere — the type union is
+// `'quarterly' | 'annual' | null`. Production has zero subscribers
+// (alpha), but local dev/seed data may have legacy 'monthly' rows.
+// Set those to NULL so the renamed type union doesn't lie about
+// existing rows.
+
+export const clearLegacyMonthlyBillingPeriod: Migration = {
+  name: '0011_clear_legacy_monthly_billing_period',
+  sqlite(db: Database.Database): void {
+    db.prepare("UPDATE users SET billing_period = NULL WHERE billing_period = 'monthly'").run();
+  },
+  async postgres(pool: pg.Pool): Promise<void> {
+    await pool.query("UPDATE users SET billing_period = NULL WHERE billing_period = 'monthly'");
+  },
+};

--- a/server/src/db/migrations/__tests__/0011_clear_legacy_monthly_billing_period.test.ts
+++ b/server/src/db/migrations/__tests__/0011_clear_legacy_monthly_billing_period.test.ts
@@ -1,0 +1,39 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { clearLegacyMonthlyBillingPeriod } from '../0011_clear_legacy_monthly_billing_period.js';
+
+describe('migration 0011_clear_legacy_monthly_billing_period', () => {
+  it('clears billing_period = "monthly" rows (sqlite)', () => {
+    const db = new Database(':memory:');
+    db.prepare('CREATE TABLE users (id TEXT PRIMARY KEY, billing_period TEXT)').run();
+    db.prepare("INSERT INTO users (id, billing_period) VALUES ('u1', 'monthly')").run();
+    db.prepare("INSERT INTO users (id, billing_period) VALUES ('u2', 'annual')").run();
+    db.prepare("INSERT INTO users (id, billing_period) VALUES ('u3', NULL)").run();
+
+    clearLegacyMonthlyBillingPeriod.sqlite!(db);
+
+    const rows = db.prepare('SELECT id, billing_period FROM users ORDER BY id').all() as Array<{
+      id: string;
+      billing_period: string | null;
+    }>;
+    expect(rows).toEqual([
+      { id: 'u1', billing_period: null },
+      { id: 'u2', billing_period: 'annual' },
+      { id: 'u3', billing_period: null },
+    ]);
+  });
+
+  it('is idempotent (sqlite)', () => {
+    const db = new Database(':memory:');
+    db.prepare('CREATE TABLE users (id TEXT PRIMARY KEY, billing_period TEXT)').run();
+    db.prepare("INSERT INTO users (id, billing_period) VALUES ('u1', 'monthly')").run();
+
+    clearLegacyMonthlyBillingPeriod.sqlite!(db);
+    expect(() => clearLegacyMonthlyBillingPeriod.sqlite!(db)).not.toThrow();
+
+    const row = db.prepare('SELECT billing_period FROM users WHERE id = ?').get('u1') as
+      | { billing_period: string | null }
+      | undefined;
+    expect(row?.billing_period).toBeNull();
+  });
+});

--- a/server/src/db/migrations/index.ts
+++ b/server/src/db/migrations/index.ts
@@ -8,6 +8,7 @@ import { subscriptionState } from './0007_subscription_state.js';
 import { deletionLifecycle } from './0008_deletion_lifecycle.js';
 import { drainDeleteUserOutbox } from './0009_drain_delete_user_outbox.js';
 import { relaxCreatedByFks } from './0010_relax_created_by_fks.js';
+import { clearLegacyMonthlyBillingPeriod } from './0011_clear_legacy_monthly_billing_period.js';
 import type { Migration } from './types.js';
 
 /**
@@ -25,4 +26,5 @@ export const migrations: Migration[] = [
   deletionLifecycle,
   drainDeleteUserOutbox,
   relaxCreatedByFks,
+  clearLegacyMonthlyBillingPeriod,
 ];

--- a/server/src/ee/__tests__/plans.test.ts
+++ b/server/src/ee/__tests__/plans.test.ts
@@ -40,10 +40,10 @@ describe('GET /api/plans', () => {
     }
   });
 
-  it('plus plan has monthly + annual prices', async () => {
+  it('plus plan has quarterly + annual prices', async () => {
     const res = await request(app).get('/api/plans');
     const plus = res.body.plans.find((p: any) => p.id === 'plus');
-    expect(plus.prices.monthly).toBeGreaterThan(0);
+    expect(plus.prices.quarterly).toBeGreaterThan(0);
     expect(plus.prices.annual).toBeGreaterThan(0);
   });
 });

--- a/server/src/ee/lib/__tests__/planCatalog.test.ts
+++ b/server/src/ee/lib/__tests__/planCatalog.test.ts
@@ -15,8 +15,8 @@ vi.mock('../../../lib/config.js', () => ({
       proActivityRetentionDays: 90, proAiCreditsPerMonth: 250, proReorganizeMaxBins: 40,
     },
     planPrices: {
-      plusMonthlyCents: 500, plusAnnualCents: 5000,
-      proMonthlyCents: 1000, proAnnualCents: 10000,
+      plusQuarterlyCents: 1500, plusAnnualCents: 5000,
+      proQuarterlyCents: 3000, proAnnualCents: 10000,
     },
   },
 }));
@@ -32,13 +32,13 @@ describe('getPlanCatalog', () => {
   it('free plan has zero prices', () => {
     const { plans } = getPlanCatalog();
     const free = plans.find(p => p.id === 'free')!;
-    expect(free.prices).toEqual({ monthly: 0, annual: null });
+    expect(free.prices).toEqual({ quarterly: 0, annual: null });
   });
 
-  it('plus plan has monthly + annual prices in cents', () => {
+  it('plus plan has quarterly + annual prices in cents', () => {
     const { plans } = getPlanCatalog();
     const plus = plans.find(p => p.id === 'plus')!;
-    expect(plus.prices).toEqual({ monthly: 500, annual: 5000 });
+    expect(plus.prices).toEqual({ quarterly: 1500, annual: 5000 });
   });
 
   it('pro plan exposes its feature limits', () => {

--- a/server/src/ee/lib/planCatalog.ts
+++ b/server/src/ee/lib/planCatalog.ts
@@ -8,7 +8,7 @@ export interface CatalogPlan {
   id: CatalogPlanId;
   name: string;
   prices: {
-    monthly: number;
+    quarterly: number;
     annual: number | null;
   };
   features: PlanFeatures;
@@ -22,9 +22,9 @@ export function getPlanCatalog(): PlanCatalog {
   const { planPrices } = config;
   return {
     plans: [
-      { id: 'free', name: 'Free', prices: { monthly: 0, annual: null }, features: getFeatureMap(Plan.FREE) },
-      { id: 'plus', name: 'Plus', prices: { monthly: planPrices.plusMonthlyCents, annual: planPrices.plusAnnualCents }, features: getFeatureMap(Plan.PLUS) },
-      { id: 'pro',  name: 'Pro',  prices: { monthly: planPrices.proMonthlyCents,  annual: planPrices.proAnnualCents  }, features: getFeatureMap(Plan.PRO)  },
+      { id: 'free', name: 'Free', prices: { quarterly: 0, annual: null }, features: getFeatureMap(Plan.FREE) },
+      { id: 'plus', name: 'Plus', prices: { quarterly: planPrices.plusQuarterlyCents, annual: planPrices.plusAnnualCents }, features: getFeatureMap(Plan.PLUS) },
+      { id: 'pro',  name: 'Pro',  prices: { quarterly: planPrices.proQuarterlyCents,  annual: planPrices.proAnnualCents  }, features: getFeatureMap(Plan.PRO)  },
     ],
   };
 }

--- a/server/src/ee/routes/subscriptions.ts
+++ b/server/src/ee/routes/subscriptions.ts
@@ -12,7 +12,7 @@ const router = Router();
 
 const validPlans = new Set(Object.values(Plan));
 const validStatuses = new Set(Object.values(SubStatus));
-const VALID_PERIODS = new Set<'monthly' | 'annual' | null | undefined>([null, undefined, 'monthly', 'annual']);
+const VALID_PERIODS = new Set<'quarterly' | 'annual' | null | undefined>([null, undefined, 'quarterly', 'annual']);
 
 const SUBSCRIPTION_ISSUER = 'openbin-manager';
 const SUBSCRIPTION_AUDIENCE = 'openbin-backend';
@@ -42,7 +42,7 @@ router.post('/callback', asyncHandler(async (req, res) => {
     activeUntil: string;
     updatedAt?: string;
     cancelAtPeriodEnd?: string | null;
-    billingPeriod?: 'monthly' | 'annual' | null;
+    billingPeriod?: 'quarterly' | 'annual' | null;
   };
   try {
     const result = await jose.jwtVerify(token, new TextEncoder().encode(secret), {

--- a/server/src/lib/config.ts
+++ b/server/src/lib/config.ts
@@ -160,9 +160,9 @@ export const config = Object.freeze({
     trialAiCredits: clamp(parseInt(process.env.TRIAL_AI_CREDITS || '25', 10), 1, 1000, 25),
   }),
   planPrices: Object.freeze({
-    plusMonthlyCents: parseStrictInt(process.env.PLAN_PRICE_PLUS_MONTHLY, 500),
+    plusQuarterlyCents: parseStrictInt(process.env.PLAN_PRICE_PLUS_QUARTERLY, 1500),
     plusAnnualCents: parseStrictInt(process.env.PLAN_PRICE_PLUS_ANNUAL, 5000),
-    proMonthlyCents: parseStrictInt(process.env.PLAN_PRICE_PRO_MONTHLY, 1000),
+    proQuarterlyCents: parseStrictInt(process.env.PLAN_PRICE_PRO_QUARTERLY, 3000),
     proAnnualCents: parseStrictInt(process.env.PLAN_PRICE_PRO_ANNUAL, 10000),
   }),
   // Email (Resend)

--- a/server/src/lib/planGate.ts
+++ b/server/src/lib/planGate.ts
@@ -31,7 +31,7 @@ export interface UserPlanInfo {
   cancelAtPeriodEnd: string | null;
   // Current billing cadence on the subscription. null on free/inactive
   // plans or when not yet set by the webhook.
-  billingPeriod: 'monthly' | 'annual' | null;
+  billingPeriod: 'quarterly' | 'annual' | null;
 }
 
 export interface PlanFeatures {
@@ -105,7 +105,7 @@ export async function getUserPlanInfo(userId: string): Promise<UserPlanInfo | nu
     email: row.email,
     previousSubStatus: row.previous_sub_status as SubStatusType | null,
     cancelAtPeriodEnd: row.cancel_at_period_end,
-    billingPeriod: row.billing_period as 'monthly' | 'annual' | null,
+    billingPeriod: row.billing_period as 'quarterly' | 'annual' | null,
   };
 }
 

--- a/server/src/routes/__tests__/downgrade.test.ts
+++ b/server/src/routes/__tests__/downgrade.test.ts
@@ -28,7 +28,7 @@ function mockActivePlusPaidUser() {
     email: 'plus@example.com',
     previousSubStatus: null,
     cancelAtPeriodEnd: null,
-    billingPeriod: 'monthly',
+    billingPeriod: 'quarterly',
   });
   vi.mocked(isSubscriptionActive).mockReturnValue(true);
 }
@@ -42,7 +42,7 @@ function mockActiveProPaidUser() {
     email: 'pro@example.com',
     previousSubStatus: null,
     cancelAtPeriodEnd: null,
-    billingPeriod: 'monthly',
+    billingPeriod: 'quarterly',
   });
   vi.mocked(isSubscriptionActive).mockReturnValue(true);
 }

--- a/src/ee/SubscriptionSection.tsx
+++ b/src/ee/SubscriptionSection.tsx
@@ -46,18 +46,18 @@ function findPlan(plans: CatalogPlan[], tier: PlanTier): CatalogPlan | undefined
 
 function priceCentsFor(
   plan: CatalogPlan | undefined,
-  period: 'monthly' | 'annual' | null,
+  period: 'quarterly' | 'annual' | null,
 ): number | null {
   if (!plan || !period) return null;
   if (period === 'annual') return plan.prices.annual;
-  return plan.prices.monthly;
+  return plan.prices.quarterly;
 }
 
 export function SubscriptionSection() {
   const { planInfo, usage, refresh } = usePlan();
   const { plans } = usePlanCatalog();
-  const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'annual'>(
-    planInfo.billingPeriod === 'annual' ? 'annual' : 'monthly',
+  const [billingPeriod, setBillingPeriod] = useState<'quarterly' | 'annual'>(
+    planInfo.billingPeriod === 'annual' ? 'annual' : 'quarterly',
   );
   const [downgradeTarget, setDowngradeTarget] = useState<'free' | 'plus' | null>(null);
 
@@ -100,7 +100,7 @@ export function SubscriptionSection() {
     planInfo.status === 'active' &&
     !!planInfo.activeUntil &&
     (plan === 'plus' || plan === 'pro');
-  const isMonthlyPaid = isPaidActive && planInfo.billingPeriod === 'monthly';
+  const isQuarterlyPaid = isPaidActive && planInfo.billingPeriod === 'quarterly';
   const isCancelPending = !!planInfo.cancelAtPeriodEnd;
   const isTrial = planInfo.status === 'trial';
   const showPicker = plan === 'free' || isTrial;
@@ -109,7 +109,7 @@ export function SubscriptionSection() {
 
   const currentCatalogPlan = findPlan(plans, plan);
   const priceCents = priceCentsFor(currentCatalogPlan, planInfo.billingPeriod);
-  const monthlyPriceCents = currentCatalogPlan?.prices.monthly ?? null;
+  const quarterlyPriceCents = currentCatalogPlan?.prices.quarterly ?? null;
   const annualSavings = currentCatalogPlan ? computeAnnualSavings(currentCatalogPlan.prices) : 0;
 
   // Primary CTA derivation. Trial users get their CTA from the PlanPicker
@@ -123,7 +123,7 @@ export function SubscriptionSection() {
     primaryCta = { label: 'Reactivate subscription', action: planInfo.portalAction };
   } else if (
     !isTrial &&
-    isMonthlyPaid &&
+    isQuarterlyPaid &&
     annualSavings > 0 &&
     planInfo.portalAction
   ) {
@@ -148,7 +148,7 @@ export function SubscriptionSection() {
               cancelAtPeriodEnd={planInfo.cancelAtPeriodEnd}
               billingPeriod={planInfo.billingPeriod}
               trialPeriodDays={planInfo.trialPeriodDays}
-              priceCents={monthlyPriceCents}
+              priceCents={quarterlyPriceCents}
               annualSavingsCents={annualSavings}
               usage={usage ?? ZERO_USAGE}
               features={planInfo.features}

--- a/src/ee/SubscriptionSection/BillingPeriodToggle.tsx
+++ b/src/ee/SubscriptionSection/BillingPeriodToggle.tsx
@@ -1,23 +1,23 @@
 import { cn } from '@/lib/utils';
 import { formatPriceCents } from './annualSavings';
 
-interface AnnualToggleProps {
-  value: 'monthly' | 'annual';
-  onChange: (value: 'monthly' | 'annual') => void;
+interface BillingPeriodToggleProps {
+  value: 'quarterly' | 'annual';
+  onChange: (value: 'quarterly' | 'annual') => void;
   /** Best savings across visible plans, in cents/year. Used for the subtitle. */
   maxSavingsCents: number;
 }
 
-export function AnnualToggle({ value, onChange, maxSavingsCents }: AnnualToggleProps) {
+export function BillingPeriodToggle({ value, onChange, maxSavingsCents }: BillingPeriodToggleProps) {
   return (
     <div className="inline-flex items-center gap-2">
-      {maxSavingsCents > 0 && value === 'monthly' && (
+      {maxSavingsCents > 0 && value === 'quarterly' && (
         <span className="text-xs text-emerald-600 dark:text-emerald-400 mr-1">
           Annual · Save up to {formatPriceCents(maxSavingsCents)}/year
         </span>
       )}
       <div role="radiogroup" className="inline-flex rounded-[var(--radius-md)] border border-[var(--border-flat)] p-0.5">
-        {(['monthly', 'annual'] as const).map((period) => (
+        {(['quarterly', 'annual'] as const).map((period) => (
           // biome-ignore lint/a11y/useSemanticElements: segmented control needs button styling, not native radio
           <button
             key={period}
@@ -32,7 +32,7 @@ export function AnnualToggle({ value, onChange, maxSavingsCents }: AnnualToggleP
                 : 'text-[var(--text-tertiary)]',
             )}
           >
-            {period === 'monthly' ? 'Monthly' : 'Annual'}
+            {period === 'quarterly' ? 'Quarterly' : 'Annual'}
           </button>
         ))}
       </div>

--- a/src/ee/SubscriptionSection/CurrentPlanCard.tsx
+++ b/src/ee/SubscriptionSection/CurrentPlanCard.tsx
@@ -9,7 +9,7 @@ interface CurrentPlanCardProps {
   status: SubscriptionStatus;
   activeUntil: string | null;
   cancelAtPeriodEnd: string | null;
-  billingPeriod: 'monthly' | 'annual' | null;
+  billingPeriod: 'quarterly' | 'annual' | null;
   trialPeriodDays: number;
   priceCents: number | null;
   annualSavingsCents: number;
@@ -55,14 +55,14 @@ export function CurrentPlanCard(props: CurrentPlanCardProps) {
       trialDaysLeft === null || trialDaysLeft === 0
         ? 'Trial ended'
         : `${trialDaysLeft} day${trialDaysLeft === 1 ? '' : 's'} remaining`;
-    metaLine = priceCents !== null ? `Then ${formatPriceCents(priceCents)} / month` : null;
+    metaLine = priceCents !== null ? `Then ${formatPriceCents(priceCents)} / quarter` : null;
   } else {
     title = 'Active';
     if (activeUntil) {
       const datePart = `Renews ${formatBillingDate(activeUntil)}`;
       const pricePart =
         priceCents !== null && billingPeriod
-          ? ` · ${formatPriceCents(priceCents)} / ${billingPeriod === 'annual' ? 'year' : 'month'}`
+          ? ` · ${formatPriceCents(priceCents)} / ${billingPeriod === 'annual' ? 'year' : 'quarter'}`
           : '';
       metaLine = datePart + pricePart;
     }

--- a/src/ee/SubscriptionSection/PlanCard.tsx
+++ b/src/ee/SubscriptionSection/PlanCard.tsx
@@ -6,7 +6,7 @@ import { formatPriceCents } from './annualSavings';
 
 interface PlanCardProps {
   plan: CatalogPlan;
-  billingPeriod: 'monthly' | 'annual';
+  billingPeriod: 'quarterly' | 'annual';
   ctaLabel: string;
   action: CheckoutAction | null;
   isCurrentPlan?: boolean;
@@ -16,9 +16,9 @@ export function PlanCard({ plan, billingPeriod, ctaLabel, action, isCurrentPlan 
   const priceCents =
     billingPeriod === 'annual' && plan.prices.annual !== null
       ? Math.round(plan.prices.annual / 12)
-      : plan.prices.monthly;
+      : plan.prices.quarterly;
 
-  const periodLabel = billingPeriod === 'annual' ? '/ month, billed yearly' : '/ month';
+  const periodLabel = billingPeriod === 'annual' ? '/ month, billed yearly' : '/ quarter';
 
   const ctaClassName = cn(
     'inline-flex w-full items-center justify-center gap-1.5 rounded-[var(--radius-md)] bg-[var(--accent)] h-10 px-5 text-[14px] font-semibold text-[var(--text-on-accent)] hover:bg-[var(--accent-hover)] transition-colors',

--- a/src/ee/SubscriptionSection/PlanPicker.tsx
+++ b/src/ee/SubscriptionSection/PlanPicker.tsx
@@ -1,13 +1,13 @@
 import type { CatalogPlan, CheckoutAction, PlanCatalog, PlanTier } from '@/types';
-import { AnnualToggle } from './AnnualToggle';
 import { computeAnnualSavings } from './annualSavings';
+import { BillingPeriodToggle } from './BillingPeriodToggle';
 import { PlanCard } from './PlanCard';
 
 interface PlanPickerProps {
   catalog: PlanCatalog;
   currentPlan: PlanTier;
-  billingPeriod: 'monthly' | 'annual';
-  onBillingPeriodChange: (period: 'monthly' | 'annual') => void;
+  billingPeriod: 'quarterly' | 'annual';
+  onBillingPeriodChange: (period: 'quarterly' | 'annual') => void;
   actions: {
     plus: CheckoutAction | null;
     pro: CheckoutAction | null;
@@ -42,7 +42,7 @@ export function PlanPicker(props: PlanPickerProps) {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <AnnualToggle
+        <BillingPeriodToggle
           value={billingPeriod}
           onChange={onBillingPeriodChange}
           maxSavingsCents={maxSavings}

--- a/src/ee/SubscriptionSection/UpgradeCard.tsx
+++ b/src/ee/SubscriptionSection/UpgradeCard.tsx
@@ -10,7 +10,7 @@ interface UpgradeCardProps {
 }
 
 export function UpgradeCard({ targetPlan, action }: UpgradeCardProps) {
-  const monthly = formatPriceCents(targetPlan.prices.monthly);
+  const quarterly = formatPriceCents(targetPlan.prices.quarterly);
   const annual = targetPlan.prices.annual !== null ? formatPriceCents(targetPlan.prices.annual) : null;
   const ctaClassName = cn(
     'inline-flex items-center justify-center gap-1.5 rounded-[var(--radius-md)] bg-[var(--accent)] h-10 px-5 text-[14px] font-semibold text-[var(--text-on-accent)] hover:bg-[var(--accent-hover)] transition-colors',
@@ -21,7 +21,7 @@ export function UpgradeCard({ targetPlan, action }: UpgradeCardProps) {
       <div className="space-y-1">
         <h3 className="text-base font-semibold text-[var(--text-primary)]">Upgrade to {targetPlan.name}</h3>
         <p className="text-sm text-[var(--text-tertiary)]">
-          {monthly}/mo{annual && ` · ${annual}/yr`}
+          {quarterly}/qtr{annual && ` · ${annual}/yr`}
         </p>
       </div>
       {action && (

--- a/src/ee/SubscriptionSection/__tests__/CurrentPlanCard.test.tsx
+++ b/src/ee/SubscriptionSection/__tests__/CurrentPlanCard.test.tsx
@@ -19,11 +19,11 @@ const PRO_USAGE: PlanUsage = {
 };
 
 describe('CurrentPlanCard', () => {
-  it('Pro active monthly: shows PRO eyebrow, Active title, Renews + monthly price', () => {
+  it('Pro active quarterly: shows PRO eyebrow, Active title, Renews + quarterly price', () => {
     render(
       <CurrentPlanCard
         plan="pro" status="active" activeUntil="2026-05-27T00:00:00Z"
-        cancelAtPeriodEnd={null} billingPeriod="monthly" trialPeriodDays={7}
+        cancelAtPeriodEnd={null} billingPeriod="quarterly" trialPeriodDays={7}
         priceCents={1000} annualSavingsCents={2000}
         usage={PRO_USAGE} features={PRO_FEATURES} aiCredits={null}
       />,
@@ -31,7 +31,7 @@ describe('CurrentPlanCard', () => {
     expect(screen.getByText('PRO')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.getByText(/Renews May 27, 2026/)).toBeInTheDocument();
-    expect(screen.getByText(/\$10 \/ month/)).toBeInTheDocument();
+    expect(screen.getByText(/\$10 \/ quarter/)).toBeInTheDocument();
     expect(screen.queryByText(/Saving/)).toBeNull();
   });
 
@@ -64,7 +64,7 @@ describe('CurrentPlanCard', () => {
     render(
       <CurrentPlanCard
         plan="pro" status="active" activeUntil="2026-05-27T00:00:00Z"
-        cancelAtPeriodEnd="2026-05-27T00:00:00Z" billingPeriod="monthly"
+        cancelAtPeriodEnd="2026-05-27T00:00:00Z" billingPeriod="quarterly"
         trialPeriodDays={7} priceCents={1000} annualSavingsCents={0}
         usage={PRO_USAGE} features={PRO_FEATURES} aiCredits={null}
       />,
@@ -74,7 +74,7 @@ describe('CurrentPlanCard', () => {
     expect(screen.queryByText(/Renews/)).toBeNull();
   });
 
-  it('Trial: shows TRIAL eyebrow, days remaining, "Then $X / month", trial bar', () => {
+  it('Trial: shows TRIAL eyebrow, days remaining, "Then $X / quarter", trial bar', () => {
     const future = new Date(Date.now() + 5 * 24 * 3600 * 1000).toISOString();
     render(
       <CurrentPlanCard
@@ -86,7 +86,7 @@ describe('CurrentPlanCard', () => {
     );
     expect(screen.getByText('PRO TRIAL')).toBeInTheDocument();
     expect(screen.getByText(/5 days remaining/)).toBeInTheDocument();
-    expect(screen.getByText(/Then \$10 \/ month/)).toBeInTheDocument();
+    expect(screen.getByText(/Then \$10 \/ quarter/)).toBeInTheDocument();
     expect(screen.getByRole('progressbar', { name: /trial progress/i })).toBeInTheDocument();
   });
 
@@ -94,33 +94,33 @@ describe('CurrentPlanCard', () => {
     render(
       <CurrentPlanCard
         plan="pro" status="active" activeUntil={null}
-        cancelAtPeriodEnd={null} billingPeriod="monthly" trialPeriodDays={7}
+        cancelAtPeriodEnd={null} billingPeriod="quarterly" trialPeriodDays={7}
         priceCents={1000} annualSavingsCents={0}
         usage={PRO_USAGE} features={PRO_FEATURES} aiCredits={null}
       />,
     );
     expect(screen.queryByText(/Renews/)).toBeNull();
-    expect(screen.queryByText(/\/ month/)).toBeNull();
+    expect(screen.queryByText(/\/ quarter/)).toBeNull();
   });
 
   it('Active without priceCents: shows Renews date but no price suffix', () => {
     render(
       <CurrentPlanCard
         plan="pro" status="active" activeUntil="2026-05-27T00:00:00Z"
-        cancelAtPeriodEnd={null} billingPeriod="monthly" trialPeriodDays={7}
+        cancelAtPeriodEnd={null} billingPeriod="quarterly" trialPeriodDays={7}
         priceCents={null} annualSavingsCents={0}
         usage={PRO_USAGE} features={PRO_FEATURES} aiCredits={null}
       />,
     );
     expect(screen.getByText(/Renews May 27, 2026/)).toBeInTheDocument();
-    expect(screen.queryByText(/\/ month/)).toBeNull();
+    expect(screen.queryByText(/\/ quarter/)).toBeNull();
   });
 
   it('Renders the inline UsageRow inside the card', () => {
     render(
       <CurrentPlanCard
         plan="pro" status="active" activeUntil="2026-05-27T00:00:00Z"
-        cancelAtPeriodEnd={null} billingPeriod="monthly" trialPeriodDays={7}
+        cancelAtPeriodEnd={null} billingPeriod="quarterly" trialPeriodDays={7}
         priceCents={1000} annualSavingsCents={0}
         usage={PRO_USAGE} features={PRO_FEATURES} aiCredits={null}
       />,
@@ -154,11 +154,11 @@ describe('CurrentPlanCard', () => {
     expect(screen.queryByText(/null/)).toBeNull();
   });
 
-  it('Plus active monthly: eyebrow shows PLUS (not PRO)', () => {
+  it('Plus active quarterly: eyebrow shows PLUS (not PRO)', () => {
     render(
       <CurrentPlanCard
         plan="plus" status="active" activeUntil="2026-05-27T00:00:00Z"
-        cancelAtPeriodEnd={null} billingPeriod="monthly" trialPeriodDays={7}
+        cancelAtPeriodEnd={null} billingPeriod="quarterly" trialPeriodDays={7}
         priceCents={500} annualSavingsCents={1000}
         usage={PRO_USAGE} features={PRO_FEATURES} aiCredits={null}
       />,

--- a/src/ee/SubscriptionSection/__tests__/PlanPicker.test.tsx
+++ b/src/ee/SubscriptionSection/__tests__/PlanPicker.test.tsx
@@ -11,7 +11,7 @@ describe('PlanPicker', () => {
       <PlanPicker
         catalog={FIXTURE_CATALOG}
         currentPlan="free"
-        billingPeriod="monthly"
+        billingPeriod="quarterly"
         onBillingPeriodChange={() => {}}
         actions={{ plus: POST_ACTION, pro: POST_ACTION }}
       />,
@@ -27,7 +27,7 @@ describe('PlanPicker', () => {
       <PlanPicker
         catalog={FIXTURE_CATALOG}
         currentPlan="free"
-        billingPeriod="monthly"
+        billingPeriod="quarterly"
         onBillingPeriodChange={() => {}}
         actions={{ plus: POST_ACTION, pro: POST_ACTION }}
       />,
@@ -35,13 +35,13 @@ describe('PlanPicker', () => {
     expect(screen.queryByRole('heading', { name: 'Free' })).toBeNull();
   });
 
-  it('switches monthly/annual via toggle', () => {
+  it('switches quarterly/annual via toggle', () => {
     const onChange = vi.fn();
     render(
       <PlanPicker
         catalog={FIXTURE_CATALOG}
         currentPlan="free"
-        billingPeriod="monthly"
+        billingPeriod="quarterly"
         onBillingPeriodChange={onChange}
         actions={{ plus: POST_ACTION, pro: POST_ACTION }}
       />,

--- a/src/ee/SubscriptionSection/__tests__/SubscriptionSection.test.tsx
+++ b/src/ee/SubscriptionSection/__tests__/SubscriptionSection.test.tsx
@@ -50,7 +50,7 @@ describe('SubscriptionSection orchestrator', () => {
       plan: 'pro',
       status: 'active',
       activeUntil: '2026-05-27T00:00:00Z',
-      billingPeriod: 'monthly',
+      billingPeriod: 'quarterly',
     })],
     ['locked', () => makePlanInfo({
       plan: 'plus',
@@ -74,13 +74,13 @@ describe('SubscriptionSection orchestrator', () => {
     expect(screen.queryByRole('link', { name: /Manage Subscription/i })).toBeNull();
   });
 
-  it('Pro active monthly: renders new plan card with PRO eyebrow + Active + Renews + price', () => {
+  it('Pro active quarterly: renders new plan card with PRO eyebrow + Active + Renews + price', () => {
     setPlan(
       makePlanInfo({
         plan: 'pro',
         status: 'active',
         activeUntil: '2026-05-27T00:00:00Z',
-        billingPeriod: 'monthly',
+        billingPeriod: 'quarterly',
         portalAction: { url: 'https://billing.openbin.app/portal', method: 'POST', fields: { token: 't' } },
       }),
     );
@@ -90,13 +90,13 @@ describe('SubscriptionSection orchestrator', () => {
     expect(screen.getByText(/Renews May 27, 2026/)).toBeInTheDocument();
   });
 
-  it('Pro active monthly: shows "Switch to annual" primary CTA + ghost Manage', () => {
+  it('Pro active quarterly: shows "Switch to annual" primary CTA + ghost Manage', () => {
     setPlan(
       makePlanInfo({
         plan: 'pro',
         status: 'active',
         activeUntil: '2026-05-27T00:00:00Z',
-        billingPeriod: 'monthly',
+        billingPeriod: 'quarterly',
         portalAction: { url: 'https://billing.openbin.app/portal', method: 'POST', fields: { token: 't' } },
       }),
     );
@@ -121,13 +121,13 @@ describe('SubscriptionSection orchestrator', () => {
     expect(screen.getByText(/Manage Subscription/i)).toBeInTheDocument();
   });
 
-  it('Plus paid monthly: shows Pro upsell card + annual switch primary + manage', () => {
+  it('Plus paid quarterly: shows Pro upsell card + annual switch primary + manage', () => {
     setPlan(
       makePlanInfo({
         plan: 'plus',
         status: 'active',
         activeUntil: '2026-05-27T00:00:00Z',
-        billingPeriod: 'monthly',
+        billingPeriod: 'quarterly',
         portalAction: { url: 'https://billing.openbin.app/portal', method: 'POST', fields: { token: 't' } },
         upgradeProAction: { url: 'https://billing.openbin.app/upgrade', method: 'POST', fields: { token: 't' } },
       }),

--- a/src/ee/SubscriptionSection/__tests__/annualSavings.test.ts
+++ b/src/ee/SubscriptionSection/__tests__/annualSavings.test.ts
@@ -3,15 +3,15 @@ import { computeAnnualSavings, formatPriceCents } from '../annualSavings';
 
 describe('computeAnnualSavings', () => {
   it('returns 0 when annual is null (free plan)', () => {
-    expect(computeAnnualSavings({ monthly: 0, annual: null })).toBe(0);
+    expect(computeAnnualSavings({ quarterly: 0, annual: null })).toBe(0);
   });
 
-  it('returns difference between 12*monthly and annual in cents', () => {
-    expect(computeAnnualSavings({ monthly: 500, annual: 5000 })).toBe(1000);
+  it('returns difference between 4*quarterly and annual in cents', () => {
+    expect(computeAnnualSavings({ quarterly: 1500, annual: 5000 })).toBe(1000);
   });
 
   it('returns 0 when annual is more expensive (no inverted savings)', () => {
-    expect(computeAnnualSavings({ monthly: 100, annual: 5000 })).toBe(0);
+    expect(computeAnnualSavings({ quarterly: 100, annual: 5000 })).toBe(0);
   });
 });
 

--- a/src/ee/SubscriptionSection/__tests__/fixtures/planCatalog.ts
+++ b/src/ee/SubscriptionSection/__tests__/fixtures/planCatalog.ts
@@ -4,7 +4,7 @@ export const FIXTURE_CATALOG: PlanCatalog = {
   plans: [
     {
       id: 'free', name: 'Free',
-      prices: { monthly: 0, annual: null },
+      prices: { quarterly: 0, annual: null },
       features: {
         ai: true, apiKeys: false, customFields: false, fullExport: false,
         reorganize: false, binSharing: false, attachments: false,
@@ -15,7 +15,7 @@ export const FIXTURE_CATALOG: PlanCatalog = {
     },
     {
       id: 'plus', name: 'Plus',
-      prices: { monthly: 500, annual: 5000 },
+      prices: { quarterly: 1500, annual: 5000 },
       features: {
         ai: true, apiKeys: false, customFields: false, fullExport: true,
         reorganize: true, binSharing: false, attachments: false,
@@ -26,7 +26,7 @@ export const FIXTURE_CATALOG: PlanCatalog = {
     },
     {
       id: 'pro', name: 'Pro',
-      prices: { monthly: 1000, annual: 10000 },
+      prices: { quarterly: 3000, annual: 10000 },
       features: {
         ai: true, apiKeys: true, customFields: true, fullExport: true,
         reorganize: true, binSharing: true, attachments: true,

--- a/src/ee/SubscriptionSection/annualSavings.ts
+++ b/src/ee/SubscriptionSection/annualSavings.ts
@@ -1,13 +1,13 @@
 export interface PriceShape {
-  monthly: number;
+  quarterly: number;
   annual: number | null;
 }
 
 /** Returns savings in cents (positive). Zero when no annual price or no savings. */
 export function computeAnnualSavings(price: PriceShape): number {
   if (price.annual === null) return 0;
-  const monthlyTotal = price.monthly * 12;
-  return Math.max(0, monthlyTotal - price.annual);
+  const quarterlyTotal = price.quarterly * 4;
+  return Math.max(0, quarterlyTotal - price.annual);
 }
 
 /** Renders a USD cents value as a dollar string. Whole dollars get no decimals. */

--- a/src/features/settings/dialogs/DeleteAccountDialog.tsx
+++ b/src/features/settings/dialogs/DeleteAccountDialog.tsx
@@ -137,7 +137,7 @@ export function DeleteAccountDialog({ open, onOpenChange }: DeleteAccountDialogP
   }
 
   const planLabel = user.plan ? user.plan.charAt(0).toUpperCase() + user.plan.slice(1) : '';
-  const periodLabel = planInfo?.billingPeriod ?? 'monthly';
+  const periodLabel = planInfo?.billingPeriod ?? 'quarterly';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/settings/dialogs/__tests__/DeleteAccountDialog.test.tsx
+++ b/src/features/settings/dialogs/__tests__/DeleteAccountDialog.test.tsx
@@ -49,13 +49,13 @@ function setupAuth(overrides: AuthOverrides = {}, deleteImpl?: ReturnType<typeof
   return { deleteAccount };
 }
 
-function setupPlan(opts: { selfHosted?: boolean; billingPeriod?: 'monthly' | 'annual' | null } = {}) {
+function setupPlan(opts: { selfHosted?: boolean; billingPeriod?: 'quarterly' | 'annual' | null } = {}) {
   vi.mocked(usePlan).mockReturnValue({
     isSelfHosted: opts.selfHosted ?? false,
     planInfo: {
       plan: 'pro',
       status: 'active',
-      billingPeriod: opts.billingPeriod ?? 'monthly',
+      billingPeriod: opts.billingPeriod ?? 'quarterly',
       portalAction: null,
     },
   } as unknown as ReturnType<typeof usePlan>);

--- a/src/types.ts
+++ b/src/types.ts
@@ -384,7 +384,7 @@ export interface PlanInfo {
   cancelAtPeriodEnd: string | null;
   // Current billing cadence on the subscription. null on free / inactive
   // plans or when the value has not yet been set by the billing webhook.
-  billingPeriod: 'monthly' | 'annual' | null;
+  billingPeriod: 'quarterly' | 'annual' | null;
   // Trial total length in days, sourced from `config.trialPeriodDays` on the
   // server. Surfaces here so the client trial bar uses the same denominator
   // as billing instead of hardcoding 7.
@@ -395,7 +395,7 @@ export interface CatalogPlan {
   id: 'free' | 'plus' | 'pro';
   name: string;
   prices: {
-    monthly: number;          // cents; 0 for free
+    quarterly: number;        // cents; 0 for free
     annual: number | null;    // cents/year; null for free
   };
   features: PlanFeatures;


### PR DESCRIPTION
## Summary

- Replace the `monthly | annual` billing cadence with `quarterly | annual`. Plus = $15/qtr (1500 cents), Pro = $30/qtr (3000 cents); annual unchanged ($50/$100).
- Hard rename of `'monthly'` → `'quarterly'` across type unions, server config, env vars, UI components and copy, fixtures, and tests. Component file `AnnualToggle.tsx` → `BillingPeriodToggle.tsx`. Defensive migration `0011_clear_legacy_monthly_billing_period` clears any local dev rows with `billing_period = 'monthly'`.
- No customer migration: alpha, zero subscribers. Companion PR in `openbin-deploy` (branch `feat/quarterly-pricing`) renames Stripe price ID env vars in the billing service.

## Manual prerequisites (BEFORE merging)

- [ ] Create `Plus Quarterly` ($15/qtr) and `Pro Quarterly` ($30/qtr) products + prices in the Stripe dashboard. Capture the `price_xxx` IDs.
- [ ] Update sops-encrypted `secrets/.env.billing.sops` in `openbin-deploy` with `STRIPE_PLUS_QUARTERLY_PRICE_ID` and `STRIPE_PRO_QUARTERLY_PRICE_ID`. Remove the old `STRIPE_*_MONTHLY_PRICE_ID` keys. Annual price IDs unchanged.
- [ ] Archive the old monthly Stripe products (don't delete — Stripe disallows deletion of products with subscription history). Safe in alpha because no subscriptions exist.

## Cutover order

1. Merge **this PR** (qrcode) first — defaults are 1500/3000 cents if env vars unset, so it's safe even before billing-service env is updated.
2. `./scripts/deploy.sh openbin` to ship the qrcode side.
3. Update `secrets/.env.billing.sops` with new env var names.
4. `./scripts/deploy.sh billing` to restart the billing service with new config.
5. Merge the **openbin-deploy PR** last.

## Rollback

Revert this PR and the openbin-deploy PR, then re-deploy. Migration is `UPDATE billing_period = NULL WHERE billing_period = 'monthly'` — re-running the inverse is trivial since prod is empty. Old monthly Stripe products are archived (recoverable).

## Test plan

- [x] Server tests: 1452 passed + 1 pre-existing skip
- [x] Client tests: 1616 passed
- [x] `npx tsc --noEmit` clean (client + server)
- [x] New migration test: 2/2 pass (clears 'monthly' rows, leaves 'annual'/null untouched, idempotent)
- [x] `subscriptions.test.ts`: webhook accepts `billingPeriod: 'quarterly'`, rejects `'monthly'` with `ValidationError`
- [x] Greppable invariant: every remaining `monthly` hit in src/ + server/src/ is in the spec's allow-list (migration code, AI credit comments, `UsageGranularity` chart, intentional rejection test)
- [ ] Post-deploy smoke test in Stripe test mode:
  - [ ] Subscription page renders "Quarterly | Annual" segmented control
  - [ ] Quarterly checkout → webhook callback writes `billing_period = 'quarterly'` in DB
  - [ ] CurrentPlanCard shows "$15 / quarter" copy
  - [ ] Upgrade dialog shows "Save \$10/year" hint under Plus's annual option

## Spec / plan

Design spec and implementation plan live in `docs/superpowers/specs/2026-04-30-quarterly-annual-pricing-design.md` and `docs/superpowers/plans/2026-04-30-quarterly-annual-pricing.md` (both gitignored per project convention).