### PR TITLE
fix: handle OAuth linking for users with an existing email account

### DIFF
--- a/server/src/__tests__/csrf.test.ts
+++ b/server/src/__tests__/csrf.test.ts
@@ -144,4 +144,19 @@ describe('CSRF protection', () => {
       .set('Cookie', [`openbin-access=${access}`, `openbin-refresh=${refresh}`]);
     expect(res.status).toBe(200);
   });
+
+  it('exempts /api/auth/oauth/ POSTs from CSRF (state cookie covers it)', async () => {
+    // Apple's POST callback to /api/auth/oauth/apple/callback cannot carry our
+    // X-CSRF-Token header — the OAuth state cookie + nonce already provide
+    // the CSRF defense for these paths. Without the exemption, the link flow
+    // is blocked when a logged-in user clicks "Connect Apple".
+    const { access, refresh, csrf } = await loginViaCookie();
+    const res = await request(app)
+      .post('/api/auth/oauth/apple/callback')
+      .set('Cookie', [`openbin-access=${access}`, `openbin-refresh=${refresh}`, `openbin-csrf=${csrf}`])
+      .send({ id_token: 'invalid', state: 'whatever' });
+    // Should not be blocked by CSRF — the route handler runs and rejects on
+    // missing state cookie / invalid token, but with a non-CSRF error.
+    expect(res.body.error).not.toBe('CSRF_INVALID');
+  });
 });

--- a/server/src/__tests__/oauth.test.ts
+++ b/server/src/__tests__/oauth.test.ts
@@ -3,7 +3,8 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { query } from '../db.js';
 import { createApp } from '../index.js';
-import { findOrCreateOAuthUser } from '../lib/oauth.js';
+import { ForbiddenError, UnauthorizedError } from '../lib/httpErrors.js';
+import { findOrCreateOAuthUser, linkOAuthIdentity, oauthErrorReason } from '../lib/oauth.js';
 import { signToken } from '../middleware/auth.js';
 import { createTestUser } from './helpers.js';
 
