### PR TITLE
fix: server locations import path + tour anchor test

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -46,7 +46,7 @@ import exportRoutes from './routes/export/index.js';
 import { internalRoutes } from './routes/internal.js';
 import itemCheckoutsRoutes, { locationCheckoutsRouter as locationCheckoutsRoutes } from './routes/itemCheckouts.js';
 import itemsRoutes from './routes/items/index.js';
-import locationsRoutes from './routes/locations.js';
+import locationsRoutes from './routes/locations/index.js';
 import photosRoutes from './routes/photos.js';
 import { planRoutes } from './routes/plan.js';
 import printSettingsRoutes from './routes/printSettings.js';

--- a/src/features/tour/__tests__/tourRegistry.test.ts
+++ b/src/features/tour/__tests__/tourRegistry.test.ts
@@ -90,8 +90,17 @@ describe('tour registry', () => {
     const fileContents: string[] = allFiles
       .filter((f) => !f.includes('/features/tour/tours/'))
       .map((f) => fs.readFileSync(f, 'utf8'));
+    // Accept either a literal data-tour="X" attribute or a forwarded
+    // dataTour="X" JSX prop — components like ShutterButton bind data-tour
+    // dynamically from a prop, so the literal attribute string is absent
+    // from the leaf source even though the runtime DOM has it.
     const missing = [...selectors].filter(
-      (sel) => !fileContents.some((content) => content.includes(`data-tour="${sel}"`)),
+      (sel) =>
+        !fileContents.some(
+          (content) =>
+            content.includes(`data-tour="${sel}"`) ||
+            content.includes(`dataTour="${sel}"`),
+        ),
     );
     expect(missing, `missing data-tour anchors: ${missing.join(', ')}`).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Two fixes that should have shipped with the route-split PR but slipped through:

1. **server/src/index.ts** — was importing \`./routes/locations.js\`, but the locations split renamed that file to \`./routes/locations/index.ts\`. The mismatch broke \`server/npm run build\` (and therefore the docker-publish workflow). The CI/CD workflow on the PR only runs \`tsc --noEmit\`, which apparently didn't catch this — \`npm run build\` runs \`tsc\` (without \`--noEmit\`) and emits, which surfaces the missing module differently. Update the import to match the other split routers.

2. **tour anchor test** — \`tourRegistry.test.ts\` was scanning sources for literal \`data-tour="X"\` attributes, but \`ShutterButton\` attaches the \`data-tour\` anchor dynamically from a forwarded \`dataTour\` prop (introduced by an earlier CapturePage decomposition). Accept either pattern.

## Test plan

- [x] \`cd server && npx tsc --noEmit\` — clean
- [x] \`cd server && npm run build\` — clean (this is what the docker-publish step runs)
- [x] \`npx vitest run src/features/tour/__tests__/tourRegistry.test.ts\` — 19/19 pass
- [ ] CI/CD on PR
- [ ] docker-publish on merge to main