### PR TITLE
fix: QA sweep — CSP for CF beacon, AI credit estimates, role toggle

### DIFF
--- a/server/src/__tests__/auth.test.ts
+++ b/server/src/__tests__/auth.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { getDb, query } from '../db.js';
 import { createApp } from '../index.js';
-import { createTestLocation, createTestUser } from './helpers.js';
+import { createTestLocation, createTestUser, getMemberRoleByDb } from './helpers.js';
 
 let app: Express;
 
@@ -490,6 +490,42 @@ describe('POST /api/auth/register — invite code', () => {
       });
 
     expect(res.status).toBe(404);
+  });
+
+  it('register-with-invite assigns the location\'s default_join_role (member by default)', async () => {
+    const { token: adminToken } = await createTestUser(app);
+    const location = await createTestLocation(app, adminToken);
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({
+        email: `joinrole_${Date.now()}@test.local`,
+        password: 'TestPass123!',
+        displayName: 'Join Role',
+        inviteCode: location.invite_code,
+      });
+    expect(res.status).toBe(201);
+    expect(await getMemberRoleByDb(location.id, res.body.user.id)).toBe('member');
+  });
+
+  it('register-with-invite assigns viewer when location.default_join_role = "viewer"', async () => {
+    const { token: adminToken } = await createTestUser(app);
+    const location = await createTestLocation(app, adminToken);
+    await query(
+      "UPDATE locations SET default_join_role = 'viewer' WHERE id = $1",
+      [location.id],
+    );
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({
+        email: `joinviewer_${Date.now()}@test.local`,
+        password: 'TestPass123!',
+        displayName: 'Join Viewer',
+        inviteCode: location.invite_code,
+      });
+    expect(res.status).toBe(201);
+    expect(await getMemberRoleByDb(location.id, res.body.user.id)).toBe('viewer');
   });
 });
 

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -1,6 +1,6 @@
 import type { Express } from 'express';
 import request from 'supertest';
