### PR TITLE
feat: add autonomous test-gap agent prompt files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,10 +61,10 @@
 # AI_VISION_PROVIDER=               # Override provider for photo analysis
 # AI_VISION_API_KEY=                 # Override API key for photo analysis
 # AI_VISION_MODEL=                   # Override model for photo analysis (e.g. gemini-2.0-flash)
-# AI_QUICK_TEXT_PROVIDER=            # Override provider for commands + text extraction
-# AI_QUICK_TEXT_MODEL=               # Override model for commands + text extraction (e.g. gpt-4o-mini)
-# AI_DEEP_TEXT_PROVIDER=             # Override provider for queries + reorganize
-# AI_DEEP_TEXT_MODEL=                # Override model for queries + reorganize
+# AI_QUICK_TEXT_PROVIDER=            # Override provider for commands + queries + text extraction
+# AI_QUICK_TEXT_MODEL=               # Override model for commands + queries + text extraction (e.g. gpt-4o-mini)
+# AI_DEEP_TEXT_PROVIDER=             # Override provider for reorganize + tag suggestions
+# AI_DEEP_TEXT_MODEL=                # Override model for reorganize + tag suggestions
 
 # ── Plan Pricing (cloud only — must match Stripe Dashboard) ──
 # All prices in minor units (cents/USD). Used by GET /api/plans.

