### PR TITLE
fix: unblock planGating server tests via mockable feature lookup

### DIFF
--- a/server/src/lib/planGate.ts
+++ b/server/src/lib/planGate.ts
@@ -139,7 +139,7 @@ const UNRESTRICTED: PlanFeatures = {
 };
 
 export function getFeatureMap(plan: PlanTier): PlanFeatures {
-  if (config.selfHosted) return UNRESTRICTED;
+  if (isSelfHosted()) return UNRESTRICTED;
   const pl = config.planLimits;
   if (plan === Plan.PRO) {
     return {

--- a/server/src/middleware/requirePlan.ts
+++ b/server/src/middleware/requirePlan.ts
@@ -7,7 +7,7 @@ import {
   checkAndIncrementAiCredits,
   generateUpgradeAction,
   generateUpgradePlanAction,
-  getFeatureMap,
+  getUserFeatures,
   getUserPlanInfo,
   hasAiAccess,
   isPlusOrAbove,
@@ -119,7 +119,7 @@ export function requireExportAccess(): RequestHandler {
       throw new PlanRestrictedError('Export is not available during your trial. Subscribe to export your data.', u.url, u.action);
     }
 
-    if (getFeatureMap(planInfo.plan).fullExport) { next(); return; }
+    if ((await getUserFeatures(userId)).fullExport) { next(); return; }
 
     const u = actionAndUrl(await generateUpgradeAction(userId, planInfo.email));
     throw new PlanRestrictedError('Export requires a Plus or Pro plan', u.url, u.action);


### PR DESCRIPTION
## Summary
- `server/src/__tests__/planGating.test.ts` mocks `isSelfHosted()` and `getUserFeatures()` to simulate cloud users, but two paths bypassed those mocks: `getFeatureMap()` read `config.selfHosted` directly, and `requireExportAccess()` (added in 3559a3ec) called `getFeatureMap(planInfo.plan).fullExport`, which is not mocked. With `SELF_HOSTED` defaulting to `true` in test setup, the cloud-FREE export tests returned 200 instead of 403 PLAN_RESTRICTED — failing on `main` since 777c87b3.
- Switch `getFeatureMap` to call `isSelfHosted()` (the existing wrapper at `planGate.ts:54`) so it matches the rest of the file, and route the export feature check through `getUserFeatures(userId)` — the function the test mocks and the original middleware used before 3559a3ec. Trial check is preserved.
- Net change: 3 lines across 2 files. No behavioural change for production code paths (free plan still has `fullExport: false` via either lookup); test suite is now mockable end-to-end.

## Test plan
- [x] `cd server && npx vitest run src/__tests__/planGating.test.ts` — all 18 tests pass (was 16/18 on main)
- [x] `cd server && npx vitest run src/__tests__/planGate.test.ts src/__tests__/requirePlan.test.ts src/__tests__/planGating.test.ts` — 95/95 pass
- [x] `cd server && npx vitest run` — full server suite passes
- [x] `npx biome check server/src/lib/planGate.ts server/src/middleware/requirePlan.ts` — clean