### PR TITLE
fix: hide Reanalyze AI affordance for viewer role

### DIFF
--- a/src/features/bins/useBinDetailActions.ts
+++ b/src/features/bins/useBinDetailActions.ts
@@ -172,7 +172,7 @@ export function useBinDetailActions(bin: Bin | null | undefined, id: string | un
 
   const canEdit = bin ? canWrite : false;
   const canDelete = bin ? canDeleteBin(bin.created_by) : false;
-  const showAiButton = (aiEnabled || aiGated) && photos.length > 0;
+  const showAiButton = canWrite && (aiEnabled || aiGated) && photos.length > 0;
   const isReanalysis = !!(lastSuggestions || (bin && (bin.name || bin.items.length > 0)));
 
   return {


### PR DESCRIPTION
## Summary

- Viewers saw "Reanalyze with AI" in the bin-detail more-actions menu and as the desktop sparkles button
- Clicking it returned 403 because viewers cannot consume AI credits (server middleware `requireMemberOrAbove` already enforces this)
- Gated `showAiButton` on `canWrite` from `usePermissions`, mirroring the existing pattern for `canPin` and `canCreateBin`
- One-line change at the source flag, so both the desktop button and the mobile menu item are now hidden for viewers

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npx vitest run src/features/bins` — 243 tests pass
- [ ] `npx biome check .` — no new lint
- [ ] Manual: log in as a viewer, open a bin, click "..." More — confirm "Reanalyze with AI" is NOT shown
- [ ] Manual: log in as admin/member, open a bin, confirm "Reanalyze with AI" IS still shown