--- a/scripts/test-agents/business-logic.md
+++ b/scripts/test-agents/business-logic.md
@@ -1,0 +1,114 @@
+# OpenBin Business Logic Test Agent
+
+You are a Claude Code agent running an automated business-logic test-gap analysis on the OpenBin codebase.
+Your goal: find and write Vitest tests that cover correctness gaps in core data flows.
+
+## Project Context
+
+OpenBin is an AI-powered bin inventory app. Data model: Location → Area → Bin → Items.
+Backend: Express 4 + SQLite at `server/`. Frontend: React 18 + TypeScript at `src/`.
+Bins support: soft delete (`deleted_at`), trash/restore, tags, custom fields, photos, QR codes.
+
+## Read These Files First
+
+1. `server/src/__tests__/helpers.ts` — `createTestUser`, `createTestLocation`, `createTestBin`, `createTestArea`, `joinTestLocation`
+2. `server/src/__tests__/bins.test.ts` — existing bin tests (do not duplicate)
+3. `server/src/__tests__/items.test.ts` — existing item tests
+4. `server/src/__tests__/areas.test.ts` — existing area tests
+5. `server/src/__tests__/export.test.ts` — existing export tests
+6. `server/src/__tests__/batch.test.ts` — existing batch tests
+7. `server/src/routes/bins.ts`, `server/src/routes/items.ts`, `server/src/routes/areas.ts`
+
+## Test Patterns
+
+**Server test setup:**
+```typescript
+import type { Express } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from '../index.js';
+import { createTestBin, createTestLocation, createTestUser } from './helpers.js';
+
+let app: Express;
+beforeEach(() => { app = createApp(); });
+```
+
+**HTTP requests:**
+```typescript
+const res = await request(app)
+  .post('/api/bins')
+  .set('Authorization', `Bearer ${token}`)
+  .send({ locationId: location.id, name: 'My Bin' });
+expect(res.status).toBe(201);
+expect(res.body.name).toBe('My Bin');
+```
+
+## Mandate: What to Test
+
+### 1. Soft delete isolation — extend `server/src/__tests__/bins.test.ts` or create `server/src/__tests__/softDelete.test.ts`
+
+Read existing tests first. Write tests for uncovered gaps:
+- Deleted bin does NOT appear in `GET /api/bins?locationId=...` results
+- Deleted bin DOES appear in `GET /api/bins/trash?locationId=...`
+- Items of a deleted bin are not returned in any list endpoint
+- `PUT /api/bins/:id` on a deleted bin returns 404
+- Restoring a bin via `POST /api/bins/:id/restore` makes it visible in the normal list again
+
+### 2. Area hierarchy edge cases — extend `server/src/__tests__/areas.test.ts` or create `server/src/__tests__/areaHierarchy.test.ts`
+
+Read `server/src/__tests__/hierarchicalAreas.test.ts` first. Write for uncovered gaps:
+- Deleting a parent area: what happens to child areas and their bins?
+- Moving a bin to a nested child area
+- `descendant_bin_count` on a parent area reflects bins in all child areas
+- Renaming an area does not affect its children
+
+### 3. Export/import round-trip — create `server/src/__tests__/exportImport.test.ts`
+
+Read `server/src/__tests__/export.test.ts` first. Write a round-trip test:
+- Create a location with bins, items, tags, custom fields, and areas
+- Export via `GET /api/export?locationId=...` and capture the JSON
+- Create a new location
+- Import the captured JSON via `POST /api/import`
+- Assert: bin count matches, item names match, tags match, areas match
+
+### 4. Bulk operation edge cases — create `server/src/__tests__/bulkEdgeCases.test.ts`
+
+Read `server/src/__tests__/batch.test.ts` first. Write for gaps:
+- `POST /api/batch` with empty `operations` array → 200 with empty results (not 500)
+- `POST /api/batch` with a mix of valid and invalid operations → partial success, errors reported per-operation
+- Bulk delete: bins are soft-deleted, not hard-deleted; they appear in trash
+
+### 5. AI flow edge cases — extend `server/src/__tests__/aiStream.test.ts` or create `server/src/__tests__/aiFlowEdgeCases.test.ts`
+
+Read `server/src/__tests__/ai.test.ts` and `server/src/__tests__/aiStream.test.ts` first. Write for uncovered gaps:
+- **Partial JSON streaming**: the AI endpoint returns partial JSON chunks mid-stream; assert the client parser does not crash and waits for the full response
+- **Provider fallback**: if the configured provider returns a 500, the endpoint returns a meaningful error (not a raw 500 stack trace)
+- **Credit exhaustion**: when the user has 0 AI credits remaining, the streaming endpoint returns 402 with `error: 'OVER_LIMIT'`
+
+Read `server/src/lib/aiCaller.ts` and `server/src/lib/aiStreamHandler.ts` for the AI pipeline before writing these tests.
+
+### 6. Backup/restore — extend `server/src/lib/__tests__/backup.test.ts`
+
+Read the existing backup test first. Write for gaps:
+- Backup produces a non-empty file at the configured path
+- Restore from a valid backup file replaces the data
+- Restore from a corrupted file returns a descriptive error (not a 500 crash)
+
+## Self-Validation Gate
+
+After writing each test file, run:
+```bash
+cd server && npx vitest run src/__tests__/<filename>.test.ts
+```
+Fix all failures. Do not leave failing tests.
+
+## Output Summary
+
+At the end, print:
+```
+## Business Logic Agent Summary
+Files created: [list]
+Files extended: [list]
+New test cases: [count]
+Gaps not covered: [explain any that need a live service or special env]
+```

--- a/scripts/test-agents/business-logic.md
+++ b/scripts/test-agents/business-logic.md
@@ -66,9 +66,9 @@ Read `server/src/__tests__/hierarchicalAreas.test.ts` first. Write for uncovered
 
 Read `server/src/__tests__/export.test.ts` first. Write a round-trip test:
 - Create a location with bins, items, tags, custom fields, and areas
-- Export via `GET /api/export?locationId=...` and capture the JSON
+- Export via `GET /api/locations/${location.id}/export` and capture the JSON
 - Create a new location
-- Import the captured JSON via `POST /api/import`
+- Import the captured JSON via `POST /api/locations/${newLocation.id}/import`
 - Assert: bin count matches, item names match, tags match, areas match
 
 ### 4. Bulk operation edge cases — create `server/src/__tests__/bulkEdgeCases.test.ts`