-import { getDb } from '../db.js';
+import { getDb, query } from '../db.js';
 
 /** Minimal 1x1 PNG for upload tests. */
 export const TEST_PNG = Buffer.from(
@@ -104,6 +104,14 @@ export async function joinTestLocation(app: Express, token: string, inviteCode: 
     .set('Authorization', `Bearer ${token}`)
     .send({ inviteCode });
   if (res.status >= 400) throw new Error(`join failed: ${res.status} ${JSON.stringify(res.body)}`);
+}
+
+export async function getMemberRoleByDb(locationId: string, userId: string): Promise<string | undefined> {
+  const result = await query<{ role: string }>(
+    'SELECT role FROM location_members WHERE location_id = $1 AND user_id = $2',
+    [locationId, userId],
+  );
+  return result.rows[0]?.role;
 }
 
 export async function createTestArea(app: Express, token: string, locationId: string, name?: string) {

--- a/server/src/__tests__/securityHeaders.test.ts
+++ b/server/src/__tests__/securityHeaders.test.ts
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createApp } from '../index.js';
+
+let csp: string;
+let xFrameOptions: string | undefined;
+let xContentTypeOptions: string | undefined;
+
+beforeAll(async () => {
+  const res = await request(createApp()).get('/api/auth/status');
+  csp = res.headers['content-security-policy'];
+  xFrameOptions = res.headers['x-frame-options'];
+  xContentTypeOptions = res.headers['x-content-type-options'];
+});
+
+describe('Security headers', () => {
+  it('serves a CSP that locks the app down to self + pinned inline scripts', () => {
+    expect(csp).toBeDefined();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("img-src 'self' data: blob:");
+    expect(csp).toContain("worker-src 'self' blob:");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    // Loosening these hashes would allow arbitrary inline scripts.
+    expect(csp).toContain("'sha256-7KadoKzu1sd1+0LivMFrmxISBXbhj6nm/vOZqEaVC5I='");
+    expect(csp).toContain("'sha256-4kldY8Nv9iluY61Doo0WCNi1p1qCWgXWfSgXIX8g3g0='");
+    expect(csp).toMatch(/frame-ancestors/);
+  });
+
+  it('allows the Cloudflare Web Analytics beacon (script + reporting endpoint)', () => {
+    // CF auto-injects the RUM beacon at the proxy layer when Web Analytics is enabled.
+    // Without these allowances the browser logs a CSP violation on every pageload.
+    expect(csp).toMatch(/script-src[^;]*https:\/\/static\.cloudflareinsights\.com/);
+    expect(csp).toMatch(/connect-src[^;]*https:\/\/cloudflareinsights\.com/);
+  });
+
+  it('sets the supporting headers (X-Content-Type-Options, X-Frame-Options)', () => {
+    expect(xContentTypeOptions).toBe('nosniff');
+    expect(xFrameOptions).toBeDefined();
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -63,6 +63,32 @@ import userPreferencesRoutes from './routes/userPreferences.js';
 
 const STATIC_DIR = path.join(import.meta.dirname, '..', 'public');
 
+// CSP hashes pin the inline scripts in index.html — update when those scripts change.
+// CF beacon allowances cover the Web Analytics RUM script Cloudflare auto-injects at
+// the proxy layer; harmless on self-hosted (no CF proxy in the request path).
+const CSP_INLINE_SCRIPT_HASHES = [
+  "'sha256-7KadoKzu1sd1+0LivMFrmxISBXbhj6nm/vOZqEaVC5I='",
+  "'sha256-4kldY8Nv9iluY61Doo0WCNi1p1qCWgXWfSgXIX8g3g0='",
+];
+const CF_BEACON_SCRIPT_SRC = 'https://static.cloudflareinsights.com';
+const CF_BEACON_CONNECT_SRC = 'https://cloudflareinsights.com';
+
+function buildCspHeader(): string {
+  const frameAncestors = config.frameAncestors
+    ? `frame-ancestors 'self' ${config.frameAncestors};`
+    : "frame-ancestors 'none';";
+  const scriptSrc = ["'self'", ...CSP_INLINE_SCRIPT_HASHES, CF_BEACON_SCRIPT_SRC].join(' ');
+  return [
+    "default-src 'self';",
+    frameAncestors,
+    "img-src 'self' data: blob:;",
+    `script-src ${scriptSrc};`,
+    "style-src 'self' 'unsafe-inline';",
+    `connect-src 'self' ${CF_BEACON_CONNECT_SRC};`,
+    "worker-src 'self' blob:;",
+  ].join(' ');
+}
+
 export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => void }): express.Express {
   const app = express();
   if (config.trustProxy) app.set('trust proxy', 1);
@@ -76,27 +102,20 @@ export function createApp(opts?: { mountEeRoutes?: (app: express.Express) => voi
     },
   }));
 
-  // Security headers
+  // Security headers — header strings depend only on config, so build them once.
+  const cspHeader = buildCspHeader();
+  const xFrameOptions = config.frameAncestors
+    ? `ALLOW-FROM ${config.frameAncestors.split(' ')[0]}`
+    : 'DENY';
   app.use((_req, res, next) => {
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
     res.setHeader('Permissions-Policy', 'camera=(self), microphone=(self), geolocation=()');
-    if (config.frameAncestors) {
-      res.setHeader('X-Frame-Options', `ALLOW-FROM ${config.frameAncestors.split(' ')[0]}`);
-    } else {
-      res.setHeader('X-Frame-Options', 'DENY');
-    }
+    res.setHeader('X-Frame-Options', xFrameOptions);
     if (config.trustProxy) {
       res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
     }
-    // CSP hashes must match the inline scripts in index.html — update if those scripts change
-    const frameAncestorsCsp = config.frameAncestors
-      ? `frame-ancestors 'self' ${config.frameAncestors};`
-      : "frame-ancestors 'none';";
-    res.setHeader(
-      'Content-Security-Policy',
-      `default-src 'self'; ${frameAncestorsCsp} img-src 'self' data: blob:; script-src 'self' 'sha256-7KadoKzu1sd1+0LivMFrmxISBXbhj6nm/vOZqEaVC5I=' 'sha256-4kldY8Nv9iluY61Doo0WCNi1p1qCWgXWfSgXIX8g3g0='; style-src 'self' 'unsafe-inline'; connect-src 'self'; worker-src 'self' blob:;`,
-    );
+    res.setHeader('Content-Security-Policy', cspHeader);
     next();
   });
 

--- a/src/ee/AiCreditEstimate.tsx
+++ b/src/ee/AiCreditEstimate.tsx
@@ -1,3 +1,4 @@
+import { computeCreditEstimate } from '@/lib/aiCreditCost';
 import { usePlan } from '@/lib/usePlan';
 import { cn, pluralize } from '@/lib/utils';
 
@@ -6,17 +7,22 @@ interface AiCreditEstimateProps {
   className?: string;
 }
 
+const TONE_CLASSES = {
+  neutral: 'text-zinc-500 dark:text-zinc-400',
+  amber: 'text-amber-600 dark:text-amber-400',
+  red: 'text-red-600 dark:text-red-400',
+} as const;
+
 export function AiCreditEstimate({ cost, className }: AiCreditEstimateProps) {
   const { planInfo } = usePlan();
-  const { aiCredits, status } = planInfo;
+  const estimate = computeCreditEstimate(cost, planInfo.aiCredits, planInfo.status);
 
   if (cost <= 0) return null;
 
-  // Self-host (aiCredits === null), Pro/unlimited or Free-with-no-AI
-  // (limit === 0): the percent framing is meaningless, fall back to the
-  // raw "Uses N credits" copy so this component is a drop-in for
-  // <CreditCost>.
-  if (!aiCredits || aiCredits.limit <= 0) {
+  // No meaningful limit (self-host, Pro/unlimited, Free with no AI):
+  // act as a drop-in for <CreditCost> so cloud builds always render
+  // the raw cost even when the percent framing would be vacuous.
+  if (!estimate) {
     return (
       <span className={cn('text-xs text-zinc-500 dark:text-zinc-400', className)}>
         Uses {pluralize(cost, 'credit')}
@@ -24,26 +30,10 @@ export function AiCreditEstimate({ cost, className }: AiCreditEstimateProps) {
     );
   }
 
-  const { used, limit } = aiCredits;
-  const projected = used + cost;
-  const percent = Math.min(100, Math.round((cost / limit) * 100));
-  // Trial (Plus only): no monthly reset — `resetsAt` is null even though
-  // limit > 0. Use that to switch the copy from "monthly limit" to
-  // "trial credits" so the user isn't promised a reset that never comes.
-  const isTrial = status === 'trial' || aiCredits.resetsAt === null;
-  const limitLabel = isTrial ? 'trial credits' : 'monthly limit';
-
-  const overLimit = projected > limit;
-  const nearLimit = !overLimit && projected > limit * 0.8;
-  const colorClass = overLimit
-    ? 'text-red-600 dark:text-red-400'
-    : nearLimit
-      ? 'text-amber-600 dark:text-amber-400'
-      : 'text-zinc-500 dark:text-zinc-400';
-
-  const summary = overLimit
+  const limitLabel = estimate.isTrial ? 'trial credits' : 'monthly limit';
+  const summary = estimate.overLimit
     ? `Uses ${pluralize(cost, 'credit')} · would exceed your ${limitLabel}`
-    : `Uses ${pluralize(cost, 'credit')} · ${percent}% of ${limitLabel}`;
+    : `Uses ${pluralize(cost, 'credit')} · ${estimate.percent}% of ${limitLabel}`;
 
-  return <span className={cn('text-xs', colorClass, className)}>{summary}</span>;
+  return <span className={cn('text-xs', TONE_CLASSES[estimate.tone], className)}>{summary}</span>;
 }

--- a/src/features/ai/ConversationComposer.tsx
+++ b/src/features/ai/ConversationComposer.tsx
@@ -1,5 +1,5 @@
 import { Camera, Image as ImageIcon, Plus, Send, Square } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { lazy, Suspense, useRef, useState } from 'react';
 import { Textarea } from '@/components/ui/textarea';
 import { CreditCost } from '@/lib/aiCreditCost';
 import { useClickOutside } from '@/lib/useClickOutside';
@@ -7,6 +7,10 @@ import { usePopover } from '@/lib/usePopover';
 import type { useTranscription } from '@/lib/useTranscription';
 import { cn, focusRing, iconButton } from '@/lib/utils';
 import { TranscriptionMicButton } from './TranscriptionMicButton';
+
+const AiCreditEstimate = __EE__
+  ? lazy(() => import('@/ee/AiCreditEstimate').then(m => ({ default: m.AiCreditEstimate })))
+  : (() => null) as React.FC<{ cost: number; className?: string }>;
 
 interface ConversationComposerProps {
   onSend: (text: string) => void;
@@ -177,7 +181,13 @@ export function ConversationComposer({
         )}
       </div>
       <div className="mt-1 flex justify-end">
-        <CreditCost cost={1} />
+        {__EE__ ? (
+          <Suspense fallback={<CreditCost cost={1} />}>
+            <AiCreditEstimate cost={1} />
+          </Suspense>
+        ) : (
+          <CreditCost cost={1} />
+        )}
       </div>
     </div>
   );

--- a/src/features/ai/TranscriptionMicButton.tsx
+++ b/src/features/ai/TranscriptionMicButton.tsx
@@ -1,5 +1,6 @@
 import { Loader2, Mic, Square } from 'lucide-react';
 import { Tooltip } from '@/components/ui/tooltip';
+import { useCreditCostLabel } from '@/lib/aiCreditCost';
 import type { useTranscription } from '@/lib/useTranscription';
 import { cn, formatElapsed } from '@/lib/utils';
 
@@ -11,6 +12,7 @@ interface TranscriptionMicButtonProps {
 export function TranscriptionMicButton({ transcription, className }: TranscriptionMicButtonProps) {
   const { state, duration, start, stop } = transcription;
   const elapsed = formatElapsed(duration);
+  const { label: voiceInputLabel } = useCreditCostLabel('Voice input', 1);
 
   if (state === 'recording') {
     return (
@@ -43,7 +45,7 @@ export function TranscriptionMicButton({ transcription, className }: Transcripti
   }
 
   return (
-    <Tooltip content="Voice input">
+    <Tooltip content={voiceInputLabel}>
       <button
         type="button"
         onClick={start}
@@ -51,7 +53,7 @@ export function TranscriptionMicButton({ transcription, className }: Transcripti
           'p-1.5 rounded-[var(--radius-lg)] text-[var(--text-tertiary)] hover:text-[var(--accent)] hover:bg-[var(--bg-active)] transition-colors',
           className,
         )}
-        aria-label="Voice input"
+        aria-label={voiceInputLabel}
         data-tour="voice-input"
       >
         <Mic className="h-5 w-5" />

--- a/src/features/areas/LocationSettingsMenu.tsx
+++ b/src/features/areas/LocationSettingsMenu.tsx
@@ -87,7 +87,7 @@ export function LocationSettingsMenu({ isAdmin, onRename, onRetention, onCustomF
             onClick={() => handleItem(onRetention)}
           >
             <Clock className="h-4 w-4 text-[var(--text-tertiary)]" />
-            Data Retention
+            Retention & Roles
           </button>
           <button
             type="button"

--- a/src/features/bins/BinCreateForm.tsx
+++ b/src/features/bins/BinCreateForm.tsx
@@ -1,5 +1,5 @@
 import { Check, RefreshCw, Sparkles, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Disclosure } from '@/components/ui/disclosure';
@@ -16,6 +16,7 @@ import { AreaPicker } from '@/features/areas/AreaPicker';
 import { useAreaList } from '@/features/areas/useAreas';
 import { setCapturedPhotos, setCapturedReturnTarget } from '@/features/capture/capturedPhotos';
 import { getCommandInputRef } from '@/features/tour/TourProvider';
+import { CreditCost, visionWeight } from '@/lib/aiCreditCost';
 import { useAiEnabled } from '@/lib/aiToggle';
 import { getSecondaryColorInfo, setSecondaryColor } from '@/lib/cardStyle';
 import { aiItemsToBinItems, binItemsToPayload } from '@/lib/itemQuantities';
@@ -40,6 +41,10 @@ import { useCustomFields } from './useCustomFields';
 import { useItemEntry } from './useItemEntry';
 import { usePhotoAnalysis } from './usePhotoAnalysis';
 import { VisibilityPicker } from './VisibilityPicker';
+
+const AiCreditEstimate = __EE__
+  ? lazy(() => import('@/ee/AiCreditEstimate').then(m => ({ default: m.AiCreditEstimate })))
+  : (() => null) as React.FC<{ cost: number; className?: string }>;
 
 export interface BinCreateFormData {
   name: string;
@@ -367,19 +372,31 @@ export function BinCreateForm({
                   />
                 );
               }
+              const aiFillCost = visionWeight(photos.length);
               return (
-                <Button
-                  variant="ai"
-                  type="button"
-                  onClick={handleAnalyze}
-                  disabled={photos.length === 0}
-                  className="w-full gap-1.5 min-h-[44px]"
-                >
-                  <Sparkles className="h-4 w-4" />
-                  {photos.length > 0
-                    ? `AI Fill from ${photos.length} ${plural(photos.length, 'photo')}`
-                    : 'AI Fill'}
-                </Button>
+                <div className="flex flex-col items-center gap-1.5 w-full">
+                  <Button
+                    variant="ai"
+                    type="button"
+                    onClick={handleAnalyze}
+                    disabled={photos.length === 0}
+                    className="w-full gap-1.5 min-h-[44px]"
+                  >
+                    <Sparkles className="h-4 w-4" />
+                    {photos.length > 0
+                      ? `AI Fill from ${photos.length} ${plural(photos.length, 'photo')}`
+                      : 'AI Fill'}
+                  </Button>
+                  {photos.length > 0 && (
+                    __EE__ ? (
+                      <Suspense fallback={<CreditCost cost={aiFillCost} />}>
+                        <AiCreditEstimate cost={aiFillCost} />
+                      </Suspense>
+                    ) : (
+                      <CreditCost cost={aiFillCost} />
+                    )
+                  )}
+                </div>
               );
             }
 

--- a/src/features/bins/BinDetailToolbar.tsx
+++ b/src/features/bins/BinDetailToolbar.tsx
@@ -3,12 +3,12 @@ import { ArrowRightLeft, ChevronLeft, ChevronRight, Copy, Loader2, Lock, MoreHor
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
-import { visionWeight } from '@/lib/aiCreditCost';
+import { useCreditCostLabel, visionWeight } from '@/lib/aiCreditCost';
 import { useTerminology } from '@/lib/terminology';
 import { useClickOutside } from '@/lib/useClickOutside';
 import { useMenuKeyboard } from '@/lib/useMenuKeyboard';
 import { usePopover } from '@/lib/usePopover';
-import { cn, focusRing, pluralize } from '@/lib/utils';
+import { cn, focusRing } from '@/lib/utils';
 import type { Bin, Location } from '@/types';
 
 interface BinDetailToolbarProps {
@@ -74,7 +74,7 @@ export function BinDetailToolbar({
   const { menuRef, onKeyDown: menuKeyDown } = useMenuKeyboard(visible, close);
   const aiCost = visionWeight(analyzePhotoCount);
   const aiBaseLabel = isReanalysis ? 'Reanalyze with AI' : 'Analyze with AI';
-  const aiTipLabel = `${aiBaseLabel} · ${pluralize(aiCost, 'credit')}`;
+  const { label: aiTipLabel, compactSuffix: aiMobileSuffix } = useCreditCostLabel(aiBaseLabel, aiCost);
 
   const [editingName, setEditingName] = useState(false);
   const [nameValue, setNameValue] = useState(bin.name);
@@ -223,7 +223,7 @@ export function BinDetailToolbar({
                     {isAnalyzing ? <Loader2 className="h-4 w-4 text-[var(--text-tertiary)] animate-spin" /> : <Sparkles className="h-4 w-4 text-[var(--text-tertiary)]" />}
                     {aiBaseLabel}
                   </span>
-                  <span className="text-xs text-[var(--text-tertiary)]">{aiCost}c</span>
+                  <span className="text-xs text-[var(--text-tertiary)]">{aiCost}c{aiMobileSuffix}</span>
                 </button>
               )}
               {canPin && (

--- a/src/features/bins/DictationButton.tsx
+++ b/src/features/bins/DictationButton.tsx
@@ -4,8 +4,13 @@ import type { LabelThreshold } from '@/components/ui/ai-progress-bar';
 import { AiProgressBar } from '@/components/ui/ai-progress-bar';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
+import { useCreditCostLabel } from '@/lib/aiCreditCost';
 import type { useDictation } from '@/lib/useDictation';
 import { cn, formatElapsed } from '@/lib/utils';
+
+// Dictation chains transcribe (1 credit) + structure-text (1 credit) per
+// gesture, so the entry-point tooltip surfaces 2.
+const DICTATION_COST = 2;
 
 const TRANSCRIBE_LABELS: LabelThreshold[] = [
   [0, 'Sending audio...'],
@@ -71,15 +76,16 @@ export function DictationButton({ dictation }: DictationButtonProps) {
   }
 
   const elapsed = formatElapsed(duration);
+  const { label: dictateLabel } = useCreditCostLabel('Dictate items', DICTATION_COST);
 
   if (state === 'idle') {
     return (
-      <Tooltip content="Dictate items">
+      <Tooltip content={dictateLabel}>
         <button
           type="button"
           onClick={start}
           className="shrink-0 flex items-center justify-center size-11 rounded-[var(--radius-lg)] text-[var(--text-tertiary)] hover:bg-[var(--bg-active)] transition-colors"
-          aria-label="Dictate items"
+          aria-label={dictateLabel}
         >
           <Mic className="h-4 w-4" />
         </button>

--- a/src/features/bins/QuickAddWidget.tsx
+++ b/src/features/bins/QuickAddWidget.tsx
@@ -5,6 +5,7 @@ import { AiProgressBar } from '@/components/ui/ai-progress-bar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tooltip } from '@/components/ui/tooltip';
+import { useCreditCostLabel } from '@/lib/aiCreditCost';
 import type { useDictation } from '@/lib/useDictation';
 import { cn } from '@/lib/utils';
 import { DictationButton } from './DictationButton';
@@ -38,6 +39,7 @@ export function QuickAddWidget({ quickAdd, aiEnabled, aiGated, onUpgrade, dictat
   const isRecording = dictation?.state === 'recording';
   const isInline = variant === 'inline';
   const hasValue = quickAdd.value.trim().length > 0;
+  const { label: aiAddLabel } = useCreditCostLabel('Add with AI', 1);
   // Sub-panel padding for expanded/preview states. In `card` variant the outer
   // wrapper supplies padding; in `inline` we add it per-state to align with row inset.
   const panelClass = isInline ? 'space-y-2 px-3.5 py-2.5' : 'space-y-2';
@@ -106,12 +108,12 @@ export function QuickAddWidget({ quickAdd, aiEnabled, aiGated, onUpgrade, dictat
             </Tooltip>
           )}
           {!isRecording && (aiEnabled || aiGated) && (
-            <Tooltip content="Add with AI">
+            <Tooltip content={aiAddLabel}>
               <button
                 type="button"
                 onClick={aiGated ? onUpgrade : quickAdd.handleAiClick}
                 className="shrink-0 flex items-center justify-center size-11 rounded-[var(--radius-lg)] text-[var(--text-tertiary)] hover:bg-[var(--bg-active)] transition-colors"
-                aria-label="Add with AI"
+                aria-label={aiAddLabel}
               >
                 <Sparkles className="h-4 w-4" />
               </button>

--- a/src/features/bins/__tests__/BinCreateForm.test.tsx
+++ b/src/features/bins/__tests__/BinCreateForm.test.tsx
@@ -120,6 +120,23 @@ vi.mock('@/lib/audioRecorder', () => ({
   isRecordingSupported: () => false,
 }));
 
+vi.mock('@/lib/usePlan', () => ({
+  usePlan: () => ({
+    planInfo: {
+      plan: 'pro', status: 'active', activeUntil: null, previousSubStatus: null,
+      selfHosted: true, locked: false, features: {},
+      upgradeUrl: null, upgradePlusUrl: null, upgradeProUrl: null, portalUrl: null, subscribePlanUrl: null,
+      upgradeAction: null, upgradePlusAction: null, upgradeProAction: null, subscribePlanAction: null, portalAction: null,
+      canDowngradeToFree: false, aiCredits: null, cancelAtPeriodEnd: null, billingPeriod: null, trialPeriodDays: 7,
+    },
+    isLoading: false,
+    isPro: false, isPlus: false, isFree: false, isSelfHosted: true, isLocked: false,
+    isGated: () => false,
+    refresh: vi.fn(), usage: null, overLimits: null, isOverAnyLimit: false,
+    isLocationOverLimit: () => false, refreshUsage: vi.fn(),
+  }),
+}));
+
 vi.mock('@/lib/terminology', () => ({
   useTerminology: () => ({
     bin: 'bin', bins: 'bins', Bin: 'Bin', Bins: 'Bins',

--- a/src/features/bulk-add/GroupReviewStep.tsx
+++ b/src/features/bulk-add/GroupReviewStep.tsx
@@ -1,5 +1,5 @@
 import { ArrowUp, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Sparkles } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Disclosure } from '@/components/ui/disclosure';
 import { Input } from '@/components/ui/input';
@@ -33,6 +33,10 @@ import { cn, stickyDialogFooter } from '@/lib/utils';
 import type { AiSettings, AiSuggestions, BinItem } from '@/types';
 import { PhotoScanFrame } from './PhotoScanFrame';
 import type { BulkAddAction, Group, Photo } from './useBulkGroupAdd';
+
+const AiCreditEstimate = __EE__
+  ? lazy(() => import('@/ee/AiCreditEstimate').then(m => ({ default: m.AiCreditEstimate })))
+  : (() => null) as React.FC<{ cost: number; className?: string }>;
 
 const MAX_CORRECTIONS = 3;
 
@@ -496,7 +500,13 @@ export function GroupReviewStep({ groups, currentIndex, editingFromSummary, aiSe
                 <Sparkles className="h-4 w-4 mr-1.5" />
                 Scan with AI
               </Button>
-              <CreditCost cost={visionWeight(group.photos.length)} className="self-center" />
+              {__EE__ ? (
+                <Suspense fallback={<CreditCost cost={visionWeight(group.photos.length)} className="self-center" />}>
+                  <AiCreditEstimate cost={visionWeight(group.photos.length)} className="self-center" />
+                </Suspense>
+              ) : (
+                <CreditCost cost={visionWeight(group.photos.length)} className="self-center" />
+              )}
               <button
                 type="button"
                 onClick={() => setRetryBandDismissed(true)}
@@ -566,6 +576,15 @@ export function GroupReviewStep({ groups, currentIndex, editingFromSummary, aiSe
                     </button>
                   )}
                 </div>
+              )}
+              {group.correctionCount < MAX_CORRECTIONS && (
+                __EE__ ? (
+                  <Suspense fallback={<CreditCost cost={correctionText.trim() ? 1 : visionWeight(group.photos.length)} className="self-start" />}>
+                    <AiCreditEstimate cost={correctionText.trim() ? 1 : visionWeight(group.photos.length)} className="self-start" />
+                  </Suspense>
+                ) : (
+                  <CreditCost cost={correctionText.trim() ? 1 : visionWeight(group.photos.length)} className="self-start" />
+                )
               )}
             </div>
           )}

--- a/src/features/reorganize/ReorganizePage.tsx
+++ b/src/features/reorganize/ReorganizePage.tsx
@@ -588,7 +588,7 @@ export function ReorganizePage() {
               Suggest tags for {selection.selectedIds.size} {selection.selectedIds.size === 1 ? t.bin : t.bins}
             </Button>
           )}
-          {selection.selectedIds.size >= 2 && !overCap && (
+          {selection.selectedIds.size >= (mode === 'bins' ? 2 : 1) && !overCap && (
             <div className="text-[12px] text-[var(--text-tertiary)] text-center -mt-2 flex flex-col items-center gap-0.5">
               <span>
                 {itemCount} item{itemCount !== 1 ? 's' : ''} across {selection.selectedIds.size} {t.bins}

--- a/src/lib/__tests__/aiCreditCost.test.tsx
+++ b/src/lib/__tests__/aiCreditCost.test.tsx
@@ -1,6 +1,10 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { CreditCost, reorganizeWeight, visionWeight } from '../aiCreditCost';
+import { render, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../usePlan', () => ({ usePlan: vi.fn() }));
+
+import { CreditCost, computeCreditEstimate, formatCreditCompactSuffix, formatCreditSuffix, reorganizeWeight, useCreditCostLabel, visionWeight } from '../aiCreditCost';
+import { usePlan } from '../usePlan';
 
 describe('visionWeight (client mirror)', () => {
   it('charges 5 credits for 1 image', () => {
@@ -55,5 +59,134 @@ describe('<CreditCost>', () => {
     const { container } = render(<CreditCost cost={5} className="ml-2" />);
     const el = container.firstChild as HTMLElement | null;
     expect(el?.className).toContain('ml-2');
+  });
+});
+
+describe('computeCreditEstimate', () => {
+  it('returns null when cost is 0', () => {
+    expect(computeCreditEstimate(0, { used: 10, limit: 100, resetsAt: 'x' }, 'active')).toBeNull();
+  });
+
+  it('returns null when aiCredits is null (self-host)', () => {
+    expect(computeCreditEstimate(5, null, 'active')).toBeNull();
+  });
+
+  it('returns null when limit is 0 (Pro unlimited or Free no-AI)', () => {
+    expect(computeCreditEstimate(5, { used: 10, limit: 0, resetsAt: null }, 'active')).toBeNull();
+  });
+
+  it('computes percent of limit for an active plan', () => {
+    const e = computeCreditEstimate(24, { used: 10, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(e?.percent).toBe(24);
+    expect(e?.projected).toBe(34);
+    expect(e?.tone).toBe('neutral');
+    expect(e?.overLimit).toBe(false);
+    expect(e?.isTrial).toBe(false);
+  });
+
+  it('caps percent at 100 when single cost exceeds limit', () => {
+    const e = computeCreditEstimate(150, { used: 0, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(e?.percent).toBe(100);
+    expect(e?.overLimit).toBe(true);
+    expect(e?.tone).toBe('red');
+  });
+
+  it('flags trial when status is trial', () => {
+    const e = computeCreditEstimate(10, { used: 0, limit: 75, resetsAt: '2026-06-01' }, 'trial');
+    expect(e?.isTrial).toBe(true);
+  });
+
+  it('flags trial when resetsAt is null even with active status', () => {
+    const e = computeCreditEstimate(10, { used: 0, limit: 75, resetsAt: null }, 'active');
+    expect(e?.isTrial).toBe(true);
+  });
+
+  it('returns amber tone when projected use is past 80% but not over the limit', () => {
+    const e = computeCreditEstimate(5, { used: 80, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(e?.tone).toBe('amber');
+    expect(e?.overLimit).toBe(false);
+  });
+
+  it('returns red tone and overLimit when projected exceeds limit', () => {
+    const e = computeCreditEstimate(20, { used: 95, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(e?.tone).toBe('red');
+    expect(e?.overLimit).toBe(true);
+  });
+
+  it('stays neutral exactly at the 80% threshold', () => {
+    // projected = 80, limit = 100. Test uses strict-greater-than for the
+    // amber edge — at 80 exactly, tone is neutral.
+    const e = computeCreditEstimate(40, { used: 40, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(e?.tone).toBe('neutral');
+  });
+});
+
+describe('formatCreditSuffix', () => {
+  it('returns empty string for null estimate (self-host fallback)', () => {
+    expect(formatCreditSuffix(null)).toBe('');
+  });
+
+  it('returns parenthesized percent for normal estimate', () => {
+    const e = computeCreditEstimate(24, { used: 0, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(formatCreditSuffix(e)).toBe(' (24%)');
+  });
+
+  it('returns "would exceed monthly limit" for over-limit, non-trial', () => {
+    const e = computeCreditEstimate(50, { used: 90, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(formatCreditSuffix(e)).toBe(' (would exceed monthly limit)');
+  });
+
+  it('returns "would exceed trial credits" for over-limit on trial', () => {
+    const e = computeCreditEstimate(20, { used: 70, limit: 75, resetsAt: null }, 'trial');
+    expect(formatCreditSuffix(e)).toBe(' (would exceed trial credits)');
+  });
+});
+
+describe('formatCreditCompactSuffix', () => {
+  it('returns empty string for null estimate', () => {
+    expect(formatCreditCompactSuffix(null)).toBe('');
+  });
+
+  it('returns " · X%" for normal estimate', () => {
+    const e = computeCreditEstimate(24, { used: 0, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(formatCreditCompactSuffix(e)).toBe(' · 24%');
+  });
+
+  it('returns " · over" for over-limit estimate', () => {
+    const e = computeCreditEstimate(50, { used: 90, limit: 100, resetsAt: '2026-06-01' }, 'active');
+    expect(formatCreditCompactSuffix(e)).toBe(' · over');
+  });
+});
+
+describe('useCreditCostLabel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupPlan(aiCredits: { used: number; limit: number; resetsAt: string | null } | null, status: 'active' | 'trial' | 'inactive' = 'active') {
+    vi.mocked(usePlan).mockReturnValue({
+      planInfo: { aiCredits, status } as never,
+    } as never);
+  }
+
+  it('composes label and compactSuffix from plan info', () => {
+    setupPlan({ used: 10, limit: 100, resetsAt: '2026-06-01' });
+    const { result } = renderHook(() => useCreditCostLabel('Reanalyze with AI', 5));
+    expect(result.current.label).toBe('Reanalyze with AI · 5 credits (5%)');
+    expect(result.current.compactSuffix).toBe(' · 5%');
+  });
+
+  it('omits the percent when aiCredits is null (self-host)', () => {
+    setupPlan(null);
+    const { result } = renderHook(() => useCreditCostLabel('Voice input', 1));
+    expect(result.current.label).toBe('Voice input · 1 credit');
+    expect(result.current.compactSuffix).toBe('');
+  });
+
+  it('renders "would exceed" copy when projected exceeds limit', () => {
+    setupPlan({ used: 95, limit: 100, resetsAt: '2026-06-01' });
+    const { result } = renderHook(() => useCreditCostLabel('Reorganize', 20));
+    expect(result.current.label).toBe('Reorganize · 20 credits (would exceed monthly limit)');
+    expect(result.current.compactSuffix).toBe(' · over');
   });
 });

--- a/src/lib/aiCreditCost.tsx
+++ b/src/lib/aiCreditCost.tsx
@@ -1,3 +1,6 @@
+import type { ProgressTone } from '@/components/ui/progress-bar';
+import type { PlanInfo, SubscriptionStatus } from '@/types';
+import { usePlan } from './usePlan';
 import { cn, pluralize } from './utils';
 
 // Mirror of the server-side weights. Kept as a small duplicate (instead
@@ -17,6 +20,74 @@ export function visionWeight(imageCount: number): number {
 export function reorganizeWeight(binCount: number): number {
   const n = Math.max(0, Math.ceil(binCount));
   return PER_BIN * n;
+}
+
+export type CreditTone = ProgressTone;
+
+export interface CreditEstimate {
+  percent: number;
+  projected: number;
+  overLimit: boolean;
+  tone: CreditTone;
+  isTrial: boolean;
+}
+
+/** Pure math: derive the percent / threshold tone for a cost against the
+ *  user's current `aiCredits` snapshot. Returns null when there is no
+ *  meaningful limit to compare against (self-host, Pro/unlimited, Free
+ *  with no AI), which lets callers fall back to plain "Uses N credits"
+ *  copy. The display itself is cloud-only, but the arithmetic is data
+ *  transformation — no cloud business logic. */
+export function computeCreditEstimate(
+  cost: number,
+  aiCredits: PlanInfo['aiCredits'],
+  status: SubscriptionStatus,
+): CreditEstimate | null {
+  if (cost <= 0) return null;
+  if (!aiCredits || aiCredits.limit <= 0) return null;
+
+  const { used, limit, resetsAt } = aiCredits;
+  const projected = used + cost;
+  const percent = Math.min(100, Math.round((cost / limit) * 100));
+  const overLimit = projected > limit;
+  const nearLimit = !overLimit && projected > limit * 0.8;
+  const tone: CreditTone = overLimit ? 'red' : nearLimit ? 'amber' : 'neutral';
+  // Plus trials have no monthly reset, so `resetsAt` stays null even when
+  // limit > 0. Either signal flips the copy to "trial credits".
+  const isTrial = status === 'trial' || resetsAt === null;
+
+  return { percent, projected, overLimit, tone, isTrial };
+}
+
+/** Inline tooltip suffix: ` (12%)` or ` (would exceed monthly limit)`.
+ *  Returns '' when there's no estimate to surface, so callers can
+ *  unconditionally concat without an extra null check. */
+export function formatCreditSuffix(estimate: CreditEstimate | null): string {
+  if (!estimate) return '';
+  if (estimate.overLimit) {
+    return ` (would exceed ${estimate.isTrial ? 'trial credits' : 'monthly limit'})`;
+  }
+  return ` (${estimate.percent}%)`;
+}
+
+/** Compact mobile suffix: ` · 12%` or ` · over`. */
+export function formatCreditCompactSuffix(estimate: CreditEstimate | null): string {
+  if (!estimate) return '';
+  return estimate.overLimit ? ' · over' : ` · ${estimate.percent}%`;
+}
+
+/** Compose a "${baseLabel} · N credits (X%)" tooltip label plus a
+ *  compact mobile suffix from the user's current plan info. Self-host
+ *  has `aiCredits === null` and unlimited plans have `limit === 0`, so
+ *  `computeCreditEstimate` returns null and the suffixes collapse to ''
+ *  — the label degrades to "baseLabel · N credits" without a gate. */
+export function useCreditCostLabel(baseLabel: string, cost: number): { label: string; compactSuffix: string } {
+  const { planInfo } = usePlan();
+  const estimate = computeCreditEstimate(cost, planInfo.aiCredits, planInfo.status);
+  return {
+    label: `${baseLabel} · ${pluralize(cost, 'credit')}${formatCreditSuffix(estimate)}`,
+    compactSuffix: formatCreditCompactSuffix(estimate),
+  };
 }
 
 interface CreditCostProps {


### PR DESCRIPTION
## Summary
- **CSP**: production was logging a CSP violation on every pageload because the Cloudflare Web Analytics beacon (`static.cloudflareinsights.com` script + `cloudflareinsights.com` reporting endpoint) wasn't in `script-src` / `connect-src`. Added both, and hoisted CSP construction out of the per-request middleware since it only depends on config.
- **AI credit estimates**: every AI-action affordance now shows "Uses N credits (X%)" before the user commits. Lifted `computeCreditEstimate` / `formatCreditSuffix` / `useCreditCostLabel` from `src/ee/AiCreditEstimate.tsx` into shared `src/lib/aiCreditCost.tsx` so non-EE / self-host builds get the math too — EE keeps the colored variant (neutral / amber >80% / red over-limit), non-EE collapses to plain text.
- **Default-role toggle discoverability**: the location settings "Data Retention" menu item also contains the `default_join_role` toggle. Renamed to "Retention & Roles" so admins can find it without opening the dialog speculatively.

Affordances wired to credit estimates: BinCreateForm AI Fill, BinDetailToolbar Reanalyze, DictationButton, ConversationComposer, TranscriptionMicButton, QuickAddWidget AI-add, GroupReviewStep, ReorganizePage.

## Test plan
- [ ] `npx biome check .`
- [ ] `npx tsc --noEmit`
- [ ] `npx vitest run` (covers new `aiCreditCost.test.tsx` math + `BinCreateForm.test.tsx` updates)
- [ ] `cd server && npx vitest run` (covers new `securityHeaders.test.ts` CSP pin + register-with-invite default_join_role regression)
- [ ] `cd server && npx tsc --noEmit`
- [ ] Manual: load production-built page, confirm no CSP violations in console; Cloudflare beacon loads
- [ ] Manual: location settings menu shows "Retention & Roles"; toggle persists default_join_role
- [ ] Manual (EE build): AI buttons show credit suffix; turns amber >80%, red when over limit
- [ ] Manual (non-EE build): AI buttons show plain "Uses N credits" suffix