### PR TITLE
fix: preserve item quantity on bin create and duplicate

### DIFF
--- a/server/src/lib/binUpdateHelpers.ts
+++ b/server/src/lib/binUpdateHelpers.ts
@@ -193,9 +193,12 @@ export async function insertBinWithItems(fields: InsertBinFields, assertLimitUse
           const item = fields.items[i];
           const itemName = typeof item === 'string' ? item : (item as { name: string })?.name;
           if (!itemName) continue;
+          const itemQty = typeof item === 'object' && item !== null
+            ? ((item as { quantity?: number | null }).quantity ?? null)
+            : null;
           await tx(
-            'INSERT INTO bin_items (id, bin_id, name, quantity, position) VALUES ($1, $2, $3, NULL, $4)',
-            [generateUuid(), binId, itemName, i]
+            'INSERT INTO bin_items (id, bin_id, name, quantity, position) VALUES ($1, $2, $3, $4, $5)',
+            [generateUuid(), binId, itemName, itemQty, i]
           );
         }
 

--- a/server/src/routes/__tests__/binsQuantity.test.ts
+++ b/server/src/routes/__tests__/binsQuantity.test.ts
@@ -1,0 +1,101 @@
+import type { Express } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createTestLocation, createTestUser } from '../../__tests__/helpers.js';
+import { createApp } from '../../index.js';
+
+interface BinItemResponse {
+  id: string;
+  name: string;
+  quantity: number | null;
+}
+
+interface BinResponse {
+  id: string;
+  short_code: string;
+  name: string;
+  items: BinItemResponse[];
+}
+
+describe('POST /api/bins — preserves item quantity on create', () => {
+  let app: Express;
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('persists per-item quantity supplied at creation time', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+
+    const res = await request(app)
+      .post('/api/bins')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        locationId: loc.id,
+        name: 'Quantity Bin',
+        items: [{ name: 'a' }, { name: 'b', quantity: 3 }],
+      });
+
+    expect(res.status).toBe(201);
+    const body = res.body as BinResponse;
+    expect(body.items).toHaveLength(2);
+
+    const itemA = body.items.find((it) => it.name === 'a');
+    const itemB = body.items.find((it) => it.name === 'b');
+    expect(itemA).toBeDefined();
+    expect(itemB).toBeDefined();
+    // Item without supplied quantity should be null.
+    expect(itemA!.quantity).toBeNull();
+    // Item with quantity:3 must round-trip.
+    expect(itemB!.quantity).toBe(3);
+  });
+});
+
+describe('POST /api/bins/:id/duplicate — preserves item quantity', () => {
+  let app: Express;
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('copies item quantity from source bin to duplicated bin', async () => {
+    const { token } = await createTestUser(app);
+    const loc = await createTestLocation(app, token);
+
+    // 1. Create the source bin with one item.
+    const createRes = await request(app)
+      .post('/api/bins')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        locationId: loc.id,
+        name: 'Source Bin',
+        items: [{ name: 'widget' }],
+      });
+    expect(createRes.status).toBe(201);
+    const source = createRes.body as BinResponse;
+    expect(source.items).toHaveLength(1);
+    const widgetId = source.items[0].id;
+
+    // 2. PATCH the item quantity to 5.
+    const patchRes = await request(app)
+      .patch(`/api/bins/${source.id}/items/${widgetId}/quantity`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ quantity: 5 });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.quantity).toBe(5);
+
+    // 3. Duplicate the source bin.
+    const dupRes = await request(app)
+      .post(`/api/bins/${source.id}/duplicate`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(dupRes.status).toBe(201);
+    const duplicate = dupRes.body as BinResponse;
+    expect(duplicate.id).not.toBe(source.id);
+    expect(duplicate.items).toHaveLength(1);
+
+    // The duplicate's matching item must preserve quantity from the source.
+    const dupItem = duplicate.items.find((it) => it.name === 'widget');
+    expect(dupItem).toBeDefined();
+    expect(dupItem!.quantity).toBe(5);
+  });
+});

--- a/server/src/routes/bins.ts
+++ b/server/src/routes/bins.ts
@@ -670,8 +670,8 @@ router.post('/:id/duplicate', asyncHandler(async (req, res) => {
   if (req.body.name) validateBinName(req.body.name);
 
   // Copy items from source
-  const itemsResult = await query<{ name: string; position: number }>(
-    'SELECT name, position FROM bin_items WHERE bin_id = $1 AND deleted_at IS NULL ORDER BY position',
+  const itemsResult = await query<{ name: string; position: number; quantity: number | null }>(
+    'SELECT name, position, quantity FROM bin_items WHERE bin_id = $1 AND deleted_at IS NULL ORDER BY position',
     [id]
   );
 


### PR DESCRIPTION
## Summary

- Fixes two related bugs that caused item `quantity` to be silently dropped from bin items
- `binUpdateHelpers.ts:insertBinWithItems` was hardcoding `quantity = NULL` on the create path despite the user-supplied value
- `bins.ts` duplicate route SELECT was omitting the `quantity` column when reading source items

Both routes now preserve quantity round-trips. The standalone item-add endpoint (`POST /api/bins/:id/items`) and the quantity PATCH already worked correctly — only the create + duplicate paths were affected.

Found during a manual QA pass; the only previously-correct path with full coverage was `replaceBinItems` (line 75 of `binUpdateHelpers.ts`), and the new code mirrors that pattern.

## Test plan

- [ ] `cd server && npx vitest run` — full server suite passes (1460 passing pre-existing + 2 new)
- [ ] `cd server && npx tsc --noEmit` — no type errors
- [ ] `npx biome check .` — no new lint
- [ ] Manual: POST `/api/bins` with `items: [{name:\"x\", quantity:3}]`, confirm response preserves `quantity: 3`
- [ ] Manual: duplicate a bin whose items have non-null quantities, confirm copy preserves them