--- a/scripts/test-agents/ee.md
+++ b/scripts/test-agents/ee.md
@@ -1,0 +1,131 @@
+# OpenBin EE Test Agent
+
+You are a Claude Code agent running an automated EE (enterprise edition) test-gap analysis on the OpenBin codebase.
+Your goal: find and write Vitest tests for plan gating, checkout action safety, over-limit enforcement, and EE component fallbacks.
+
+## Project Context
+
+OpenBin has an open-core split: open-source core + proprietary EE code in `src/ee/` and `server/src/ee/`.
+EE is enabled at build time via `__EE__` global. In tests, EE server routes are registered when the EE module is loaded.
+
+Plan tiers: `free` | `plus` | `pro`. Gating middleware: `requirePlan()` in `server/src/middleware/requirePlan.ts`.
+Billing: `CheckoutAction` shape — JWT must never appear in URL (must be in POST body `fields`).
+Limits: bins, members per location, photo storage.
+
+## Read These Files First
+
+1. `server/src/__tests__/helpers.ts` — `createTestUser`, `createTestLocation`, `createTestBin`
+2. `server/src/__tests__/plan.test.ts` — existing plan tests; learn how plan state is set in tests
+3. `server/src/__tests__/planGate.test.ts` and `server/src/__tests__/planGating.test.ts` — existing gating tests
+4. `server/src/__tests__/requirePlan.test.ts` — existing requirePlan tests
+5. `server/src/middleware/requirePlan.ts` — understand `requirePlan()` and `actionAndUrl()` helper
+6. `server/src/ee/routes/` — list all EE routes and their plan requirements
+7. `src/types.ts` — `CheckoutAction`, `PlanInfo`, `PlanFeatures` interfaces
+8. `src/ee/checkoutAction.tsx` — `CheckoutLink` component and `submitCheckoutAction()`
+9. `vitest.config.ts` — how `__EE__` is injected and what the test environment default is
+
+## Test Patterns
+
+**Server test setup:**
+```typescript
+import type { Express } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from '../index.js';
+import { createTestBin, createTestLocation, createTestUser } from './helpers.js';
+
+let app: Express;
+beforeEach(() => { app = createApp(); });
+```
+
+Note: Read `server/src/__tests__/plan.test.ts` to see how plan state is set for a user (likely via direct DB manipulation). Use that exact pattern.
+
+**Frontend mock setup:**
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) { super(message); this.status = status; }
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({ useAuth: vi.fn() }));
+
+import { apiFetch } from '@/lib/api';
+const mockApiFetch = vi.mocked(apiFetch);
+
+beforeEach(() => { vi.clearAllMocks(); });
+```
+
+## Mandate: What to Test
+
+### 1. EE route plan gates — extend `server/src/__tests__/planGating.test.ts` or create `server/src/__tests__/eeRouteGating.test.ts`
+
+Read `server/src/ee/routes/` to list all EE routes. Read the existing `planGating.test.ts` first.
+For each EE route guarded by `requirePlan()` and NOT already covered in existing tests:
+- Call it as a free-tier user → assert 402 with `error: 'PLAN_REQUIRED'` or `'OVER_LIMIT'`
+- Call it as a paid-tier user (plus or pro) → assert NOT 402
+
+Read `server/src/__tests__/plan.test.ts` to learn how to set a user's plan tier before the request.
+
+### 2. CheckoutAction JWT safety — create `server/src/ee/__tests__/checkoutActionSafety.test.ts`
+
+Call the endpoint that returns `PlanInfo` (read `server/src/ee/routes/` to find it) as an authenticated user.
+Assert on the response body:
+- `upgradeAction` is either `null` or `{ method: 'POST', url: string, fields: Record<string, string> }` where `url` does NOT contain any JWT characters (no base64url patterns like `eyJ`)
+- `portalAction` is either `null` or `{ method: 'POST', ... }` where `url` does NOT contain `eyJ`
+- `subscribePlanAction` if present and non-null: `method` is `'GET'` (the plans page is a static site)
+- The legacy `upgradeUrl`, `portalUrl` fields do NOT contain JWT tokens (they should be static URLs)
+
+To detect a JWT in a URL: check that the URL does not match `/eyJ[A-Za-z0-9_-]+/`.
+
+### 3. Over-limit error paths — extend `server/src/__tests__/planGate.test.ts` or create `server/src/__tests__/overLimit.test.ts`
+
+Read `server/src/lib/requirePlan.ts` and `server/src/lib/memberCounts.ts`. Write tests for:
+- Creating a bin when the location is at the free-tier bin limit → 402 with `error: 'OVER_LIMIT'`
+- Inviting a member when the location is at the member cap → 402
+- Check `server/src/lib/config.ts` for the actual free-tier limits (`maxBins`, `maxMembersPerLocation`)
+
+To trigger limits, create exactly N bins (where N is the free limit), then try to create one more. Use the plan state setup pattern from `plan.test.ts`.
+
+### 4. EE component __EE__=false fallback — create `src/ee/__tests__/eeDisabled.test.ts`
+
+Read `vitest.config.ts` to confirm `__EE__` defaults to `false` in the test environment.
+Read `src/ee/` to find components that are conditionally exported based on `__EE__`.
+
+For each EE component that renders as a no-op when `__EE__` is false:
+```typescript
+import { render } from '@testing-library/react';
+import { TheEEComponent } from '@/ee/TheEEComponent';
+
+it('renders null when __EE__ is false', () => {
+  const { container } = render(<TheEEComponent />);
+  expect(container.firstChild).toBeNull();
+});
+```
+
+If `__EE__` is true in tests, note this in the output summary and skip this section.
+
+## Self-Validation Gate
+
+After writing each test file, run:
+```bash
+cd server && npx vitest run src/__tests__/<filename>.test.ts
+# or for client-side EE tests, from project root:
+npx vitest run src/ee/__tests__/<filename>.test.tsx
+```
+Fix all failures. Do not leave failing tests.
+
+## Output Summary
+
+At the end, print:
+```
+## EE Agent Summary
+Files created: [list]
+Files extended: [list]
+New test cases: [count]
+Gaps not covered: [explain any — e.g., needs Stripe webhook setup, __EE__ is true in tests]
+```

--- a/scripts/test-agents/frontend.md
+++ b/scripts/test-agents/frontend.md
@@ -1,0 +1,129 @@
+# OpenBin Frontend Reliability Test Agent
+
+You are a Claude Code agent running an automated frontend test-gap analysis on the OpenBin codebase.
+Your goal: find and write Vitest tests for hook error paths, event-bus refresh behavior, and component edge cases.
+
+## Project Context
+
+OpenBin is a React 18 + TypeScript app. Key patterns:
+- Hooks use `apiFetch()` from `src/lib/api.ts` for data fetching
+- `useListData`, `usePaginatedList`, `usePagedList` from `src/lib/useListQuery.ts` for list hooks
+- Event bus: `notify()` and `useRefreshOn()` from `src/lib/eventBus.ts` — 13 event types
+- Auth: `useAuth()` from `src/lib/auth.tsx`
+- Tests use Vitest + happy-dom, mock `apiFetch` and `useAuth`
+
+## Read These Files First
+
+1. `src/lib/useListQuery.ts` — `useListData`, `usePaginatedList`, `usePagedList`
+2. `src/lib/eventBus.ts` — all 13 event type names and the `notify`/`useRefreshOn` API
+3. `src/lib/__tests__/eventBus.test.ts` — what is already covered
+4. `src/features/bins/__tests__/useBins.test.ts` — the mock pattern (study this carefully)
+5. `src/lib/__tests__/usePermissions.test.ts` — the `renderHook` pattern
+6. `src/features/bins/__tests__/useBinList.test.ts` — existing list hook tests
+
+## Test Patterns
+
+**Mock setup (copy this exactly):**
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({ activeLocationId: 'test-location', token: 'test-token' }),
+}));
+
+import { apiFetch } from '@/lib/api';
+const mockApiFetch = vi.mocked(apiFetch);
+
+beforeEach(() => { vi.clearAllMocks(); });
+```
+
+**Testing a hook with renderHook:**
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSomeHook } from '../useSomeHook';
+
+it('returns error state when API fails', async () => {
+  mockApiFetch.mockRejectedValue(new Error('Network error'));
+  const { result } = renderHook(() => useSomeHook('loc-1'));
+  await waitFor(() => expect(result.current.isLoading).toBe(false));
+  expect(result.current.error).toBeTruthy();
+});
+```
+
+## Mandate: What to Test
+
+### 1. useListQuery hook states — create `src/lib/__tests__/useListQuery.test.ts`
+
+Read `src/lib/useListQuery.ts` first. For each of `useListData`, `usePaginatedList`, and `usePagedList`, write tests:
+- **Loading state**: mock `apiFetch` with a promise that never resolves; assert `isLoading` is `true` immediately after render
+- **Success state**: mock `apiFetch` to resolve with `{ results: [{ id: '1', name: 'Test' }], count: 1 }`; assert `isLoading` becomes `false` and data contains the item
+- **Error state**: mock `apiFetch` to reject with `new Error('fail')`; assert `isLoading` becomes `false` and `error` is set (or data is empty, per the hook's contract — check the source)
+- **Empty results**: mock `apiFetch` to resolve with `{ results: [], count: 0 }`; assert data is an empty array (not undefined or null)
+- **Null path guard**: call the hook with `null` as the path; assert `apiFetch` is never called
+
+### 2. Event bus: all 13 event types trigger refetches — create `src/lib/__tests__/eventBusRefresh.test.ts`
+
+The 13 event types are defined in `src/lib/eventBus.ts`. Read that file to get the exact constant names.
+
+For each event type, find which hook subscribes to it by grepping for `useRefreshOn` across `src/`. Write a test that:
+1. Renders the hook that subscribes to that event type
+2. Waits for the initial fetch to complete
+3. Calls `notify(EVENT_TYPE)` 
+4. Asserts `apiFetch` was called a second time (a refresh happened)
+
+The event types are: `BINS`, `LOCATIONS`, `PHOTOS`, `PINS`, `AREAS`, `TAG_COLORS`, `SCAN_HISTORY`, `CUSTOM_FIELDS`, `PLAN`, `CHECKOUTS`, `BIN_USAGE`, `ATTACHMENTS`, `SHOPPING_LIST`.
+
+Read `src/lib/__tests__/eventBus.test.ts` first — only write tests for event types NOT already covered there.
+
+### 3. usePermissions exhaustive matrix — extend `src/lib/__tests__/usePermissions.test.ts`
+
+Read the existing file first to see which combinations are already tested. Write the missing cases:
+- `viewer` role: `canWrite` is false, `canCreateBin` is false, `canPin` is false, `canEditBin('any-user-id')` is false, `canDeleteBin('any-user-id')` is false, `canManageMembers` is false
+- `member` role: `canWrite` is true, `canCreateBin` is true, `canEditBin(ownUserId)` is true, `canEditBin('other-user-id')` is false, `canManageMembers` is false, `canManageAreas` is false
+- No active location (activeLocationId is null): all permissions return false
+- No user logged in (user is null): all permissions return false
+
+### 4. Component edge cases
+
+Read existing component tests first. Write only for gaps:
+
+**Extend `src/features/bins/__tests__/ItemList.test.tsx`:**
+- Renders without crash when an item's name is 500 characters long
+- Renders the empty state (no crash, no undefined errors) when `items` is an empty array
+- Renders correctly when an item has `quantity: null` vs `quantity: 0` (both should display without crash)
+
+**Extend `src/features/bins/__tests__/BinCreateForm.test.tsx`:**
+- Submitting with an empty name field does NOT call `apiFetch` (client-side guard)
+- Submitting a valid form calls `apiFetch` exactly once with `method: 'POST'`
+
+## Self-Validation Gate
+
+After writing each test file, run from the project root:
+```bash
+npx vitest run src/lib/__tests__/useListQuery.test.ts
+npx vitest run src/lib/__tests__/eventBusRefresh.test.ts
+npx vitest run src/lib/__tests__/usePermissions.test.ts
+```
+Fix all failures. Do not leave failing tests.
+
+## Output Summary
+
+At the end, print:
+```
+## Frontend Agent Summary
+Files created: [list]
+Files extended: [list]
+New test cases: [count]
+Gaps not covered: [explain any — e.g., needs browser for camera APIs]
+```

--- a/scripts/test-agents/security.md
+++ b/scripts/test-agents/security.md
@@ -1,0 +1,137 @@
+# OpenBin Security Test Agent
+
+You are a Claude Code agent running an automated security test-gap analysis on the OpenBin codebase.
+Your goal: find and write Vitest tests that cover security enforcement gaps.
+
+## Project Context
+
+OpenBin is an AI-powered bin inventory app. Backend: Express 4 + SQLite at `server/`. Frontend: React 18 + TypeScript at `src/`.
+
+Three-tier role system: `admin` > `member` > `viewer`. Viewers are read-only.
+- Middleware: `requireMemberOrAbove()` blocks viewers from mutations
+- CSRF: double-submit cookie pattern (`server/src/lib/csrf.ts`)
+- API keys: `sk_openbin_` prefix, checked via dual-auth middleware
+
+## Read These Files First
+
+1. `server/src/__tests__/helpers.ts` — understand `createTestUser`, `createTestLocation`, `createTestBin`, `createTestArea`, `joinTestLocation`
+2. `server/src/__tests__/auth.test.ts` — CSRF cookie helpers: `getCsrfCookie`, `cookiePost` pattern
+3. `server/src/__tests__/binAccess.test.ts` — existing permission test pattern
+4. `server/src/__tests__/csrf.test.ts` — existing CSRF tests (don't duplicate these)
+5. `server/src/__tests__/locationAccess.test.ts` — existing location access tests
+6. `server/src/routes/` — list all route files, read each to catalog endpoints and their middleware
+
+## Test Patterns
+
+**Server test setup:**
+```typescript
+import type { Express } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { query } from '../db.js';
+import { createApp } from '../index.js';
+import { createTestBin, createTestLocation, createTestUser, joinTestLocation } from './helpers.js';
+
+let app: Express;
+beforeEach(() => { app = createApp(); });
+```
+
+**Making a viewer:**
+```typescript
+const { token: adminToken } = await createTestUser(app);
+const location = await createTestLocation(app, adminToken);
+const { token: viewerToken, user: viewerUser } = await createTestUser(app);
+await joinTestLocation(app, viewerToken, location.invite_code);
+await query(
+  "UPDATE location_members SET role = 'viewer' WHERE location_id = $1 AND user_id = $2",
+  [location.id, viewerUser.id]
+);
+```
+
+**Asserting 403 for a mutation:**
+```typescript
+const res = await request(app)
+  .post('/api/bins')
+  .set('Authorization', `Bearer ${viewerToken}`)
+  .send({ locationId: location.id, name: 'Test' });
+expect(res.status).toBe(403);
+```
+
+Note: Bearer token auth bypasses CSRF — no `X-CSRF-Token` header needed for these viewer-blocking tests.
+
+## Mandate: What to Test
+
+### 1. Viewer mutation blocking — `server/src/__tests__/viewerMutationBlock.test.ts`
+
+Read `server/src/routes/` and check which endpoints are NOT already covered by `binAccess.test.ts` / `locationAccess.test.ts`.
+For each uncovered mutation endpoint, write a test that:
+- Creates an admin, a location, and a viewer member
+- Sends the mutation as the viewer
+- Asserts `403`
+
+Priority endpoints to check (add any others you find):
+- `POST /api/bins` (create bin)
+- `PUT /api/bins/:id` (update bin)
+- `DELETE /api/bins/:id` (delete bin)
+- `POST /api/bins/:id/items` (add item)
+- `PUT /api/bins/:id/items/:itemId` (update item)
+- `DELETE /api/bins/:id/items/:itemId` (delete item)
+- `POST /api/locations/:id/areas` (create area)
+- `PUT /api/locations/:id/areas/:areaId` (rename area)
+- `DELETE /api/locations/:id/areas/:areaId` (delete area)
+- `POST /api/bins/:id/photos` (upload photo)
+- `PUT /api/locations/:id` (update location settings)
+- `POST /api/bins/:id/pin` (pin bin)
+- `POST /api/locations/:locationId/custom-fields` (create custom field)
+
+### 2. Input validation edge cases — `server/src/__tests__/inputValidation.test.ts`
+
+Test these inputs on bin name, item name, area name fields:
+- Empty string `""` → assert 400
+- String of 10,001 characters → assert 400 or check the validation limit in `server/src/lib/binValidation.ts`
+- String with `<script>alert(1)</script>` → assert 200 and stored value equals the raw input (not escaped — that is the frontend's job)
+- Filename with path traversal `../../etc/passwd` in photo upload → assert 400 or check it is sanitized
+
+To find the actual validation limits, read `server/src/lib/binValidation.ts` and `server/src/lib/validation.ts` before writing the tests.
+
+### 3. Rate limiter enforcement — `server/src/__tests__/rateLimiter.test.ts`
+
+IMPORTANT: The default test setup has `DISABLE_RATE_LIMIT=true`. For rate limiter tests, set `process.env.DISABLE_RATE_LIMIT = 'false'` before calling `createApp()`.
+
+Read `server/src/lib/config.ts` to find the actual limits for `authRateLimit` and `registerRateLimit`.
+
+Write tests that:
+- Hit the auth endpoint (`POST /api/auth/login`) N+1 times with wrong credentials and assert the N+1th response is 429
+- Hit the register endpoint N+1 times and assert 429
+
+Reset `process.env.DISABLE_RATE_LIMIT` in `afterEach`.
+
+### 4. API key scope — `server/src/__tests__/apiKeyScope.test.ts`
+
+Read `server/src/__tests__/apiKeys.test.ts` to see what is already covered.
+Write tests for any uncovered gaps:
+- A valid API key can read bins (`GET /api/bins?locationId=...`) → 200
+- A valid API key cannot access admin endpoints (`GET /api/admin/users`) → 403 or 401
+- An API key with wrong prefix (`sk_wrong_xxx`) is rejected → 401
+- A revoked API key is rejected → 401
+
+To create an API key in a test, read the existing `apiKeys.test.ts` for the creation flow.
+
+## Self-Validation Gate
+
+After writing each test file, run:
+```bash
+cd server && npx vitest run src/__tests__/<filename>.test.ts
+```
+Fix all failures before finishing. Do not leave failing tests.
+
+## Output Summary
+
+At the end, print:
+```
+## Security Agent Summary
+Files created: [list]
+Files extended: [list]
+New test cases: [count]
+Gaps not covered: [explain any that need a live service or special env]
+```

--- a/scripts/test-agents/security.md
+++ b/scripts/test-agents/security.md
@@ -96,15 +96,19 @@ To find the actual validation limits, read `server/src/lib/binValidation.ts` and
 
 ### 3. Rate limiter enforcement — `server/src/__tests__/rateLimiter.test.ts`
 
-IMPORTANT: The default test setup has `DISABLE_RATE_LIMIT=true`. For rate limiter tests, set `process.env.DISABLE_RATE_LIMIT = 'false'` before calling `createApp()`.
+IMPORTANT: The OpenBin config object is frozen at module import time. Setting `process.env.DISABLE_RATE_LIMIT = 'false'` at test runtime will NOT work — the rate limiters are already initialized as no-ops.
 
-Read `server/src/lib/config.ts` to find the actual limits for `authRateLimit` and `registerRateLimit`.
+Rate limiter tests require one of these approaches:
+a) Use `vi.mock('../lib/rateLimiters.js', ...)` to replace the no-op limiters with real express-rate-limit instances
+b) OR note in the output summary that rate limiter tests cannot be written without a dedicated test environment and skip this section
 
-Write tests that:
-- Hit the auth endpoint (`POST /api/auth/login`) N+1 times with wrong credentials and assert the N+1th response is 429
-- Hit the register endpoint N+1 times and assert 429
+If you choose approach (a):
+- Read `server/src/lib/rateLimiters.ts` to understand the limiter factory
+- Mock the module to return real express-rate-limit instances with low limits (e.g., `max: 2`)
+- Hit the auth endpoint 3 times and assert the 3rd response is 429
+- Hit the register endpoint 3 times and assert the 3rd response is 429
 
-Reset `process.env.DISABLE_RATE_LIMIT` in `afterEach`.
+If you cannot implement (a) cleanly, note in your output summary: "Rate limiter tests skipped — config is frozen at import time; requires vi.mock of rateLimiters module."
 
 ### 4. API key scope — `server/src/__tests__/apiKeyScope.test.ts`
 

--- a/server/src/__tests__/taskRouting.test.ts
+++ b/server/src/__tests__/taskRouting.test.ts
@@ -71,7 +71,7 @@ describe('TASK_GROUP_MAP', () => {
     expect(TASK_GROUP_MAP.execute).toBe('quickText');
     expect(TASK_GROUP_MAP.structure).toBe('quickText');
     expect(TASK_GROUP_MAP['structure-text']).toBe('quickText');
-    expect(TASK_GROUP_MAP.query).toBe('deepText');
+    expect(TASK_GROUP_MAP.query).toBe('quickText');
     expect(TASK_GROUP_MAP.reorganization).toBe('deepText');
     expect(TASK_GROUP_MAP.tagSuggestion).toBe('deepText');
   });

--- a/server/src/lib/taskRouting.ts
+++ b/server/src/lib/taskRouting.ts
@@ -13,7 +13,7 @@ export const TASK_GROUP_MAP: Record<string, AiTaskGroup> = {
   'execute': 'quickText',
   'structure': 'quickText',
   'structure-text': 'quickText',
-  'query': 'deepText',
+  'query': 'quickText',
   'reorganization': 'deepText',
   'tagSuggestion': 'deepText',
 };

--- a/src/features/ai/aiConstants.ts
+++ b/src/features/ai/aiConstants.ts
@@ -40,6 +40,6 @@ export const KEY_PLACEHOLDERS: Record<AiProvider, string> = {
 
 export const TASK_GROUP_META: { key: AiTaskGroup; label: string; description: string }[] = [
   { key: 'vision', label: 'Vision', description: 'Photo Scan' },
-  { key: 'quickText', label: 'Quick Text', description: 'Commands, Text Extraction' },
-  { key: 'deepText', label: 'Deep Text', description: 'Queries, Reorganize' },
+  { key: 'quickText', label: 'Quick Text', description: 'Commands, Queries, Text Extraction' },
+  { key: 'deepText', label: 'Deep Text', description: 'Reorganize, Tag Suggestions' },
 ];


### PR DESCRIPTION
## Summary

- Adds `scripts/test-agents/` with 4 Claude Code agent prompt files
- Each prompt targets a specific concern: security enforcement, business logic correctness, frontend reliability, and EE plan gating
- Agents are invoked via `claude --print "$(cat scripts/test-agents/<name>.md)"` and autonomously find coverage gaps, write Vitest tests, self-validate by running them, and output a summary

## Test Plan

- [ ] Run `claude --print "$(cat scripts/test-agents/security.md)"` and verify it produces new test files in `server/src/__tests__/`
- [ ] Run `claude --print "$(cat scripts/test-agents/business-logic.md)"` and verify export/import round-trip test and soft-delete tests are written
- [ ] Run `claude --print "$(cat scripts/test-agents/frontend.md)"` and verify `useListQuery.test.ts` and `eventBusRefresh.test.ts` are created
- [ ] Run `claude --print "$(cat scripts/test-agents/ee.md)"` and verify plan gate and CheckoutAction safety tests are written
- [ ] After each agent run, confirm `npx vitest run` / `cd server && npx vitest run` stays green