@@ -214,6 +215,87 @@ describe('OAuth routes', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({ password: 'WrongPassword123!' });
     expect(res.status).toBe(401);
+  });
+
+  it('password user links a Google identity (created)', async () => {
+    const { user } = await createTestUser(app, { email: 'pwlink@example.com' });
+    const result = await linkOAuthIdentity({
+      userId: user.id,
+      provider: 'google',
+      providerUserId: 'sub-pwlink',
+      email: 'pwlink@example.com',
+    });
+    expect(result).toBe('created');
+    const links = await query<{ provider: string; provider_user_id: string }>(
+      'SELECT provider, provider_user_id FROM user_oauth_links WHERE user_id = $1',
+      [user.id],
+    );
+    expect(links.rows).toEqual([{ provider: 'google', provider_user_id: 'sub-pwlink' }]);
+  });
+
+  it('linking the same identity twice returns already_linked', async () => {
+    const { user } = await createTestUser(app, { email: 'twice@example.com' });
+    await linkOAuthIdentity({
+      userId: user.id,
+      provider: 'google',
+      providerUserId: 'sub-twice',
+      email: 'twice@example.com',
+    });
+    const second = await linkOAuthIdentity({
+      userId: user.id,
+      provider: 'google',
+      providerUserId: 'sub-twice',
+      email: 'twice@example.com',
+    });
+    expect(second).toBe('already_linked');
+  });
+
+  it('linking an identity already attached to another user returns conflict', async () => {
+    const a = await createTestUser(app, { email: 'a@example.com' });
+    const b = await createTestUser(app, { email: 'b@example.com' });
+    await linkOAuthIdentity({
+      userId: a.user.id,
+      provider: 'google',
+      providerUserId: 'sub-shared',
+      email: 'a@example.com',
+    });
+    const second = await linkOAuthIdentity({
+      userId: b.user.id,
+      provider: 'google',
+      providerUserId: 'sub-shared',
+      email: 'b@example.com',
+    });
+    expect(second).toBe('conflict');
+  });
+
+  it('linking replaces an existing different sub for the same (user, provider)', async () => {
+    const { user } = await createTestUser(app, { email: 'rep@example.com' });
+    await linkOAuthIdentity({
+      userId: user.id,
+      provider: 'google',
+      providerUserId: 'sub-old',
+      email: 'rep@example.com',
+    });
+    const replaced = await linkOAuthIdentity({
+      userId: user.id,
+      provider: 'google',
+      providerUserId: 'sub-new',
+      email: 'rep@example.com',
+    });
+    expect(replaced).toBe('created');
+    const links = await query<{ provider_user_id: string }>(
+      'SELECT provider_user_id FROM user_oauth_links WHERE user_id = $1 AND provider = $2',
+      [user.id, 'google'],
+    );
+    expect(links.rows).toEqual([{ provider_user_id: 'sub-new' }]);
+  });
+
+  it('oauthErrorReason maps known errors to specific reasons', () => {
+    expect(oauthErrorReason(new ForbiddenError('An account with this email already exists. ...'))).toBe('email_in_use');
+    expect(oauthErrorReason(new ForbiddenError('Registration is currently closed'))).toBe('forbidden');
+    expect(oauthErrorReason(new UnauthorizedError('Invalid OAuth state'))).toBe('invalid_state');
+    expect(oauthErrorReason({ code: 'ERR_JWT_INVALID' })).toBe('token_invalid');
+    expect(oauthErrorReason(new Error('something else'))).toBe('callback_failed');
   });
 
   it('password user can delete account with correct password', async () => {

--- a/server/src/lib/csrf.ts
+++ b/server/src/lib/csrf.ts
@@ -34,6 +34,13 @@ function isApiKeyAuth(req: Request): boolean {
   return typeof h === 'string' && h.startsWith('Bearer ');
 }
 
+// OAuth callback endpoints are exempt — they carry their own CSRF defense via
+// the oauth_state cookie + PKCE / nonce, and Apple's POST callback is a
+// cross-site form post that cannot carry our X-CSRF-Token header. Without
+// this exemption, the link-from-settings flow is blocked for Apple whenever
+// the user is already authenticated.
+const CSRF_EXEMPT_PREFIXES = ['/api/auth/oauth/'];
+
 /**
  * Double-submit CSRF protection for cookie-authenticated state-changing requests.
  *
@@ -54,6 +61,12 @@ export function csrfProtect(req: Request, res: Response, next: NextFunction): vo
   }
 
   if (isApiKeyAuth(req) || !hasAuthCookie(req)) {
+    next();
+    return;
+  }
+
+  const path = req.path;
+  if (CSRF_EXEMPT_PREFIXES.some((p) => path.startsWith(p))) {
     next();
     return;
   }

--- a/server/src/lib/oauth.ts
+++ b/server/src/lib/oauth.ts
@@ -186,6 +186,86 @@ export async function finalizeOAuthLogin(
   res.redirect('/?oauth=success');
 }
 
+// -- Link OAuth identity to an already-authenticated user --
+
+export type LinkResult = 'created' | 'already_linked' | 'conflict';
+
+export interface LinkOAuthInput {
+  userId: string;
+  provider: string;
+  providerUserId: string;
+  email: string;
+}
+
+/**
+ * Attaches an OAuth identity to an existing authenticated user.
+ *
+ * Email-based auto-linking on the login path was removed in 6e0d8202 to close
+ * an account-takeover vector — anyone holding a Google identity with a
+ * victim's email could otherwise claim the account. The intended path for
+ * users who already have a password account is to log in and explicitly
+ * link from settings; this helper backs that flow.
+ *
+ * Conflict semantics:
+ *   - same user already linked → 'already_linked' (no-op)
+ *   - different user already linked → 'conflict' (refuse — the OAuth identity
+ *     belongs to someone else)
+ *   - same user has a different sub for this provider → replaced (UPSERT)
+ */
+export async function linkOAuthIdentity(input: LinkOAuthInput): Promise<LinkResult> {
+  const { userId, provider, providerUserId, email } = input;
+
+  const existing = await query<{ user_id: string }>(
+    'SELECT user_id FROM user_oauth_links WHERE provider = $1 AND provider_user_id = $2',
+    [provider, providerUserId],
+  );
+  if (existing.rows.length > 0) {
+    if (existing.rows[0].user_id === userId) return 'already_linked';
+    log.warn(`Link refused: ${provider} identity already linked to a different user`);
+    return 'conflict';
+  }
+
+  // Replace any existing link for the same (user, provider). Most recent
+  // OAuth login wins, so an old sub for this provider gets cleared instead
+  // of accumulating dead rows. There's no UNIQUE(user_id, provider) on the
+  // table — only UNIQUE(provider, provider_user_id) — so we can't ON CONFLICT
+  // cleanly across both engines; the explicit DELETE+INSERT works on both.
+  await withTransaction(async (txQuery) => {
+    await txQuery(
+      'DELETE FROM user_oauth_links WHERE user_id = $1 AND provider = $2',
+      [userId, provider],
+    );
+    await txQuery(
+      `INSERT INTO user_oauth_links (id, user_id, provider, provider_user_id, email)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [generateUuid(), userId, provider, providerUserId, email],
+    );
+  });
+  log.info(`Linked ${provider} identity to user ${userId}`);
+  return 'created';
+}
+
+// -- Map a thrown callback error to a specific URL reason --
+
+/**
+ * Translates an unhandled OAuth callback exception into the `reason` query
+ * parameter we redirect with. Adds context the user (and ops) can act on
+ * instead of the previous catch-all `callback_failed`. Reasons consumed by
+ * `OAuthReturn.tsx` to render specific toasts.
+ */
+export function oauthErrorReason(err: unknown): string {
+  if (err instanceof ForbiddenError) {
+    if (/already exists/i.test(err.message)) return 'email_in_use';
+    return 'forbidden';
+  }
+  if (err instanceof UnauthorizedError) return 'invalid_state';
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === 'string' && code.startsWith('ERR_JW')) return 'token_invalid';
+  }
+  return 'callback_failed';
+}
+
 // -- Available providers --
 
 export function getOAuthProviders(): string[] {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -21,6 +21,8 @@ import {
   getCodeVerifier,
   getOAuthProviders,
   googleJwks,
+  linkOAuthIdentity,
+  oauthErrorReason,
   validateState,
 } from '../lib/oauth.js';
 import { consumeResetToken, createPasswordResetToken } from '../lib/passwordReset.js';
@@ -814,6 +816,24 @@ router.get('/oauth/google/callback', asyncHandler(async (req, res) => {
 
     clearOAuthCookies(res);
 
+    // If the user is already authenticated, this is a link attempt from
+    // settings — don't try to create a new account, attach the identity
+    // to the current user instead.
+    if (req.user) {
+      const result = await linkOAuthIdentity({
+        userId: req.user.id,
+        provider: 'google',
+        providerUserId: sub,
+        email,
+      });
+      if (result === 'conflict') {
+        res.redirect('/?oauth=error&reason=link_conflict');
+        return;
+      }
+      res.redirect('/?oauth=linked');
+      return;
+    }
+
     const { user } = await findOrCreateOAuthUser({
       provider: 'google',
       providerUserId: sub,
@@ -825,7 +845,7 @@ router.get('/oauth/google/callback', asyncHandler(async (req, res) => {
   } catch (err) {
     clearOAuthCookies(res);
     log.error('Google OAuth callback error:', err);
-    res.redirect('/?oauth=error&reason=callback_failed');
+    res.redirect(`/?oauth=error&reason=${oauthErrorReason(err)}`);
   }
 }));
 
@@ -899,6 +919,21 @@ router.post('/oauth/apple/callback', asyncHandler(async (req, res) => {
       return;
     }
 
+    if (req.user) {
+      const result = await linkOAuthIdentity({
+        userId: req.user.id,
+        provider: 'apple',
+        providerUserId: sub,
+        email,
+      });
+      if (result === 'conflict') {
+        res.redirect('/?oauth=error&reason=link_conflict');
+        return;
+      }
+      res.redirect('/?oauth=linked');
+      return;
+    }
+
     const { user } = await findOrCreateOAuthUser({
       provider: 'apple',
       providerUserId: sub,
@@ -910,7 +945,7 @@ router.post('/oauth/apple/callback', asyncHandler(async (req, res) => {
   } catch (err) {
     clearOAuthCookies(res);
     log.error('Apple OAuth callback error:', err);
-    res.redirect('/?oauth=error&reason=callback_failed');
+    res.redirect(`/?oauth=error&reason=${oauthErrorReason(err)}`);
   }
 }));
 

--- a/src/features/auth/OAuthReturn.tsx
+++ b/src/features/auth/OAuthReturn.tsx
@@ -11,6 +11,11 @@ const ERROR_MESSAGES: Record<string, string> = {
   callback_failed: 'Authentication failed — please try again',
   no_email: 'An email address is required to sign in',
   invalid_flow: 'Invalid authentication flow',
+  email_in_use: 'An account with this email already exists. Sign in with your password, then link from settings.',
+  link_conflict: 'This account is already linked to a different OpenBin user.',
+  invalid_state: 'Sign-in expired — please try again',
+  token_invalid: 'Authentication failed — please try again',
+  forbidden: 'Sign-in not permitted for this account',
 };
 
 export function useOAuthReturn() {
@@ -23,6 +28,9 @@ export function useOAuthReturn() {
     if (!oauth) return;
 
     if (oauth === 'success') {
+      refreshSession();
+    } else if (oauth === 'linked') {
+      showToast({ message: 'Account linked successfully', variant: 'success' });
       refreshSession();
     } else if (oauth === 'error') {
       const reason = searchParams.get('reason') || 'callback_failed';

--- a/src/features/layout/AppLayout.tsx
+++ b/src/features/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { CommandPalette } from '@/components/ui/command-palette';
 import { ShortcutsHelp } from '@/components/ui/shortcuts-help';
 import { useToast } from '@/components/ui/toast';
 import { useAiSettings } from '@/features/ai/useAiSettings';
+import { useOAuthReturn } from '@/features/auth/OAuthReturn';
 import { useFirstBinIds } from '@/features/bins/useBins';
 import { useAutoOpenOnCapture } from '@/features/capture/useAutoOpenOnCapture';
 import { useLocationList } from '@/features/locations/useLocations';
@@ -56,6 +57,7 @@ interface BeforeInstallPromptEvent extends Event {
 
 export function AppLayout() {
   useTheme();
+  useOAuthReturn();
   const { isCollapsed: sidebarCollapsed } = useSidebarCollapsed();
   const { settings } = useAppSettings();
   const { activeLocationId, setActiveLocationId, demoMode } = useAuth();


### PR DESCRIPTION
## Summary

OAuth login fails with `?oauth=error&reason=callback_failed` when the user's email is already attached to a password account, and the intended workaround ("log in with password, link Google from Settings → Connected Accounts") hits the same error. The Google + Apple callbacks always ran `findOrCreateOAuthUser` — there was no branch for an authenticated user attaching a provider to an existing account.

Email-based auto-linking was deliberately removed in `6e0d8202` to close an account-takeover vector (anyone holding an OAuth identity with a victim's email could otherwise claim the account). That left the explicit-link path as the only safe option, but the callbacks never implemented it. This PR adds the link branch and surfaces specific reasons so future failures aren't opaque.

- Add `linkOAuthIdentity()` with explicit conflict semantics (`already_linked` / `conflict` / replace-stale-sub) and an `oauthErrorReason()` mapper
- Both callbacks branch on `req.user`: link mode → `/?oauth=linked`, login mode unchanged
- Generic catch blocks now emit `email_in_use` / `forbidden` / `invalid_state` / `token_invalid` instead of always `callback_failed`
- Exempt `/api/auth/oauth/` from CSRF — state cookie + PKCE/nonce already cover it, and Apple's cross-site POST callback can't carry our `X-CSRF-Token` header
- Mount `useOAuthReturn` in `AppLayout` (was only on `LoginPage`, which authenticated users never see) so the link-success toast actually fires
- Client toasts for new reasons + `oauth=linked`

## Test plan

- [x] `npx biome check` — no new warnings/errors
- [x] `npm run check` — type checks pass (client + server)
- [x] Server suite — 1458 passed, 1 skipped (120 files); new tests cover `linkOAuthIdentity` (created/already_linked/conflict/replace) + `oauthErrorReason` mapping + CSRF exemption
- [x] Frontend suite — 1616 passed (160 files)
- [ ] After deploy: log in with password → Settings → Connect Google → returns to dashboard with "Account linked successfully" toast
- [ ] After deploy: log out, log in with Google → succeeds (was previously the failing flow)
- [ ] After deploy: try to link a Google account already attached to a different OpenBin user → `?oauth=error&reason=link_conflict`