### PR TITLE
fix: correct tab order on login page

### DIFF
--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -154,13 +154,8 @@ export function LoginPage() {
                       enterKeyHint="next"
                     />
                   </div>
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-2">
-                      <Label htmlFor="login-password">Password</Label>
-                      <Link to="/forgot-password" className="text-[13px] text-[var(--accent)] hover:underline focus-visible:underline focus-visible:outline-none shrink-0">
-                        Forgot password?
-                      </Link>
-                    </div>
+                  <div className="relative space-y-2">
+                    <Label htmlFor="login-password">Password</Label>
                     <PasswordInput
                       ref={passwordRef}
                       id="login-password"
@@ -171,6 +166,9 @@ export function LoginPage() {
                       required
                       enterKeyHint="done"
                     />
+                    <Link to="/forgot-password" className="absolute right-0 top-0 text-[13px] text-[var(--accent)] hover:underline focus-visible:underline focus-visible:outline-none shrink-0">
+                      Forgot password?
+                    </Link>
                   </div>
                   <Button
                     type="submit"


### PR DESCRIPTION
## Summary

- Fixes a keyboard-navigation surprise on `/login` where pressing Tab from the email field landed on the "Forgot password?" link instead of the password field
- Root cause: the link was rendered inside the password label group, putting it between the inputs in DOM order
- Moved the link to render after `<PasswordInput>`, absolute-positioned at top-right of the password wrapper. Visual layout is identical to before.

New tab order: email → password → Forgot password? → Sign In → Create one.

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npx vitest run src/features/auth` — passes
- [ ] `npx biome check .` — no new lint
- [ ] Manual: load `/login`, focus email, press Tab — next focused element is password input
- [ ] Visual check: layout (link position, alignment with Password label) unchanged