### PR TITLE
fix: address ultrareview findings on AI query planner

### DIFF
--- a/server/src/lib/__tests__/inventoryMatch.test.ts
+++ b/server/src/lib/__tests__/inventoryMatch.test.ts
@@ -41,6 +41,15 @@ describe('simplePluralStem', () => {
     expect(simplePluralStem('places')).toBe('place');
     expect(simplePluralStem('dices')).toBe('dice');
   });
+  it('short -ies words (4 chars) fall through to plain-s strip, not ies→y', () => {
+    expect(simplePluralStem('ties')).toBe('tie');
+    expect(simplePluralStem('lies')).toBe('lie');
+    expect(simplePluralStem('pies')).toBe('pie');
+  });
+  it('longer -ies words still stem correctly', () => {
+    expect(simplePluralStem('cherries')).toBe('cherry');
+    expect(simplePluralStem('batteries')).toBe('battery');
+  });
 });
 
 describe('normalizeForCompare', () => {

--- a/server/src/lib/__tests__/inventoryMatcher.test.ts
+++ b/server/src/lib/__tests__/inventoryMatcher.test.ts
@@ -147,6 +147,53 @@ describe('findTrashedMatches', () => {
   });
 });
 
+describe('findLiteralMatches — punctuation normalization', () => {
+  it("matches bin with apostrophe in name via query without apostrophe", async () => {
+    const s = await setup();
+    await createTestBin(app, s.token, s.locationId, { name: "Tom's Tools" });
+
+    const got = await findLiteralMatches(s.locationId, s.userId, ["Tom's tools"]);
+    expect(got.map((b) => b.name)).toContain("Tom's Tools");
+  });
+
+  it('matches bin with hyphen in name via query without hyphen', async () => {
+    const s = await setup();
+    await createTestBin(app, s.token, s.locationId, { name: 'AA-Batteries' });
+
+    const got = await findLiteralMatches(s.locationId, s.userId, ['AA batteries']);
+    expect(got.map((b) => b.name)).toContain('AA-Batteries');
+  });
+
+  it('matches bin with hash in name via query term without hash', async () => {
+    const s = await setup();
+    await createTestBin(app, s.token, s.locationId, { name: 'Phillips #2 Screwdriver' });
+
+    const got = await findLiteralMatches(s.locationId, s.userId, ['phillips', 'screwdriver']);
+    expect(got.map((b) => b.name)).toContain('Phillips #2 Screwdriver');
+  });
+});
+
+describe('findLiteralMatches — fields SQL filter', () => {
+  it('restricts to tag-only matches in SQL (not post-filtered after LIMIT)', async () => {
+    const s = await setup();
+    for (let i = 0; i < 35; i++) {
+      await createTestBin(app, s.token, s.locationId, { name: `Tools Bin ${i}` });
+    }
+    await createTestBin(app, s.token, s.locationId, { name: 'Other', tags: ['tools'] });
+    await createTestBin(app, s.token, s.locationId, { name: 'Another', tags: ['tools'] });
+    await createTestBin(app, s.token, s.locationId, { name: 'Third', tags: ['tools'] });
+
+    const got = await findLiteralMatches(s.locationId, s.userId, ['tools'], { fields: ['tag'] });
+    const names = got.map((b) => b.name);
+    expect(names).toContain('Other');
+    expect(names).toContain('Another');
+    expect(names).toContain('Third');
+    for (const name of names) {
+      expect(name).not.toMatch(/^Tools Bin \d+$/);
+    }
+  });
+});
+
 describe('findNearMissBins', () => {
   it('returns bins whose name fuzzy-matches when no literal hit exists', async () => {
     const s = await setup();

--- a/server/src/lib/__tests__/plannerSchemaContext.test.ts
+++ b/server/src/lib/__tests__/plannerSchemaContext.test.ts
@@ -1,6 +1,6 @@
 import type { Express } from 'express';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createTestArea, createTestBin, createTestLocation, createTestUser } from '../../__tests__/helpers.js';
+import { createTestArea, createTestBin, createTestLocation, createTestUser, joinTestLocation } from '../../__tests__/helpers.js';
 import { createApp } from '../../index.js';
 import { buildPlannerSchemaContext } from '../aiContext.js';
 
@@ -9,23 +9,45 @@ beforeEach(() => { app = createApp(); });
 
 describe('buildPlannerSchemaContext', () => {
   it('returns the tags and areas in the location', async () => {
-    const { token } = await createTestUser(app);
+    const { token, user } = await createTestUser(app);
     const loc = await createTestLocation(app, token);
     await createTestArea(app, token, loc.id, 'Garage');
     await createTestArea(app, token, loc.id, 'Kitchen');
     await createTestBin(app, token, loc.id, { name: 'Tools', tags: ['tools', 'metal'] });
     await createTestBin(app, token, loc.id, { name: 'Snacks', tags: ['food'] });
 
-    const schema = await buildPlannerSchemaContext(loc.id);
+    const schema = await buildPlannerSchemaContext(loc.id, user.id);
     expect(schema.tags.sort()).toEqual(['food', 'metal', 'tools']);
     expect(schema.areas.sort()).toEqual(['Garage', 'Kitchen']);
   });
 
   it('returns empty arrays when the location is empty', async () => {
-    const { token } = await createTestUser(app);
+    const { token, user } = await createTestUser(app);
     const loc = await createTestLocation(app, token);
-    const schema = await buildPlannerSchemaContext(loc.id);
+    const schema = await buildPlannerSchemaContext(loc.id, user.id);
     expect(schema.tags).toEqual([]);
     expect(schema.areas).toEqual([]);
+  });
+
+  it("does not expose User A's private-bin tags to User B", async () => {
+    const userA = await createTestUser(app);
+    const loc = await createTestLocation(app, userA.token);
+    const userB = await createTestUser(app);
+    await joinTestLocation(app, userB.token, loc.invite_code);
+
+    await createTestBin(app, userA.token, loc.id, {
+      name: 'Secret Stash',
+      visibility: 'private',
+      tags: ['private-tag-only-a'],
+    });
+    await createTestBin(app, userA.token, loc.id, {
+      name: 'Shared Box',
+      visibility: 'location',
+      tags: ['shared-tag'],
+    });
+
+    const schemaForB = await buildPlannerSchemaContext(loc.id, userB.user.id);
+    expect(schemaForB.tags).not.toContain('private-tag-only-a');
+    expect(schemaForB.tags).toContain('shared-tag');
   });
 });

--- a/server/src/lib/__tests__/queryPlan.test.ts
+++ b/server/src/lib/__tests__/queryPlan.test.ts
@@ -95,9 +95,11 @@ describe('buildPlannerSystemPrompt', () => {
     expect(p).toMatch(/never (invent|guess|emit)|do not invent/i);
   });
 
-  it('honors a user-supplied custom prompt as a prefix', () => {
+  it('appends user-supplied custom prompt as additional guidance (never replaces planner instructions)', () => {
     const p = buildPlannerSystemPrompt('Be concise.');
     expect(p).toContain('Be concise.');
+    expect(p).toMatch(/metadata|content|refusal/i);
+    expect(p).toContain('ADDITIONAL USER GUIDANCE');
   });
 });
 

--- a/server/src/lib/__tests__/queryPlanExecutor.test.ts
+++ b/server/src/lib/__tests__/queryPlanExecutor.test.ts
@@ -155,3 +155,40 @@ describe('executeQueryPlan — scope', () => {
     expect(result.matches.map((m) => m.name)).toEqual(['Battery A']);
   });
 });
+
+describe('executeQueryPlan — pre-filter limits (merged_bug_004)', () => {
+  it('fields=tag filter is applied in SQL before LIMIT so tagged bins beyond position 30 are still found', async () => {
+    const s = await setup();
+    for (let i = 0; i < 40; i++) {
+      await createTestBin(app, s.token, s.locationId, { name: `Tools Bin ${i}` });
+    }
+    const taggedA = await createTestBin(app, s.token, s.locationId, { name: 'Tagged A', tags: ['tools'] });
+    const taggedB = await createTestBin(app, s.token, s.locationId, { name: 'Tagged B', tags: ['tools'] });
+    const taggedC = await createTestBin(app, s.token, s.locationId, { name: 'Tagged C', tags: ['tools'] });
+
+    const result = await executeQueryPlan(
+      { kind: 'content', terms: ['tools'], fields: ['tag'], answer: 'Here.' },
+      s.locationId,
+      s.userId,
+    );
+    const names = result.matches.map((m) => m.name);
+    expect(names).toContain(taggedA.name);
+    expect(names).toContain(taggedB.name);
+    expect(names).toContain(taggedC.name);
+    for (const name of names) {
+      expect(name).not.toMatch(/^Tools Bin \d+$/);
+    }
+  });
+
+  it('includes total_item_count in hydrated matches', async () => {
+    const s = await setup();
+    await createTestBin(app, s.token, s.locationId, { name: 'Multi', items: ['A', 'B', 'C'] });
+
+    const result = await executeQueryPlan(
+      { kind: 'content', terms: ['multi'], answer: 'Here.' },
+      s.locationId,
+      s.userId,
+    );
+    expect(result.matches[0].total_item_count).toBe(3);
+  });
+});

--- a/server/src/lib/aiContext.ts
+++ b/server/src/lib/aiContext.ts
@@ -294,15 +294,16 @@ export async function buildInventoryContext(locationId: string, userId: string, 
  * area names in the location. Does NOT load bins (the planner doesn't
  * need them; it emits a search plan that the matcher executes).
  */
-export async function buildPlannerSchemaContext(locationId: string): Promise<{ tags: string[]; areas: string[] }> {
+export async function buildPlannerSchemaContext(locationId: string, userId: string): Promise<{ tags: string[]; areas: string[] }> {
   const [tagsResult, areasResult] = await Promise.all([
     query<{ value: string }>(
       `SELECT DISTINCT te.value AS value
        FROM bins b, ${d.jsonEachFrom('b.tags', 'te')}
        WHERE b.location_id = $1 AND b.deleted_at IS NULL
+         AND (b.visibility = 'location' OR b.created_by = $2)
        ORDER BY te.value
        LIMIT 200`,
-      [locationId],
+      [locationId, userId],
     ),
     query<{ name: string }>(
       'SELECT name FROM areas WHERE location_id = $1 ORDER BY name LIMIT 100',

--- a/server/src/lib/inventoryMatch.ts
+++ b/server/src/lib/inventoryMatch.ts
@@ -21,7 +21,7 @@ export function normalizeForMatch(s: string): string {
  */
 export function simplePluralStem(word: string): string {
   const w = word.toLowerCase();
-  if (w.length >= 4 && w.endsWith('ies')) return `${w.slice(0, -3)}y`;
+  if (w.length >= 5 && w.endsWith('ies')) return `${w.slice(0, -3)}y`;
   // Strip 'es' (2 chars) only for sibilant-stem plurals (boxes, foxes, buzzes).
   // Words like 'cables' are stem-ends-in-e + s; the plain-s rule handles those.
   // Sibilants that require 'es' in English: x, z, s (non-ss already filtered), ch, sh.

--- a/server/src/lib/inventoryMatcher.ts
+++ b/server/src/lib/inventoryMatcher.ts
@@ -1,6 +1,10 @@
 import { d, query } from '../db.js';
 import { buildSearchProbes, normalizeForCompare } from './inventoryMatch.js';
 
+function sqlNormalizeName(col: string): string {
+  return `LOWER(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(${col}, '-', ' '), '''', ' '), '/', ' '), '&', ' '), '#', ' '), '.', ' '), ',', ' '), ':', ' '))`;
+}
+
 export interface CandidateBin {
   bin_id: string;
   bin_code: string;
@@ -89,13 +93,33 @@ function rowToCandidate(r: RawRow, hint: string): CandidateBin {
   };
 }
 
+function buildScopeClause(params: unknown[], scopedBinIds: string[] | undefined): string {
+  if (!scopedBinIds || scopedBinIds.length === 0) return '';
+  const placeholders = scopedBinIds.map((id) => {
+    params.push(id);
+    return `$${params.length}`;
+  });
+  return `AND b.id IN (${placeholders.join(', ')})`;
+}
+
+export interface LiteralMatchOpts {
+  scopedBinIds?: string[];
+  fields?: string[];
+}
+
 export async function findLiteralMatches(
   locationId: string,
   userId: string,
   terms: string[],
+  opts: LiteralMatchOpts = {},
 ): Promise<CandidateBin[]> {
   const probes = buildSearchProbes(terms);
   if (probes.length === 0) return [];
+
+  const { scopedBinIds, fields } = opts;
+  const wantsName = !fields || fields.length === 0 || fields.includes('name');
+  const wantsTag = !fields || fields.length === 0 || fields.includes('tag');
+  const wantsItem = !fields || fields.length === 0 || fields.includes('item');
 
   const params: unknown[] = [locationId, userId];
   const orClauses: string[] = [];
@@ -104,12 +128,25 @@ export async function findLiteralMatches(
     const like = `%${probe.replace(/[%_\\]/g, (c) => `\\${c}`)}%`;
     const idx = params.length + 1;
     params.push(like);
-    orClauses.push(
-      `LOWER(b.name) LIKE $${idx} ESCAPE '\\' ` +
-      `OR EXISTS (SELECT 1 FROM ${d.jsonEachFrom('b.tags', 'te')} WHERE LOWER(te.value) LIKE $${idx} ESCAPE '\\') ` +
-      `OR EXISTS (SELECT 1 FROM bin_items bi WHERE bi.bin_id = b.id AND bi.deleted_at IS NULL AND LOWER(bi.name) LIKE $${idx} ESCAPE '\\')`,
-    );
+
+    const fieldClauses: string[] = [];
+    if (wantsName) {
+      fieldClauses.push(`${sqlNormalizeName('b.name')} LIKE $${idx} ESCAPE '\\'`);
+    }
+    if (wantsTag) {
+      fieldClauses.push(`EXISTS (SELECT 1 FROM ${d.jsonEachFrom('b.tags', 'te')} WHERE ${sqlNormalizeName('te.value')} LIKE $${idx} ESCAPE '\\')`);
+    }
+    if (wantsItem) {
+      fieldClauses.push(`EXISTS (SELECT 1 FROM bin_items bi WHERE bi.bin_id = b.id AND bi.deleted_at IS NULL AND ${sqlNormalizeName('bi.name')} LIKE $${idx} ESCAPE '\\')`);
+    }
+    if (fieldClauses.length > 0) {
+      orClauses.push(`(${fieldClauses.join(' OR ')})`);
+    }
   }
+
+  if (orClauses.length === 0) return [];
+
+  const scopeClause = buildScopeClause(params, scopedBinIds);
 
   const sql = `
     SELECT ${candidateSelect()}
@@ -117,6 +154,7 @@ export async function findLiteralMatches(
     WHERE b.location_id = $1
       AND b.deleted_at IS NULL
       AND ${VISIBILITY_FILTER}
+      ${scopeClause}
       AND (${orClauses.join(' OR ')})
     ORDER BY b.updated_at DESC
     LIMIT ${MAX_CANDIDATES}
@@ -144,7 +182,13 @@ function describeMatchHint(c: CandidateBin, stems: string[]): string {
   return 'matches query';
 }
 
-export async function findPinnedMatches(locationId: string, userId: string): Promise<CandidateBin[]> {
+export interface ScopeOpts {
+  scopedBinIds?: string[];
+}
+
+export async function findPinnedMatches(locationId: string, userId: string, opts: ScopeOpts = {}): Promise<CandidateBin[]> {
+  const params: unknown[] = [locationId, userId];
+  const scopeClause = buildScopeClause(params, opts.scopedBinIds);
   // Reuses the `pb` LEFT JOIN already in CANDIDATE_FROM — filter on it
   // instead of joining the same table again.
   const sql = `
@@ -153,15 +197,18 @@ export async function findPinnedMatches(locationId: string, userId: string): Pro
     WHERE b.location_id = $1
       AND b.deleted_at IS NULL
       AND ${VISIBILITY_FILTER}
+      ${scopeClause}
       AND pb.user_id IS NOT NULL
     ORDER BY pb.position
     LIMIT ${MAX_CANDIDATES}
   `;
-  const result = await query<RawRow>(sql, [locationId, userId]);
+  const result = await query<RawRow>(sql, params);
   return result.rows.map((r) => rowToCandidate(r, 'pinned'));
 }
 
-export async function findPrivateMatches(locationId: string, userId: string): Promise<CandidateBin[]> {
+export async function findPrivateMatches(locationId: string, userId: string, opts: ScopeOpts = {}): Promise<CandidateBin[]> {
+  const params: unknown[] = [locationId, userId];
+  const scopeClause = buildScopeClause(params, opts.scopedBinIds);
   const sql = `
     SELECT ${candidateSelect()}
     FROM ${CANDIDATE_FROM}
@@ -169,20 +216,24 @@ export async function findPrivateMatches(locationId: string, userId: string): Pr
       AND b.deleted_at IS NULL
       AND b.visibility = 'private'
       AND b.created_by = $2
+      ${scopeClause}
     ORDER BY b.updated_at DESC
     LIMIT ${MAX_CANDIDATES}
   `;
-  const result = await query<RawRow>(sql, [locationId, userId]);
+  const result = await query<RawRow>(sql, params);
   return result.rows.map((r) => rowToCandidate(r, 'private'));
 }
 
-export async function findCheckedOutMatches(locationId: string, userId: string): Promise<CandidateBin[]> {
+export async function findCheckedOutMatches(locationId: string, userId: string, opts: ScopeOpts = {}): Promise<CandidateBin[]> {
+  const params: unknown[] = [locationId, userId];
+  const scopeClause = buildScopeClause(params, opts.scopedBinIds);
   const sql = `
     SELECT ${candidateSelect()}
     FROM ${CANDIDATE_FROM}
     WHERE b.location_id = $1
       AND b.deleted_at IS NULL
       AND ${VISIBILITY_FILTER}
+      ${scopeClause}
       AND EXISTS (
         SELECT 1 FROM item_checkouts ic
         WHERE ic.origin_bin_id = b.id AND ic.returned_at IS NULL
@@ -190,21 +241,24 @@ export async function findCheckedOutMatches(locationId: string, userId: string):
     ORDER BY b.updated_at DESC
     LIMIT ${MAX_CANDIDATES}
   `;
-  const result = await query<RawRow>(sql, [locationId, userId]);
+  const result = await query<RawRow>(sql, params);
   return result.rows.map((r) => rowToCandidate(r, 'has checked-out items'));
 }
 
-export async function findTrashedMatches(locationId: string, userId: string): Promise<CandidateBin[]> {
+export async function findTrashedMatches(locationId: string, userId: string, opts: ScopeOpts = {}): Promise<CandidateBin[]> {
+  const params: unknown[] = [locationId, userId];
+  const scopeClause = buildScopeClause(params, opts.scopedBinIds);
   const sql = `
     SELECT ${candidateSelect()}
     FROM ${CANDIDATE_FROM}
     WHERE b.location_id = $1
       AND b.deleted_at IS NOT NULL
       AND ${VISIBILITY_FILTER}
+      ${scopeClause}
     ORDER BY b.deleted_at DESC
     LIMIT ${MAX_CANDIDATES}
   `;
-  const result = await query<RawRow>(sql, [locationId, userId]);
+  const result = await query<RawRow>(sql, params);
   return result.rows.map((r) => rowToCandidate(r, 'in trash'));
 }
 

--- a/server/src/lib/queryPlan.ts
+++ b/server/src/lib/queryPlan.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { resolvePrompt, sanitizeForPrompt, withHardening } from './aiSanitize.js';
+import { sanitizeForPrompt, withHardening } from './aiSanitize.js';
 
 export const QueryPlanMetadataKind = z.enum(['pinned', 'private', 'checked_out', 'trashed']);
 export const QueryPlanField = z.enum(['name', 'tag', 'item']);
@@ -121,8 +121,8 @@ EDGE CASES
 - Pronouns referring to a previous result ("the red ones", "only the private ones"): if the previous turn returned matches and the pronoun narrows them, emit a content plan using terms from the original turn. If you cannot resolve the pronoun, refuse with the reason.`;
 
 export function buildPlannerSystemPrompt(customPrompt?: string, isDemoUser?: boolean): string {
-  const basePrompt = resolvePrompt(PLANNER_PROMPT, customPrompt, isDemoUser);
-  return withHardening(basePrompt);
+  const customSection = !isDemoUser && customPrompt ? `\n\nADDITIONAL USER GUIDANCE:\n${customPrompt}` : '';
+  return withHardening(`${PLANNER_PROMPT}${customSection}`);
 }
 
 export function buildPlannerUserMessage(question: string, schema: PlannerSchemaContext): string {

--- a/server/src/lib/queryPlan.ts
+++ b/server/src/lib/queryPlan.ts
@@ -127,8 +127,8 @@ export function buildPlannerSystemPrompt(customPrompt?: string, isDemoUser?: boo
 
 export function buildPlannerUserMessage(question: string, schema: PlannerSchemaContext): string {
   const compact = {
-    tags: schema.tags.slice(0, 200),
-    areas: schema.areas.slice(0, 100),
+    tags: schema.tags.slice(0, 200).map(sanitizeForPrompt),
+    areas: schema.areas.slice(0, 100).map(sanitizeForPrompt),
   };
   return `Question: ${sanitizeForPrompt(question)}
 

--- a/server/src/lib/queryPlanExecutor.ts
+++ b/server/src/lib/queryPlanExecutor.ts
@@ -1,4 +1,3 @@
-import { buildSearchProbes } from './inventoryMatch.js';
 import {
   type CandidateBin,
   findCheckedOutMatches,
@@ -21,6 +20,7 @@ export interface HydratedMatch {
   is_trashed?: boolean;
   icon: string;
   color: string;
+  total_item_count: number;
 }
 
 /** Public projection of CandidateBin used for "did you mean?" suggestions. */
@@ -51,6 +51,7 @@ function hydrate(c: CandidateBin, relevance: string): HydratedMatch {
     ...(c.is_trashed ? { is_trashed: true } : {}),
     icon: c.icon,
     color: c.color,
+    total_item_count: c.items.length,
   };
 }
 
@@ -63,32 +64,6 @@ function projectNearMiss(c: CandidateBin): NearMiss {
     icon: c.icon,
     color: c.color,
   };
-}
-
-function applyFieldFilter(candidates: CandidateBin[], fields: Array<'name' | 'tag' | 'item'>, terms: string[]): CandidateBin[] {
-  if (fields.length === 0) return candidates;
-  const probes = buildSearchProbes(terms);
-  if (probes.length === 0) return candidates;
-  const wantsName = fields.includes('name');
-  const wantsTag = fields.includes('tag');
-  const wantsItem = fields.includes('item');
-  return candidates.filter((c) => {
-    const nameLower = c.name.toLowerCase();
-    const tagLowers = c.tags.map((t) => t.toLowerCase());
-    const itemLowers = c.items.map((i) => i.name.toLowerCase());
-    for (const probe of probes) {
-      if (wantsName && nameLower.includes(probe)) return true;
-      if (wantsTag && tagLowers.some((t) => t.includes(probe))) return true;
-      if (wantsItem && itemLowers.some((n) => n.includes(probe))) return true;
-    }
-    return false;
-  });
-}
-
-function filterByScope<T extends { bin_id: string }>(rows: T[], scopedBinIds: string[] | undefined): T[] {
-  if (!scopedBinIds || scopedBinIds.length === 0) return rows;
-  const allowed = new Set(scopedBinIds);
-  return rows.filter((r) => allowed.has(r.bin_id));
 }
 
 async function gatherNearMisses(
@@ -115,11 +90,10 @@ async function executeContent(
   userId: string,
   scopedBinIds: string[] | undefined,
 ): Promise<ExecutedPlan> {
-  let candidates = await findLiteralMatches(locationId, userId, plan.terms);
-  if (plan.fields && plan.fields.length > 0) {
-    candidates = applyFieldFilter(candidates, plan.fields, plan.terms);
-  }
-  candidates = filterByScope(candidates, scopedBinIds);
+  const candidates = await findLiteralMatches(locationId, userId, plan.terms, {
+    scopedBinIds,
+    fields: plan.fields,
+  });
 
   if (candidates.length > 0) {
     return {
@@ -130,7 +104,10 @@ async function executeContent(
   }
 
   // No matches — try fuzzy bin-name "did you mean?" suggestions.
-  const fuzzy = filterByScope(await gatherNearMisses(locationId, userId, plan.terms), scopedBinIds).slice(0, 3);
+  const allFuzzy = await gatherNearMisses(locationId, userId, plan.terms);
+  const fuzzy = scopedBinIds && scopedBinIds.length > 0
+    ? allFuzzy.filter((m) => scopedBinIds.includes(m.bin_id)).slice(0, 3)
+    : allFuzzy.slice(0, 3);
   const answer = fuzzy.length > 0
     ? `I couldn't find any bins matching that. Did you mean ${fuzzy.map((m) => m.name).join(', ')}?`
     : "I couldn't find any bins matching that.";
@@ -140,7 +117,7 @@ async function executeContent(
 
 const METADATA_MATCHERS: Record<
   'pinned' | 'private' | 'checked_out' | 'trashed',
-  (locationId: string, userId: string) => Promise<CandidateBin[]>
+  (locationId: string, userId: string, opts: { scopedBinIds?: string[] }) => Promise<CandidateBin[]>
 > = {
   pinned: findPinnedMatches,
   private: findPrivateMatches,
@@ -154,10 +131,7 @@ async function executeMetadata(
   userId: string,
   scopedBinIds: string[] | undefined,
 ): Promise<ExecutedPlan> {
-  const candidates = filterByScope(
-    await METADATA_MATCHERS[plan.metadata](locationId, userId),
-    scopedBinIds,
-  );
+  const candidates = await METADATA_MATCHERS[plan.metadata](locationId, userId, { scopedBinIds });
   return {
     matches: candidates.map((c) => hydrate(c, c.match_hint)),
     near_misses: [],

--- a/server/src/routes/aiStream/text.ts
+++ b/server/src/routes/aiStream/text.ts
@@ -41,7 +41,7 @@ async function streamPlannedQuery(
   const { question, locationId, scopedBinIds, scopeNote = '', priorMessages } = args;
   const [{ settings, model }, schemaCtx] = await Promise.all([
     resolveUserModel(req.user!.id, 'query', isDemoUser(req)),
-    buildPlannerSchemaContext(locationId),
+    buildPlannerSchemaContext(locationId, req.user!.id),
   ]);
 
   await pipeAiStreamToResponse(res, model, {

--- a/server/src/routes/aiStream/text.ts
+++ b/server/src/routes/aiStream/text.ts
@@ -55,8 +55,12 @@ async function streamPlannedQuery(
       if (!safe.success) {
         return { answer: "I couldn't understand that. Try rephrasing your question.", matches: [] };
       }
-      const executed = await executeQueryPlan(validateQueryPlan(safe.data), locationId, req.user!.id, scopedBinIds);
-      return { answer: executed.answer, matches: executed.matches };
+      try {
+        const executed = await executeQueryPlan(validateQueryPlan(safe.data), locationId, req.user!.id, scopedBinIds);
+        return { answer: executed.answer, matches: executed.matches };
+      } catch {
+        return { answer: "I couldn't understand that. Try rephrasing your question.", matches: [] };
+      }
     },
   });
 }
@@ -133,7 +137,9 @@ router.post('/ask/stream', ...aiRateLimiters, requireAiAccess(), checkAiCredits(
     const trimmed = text.trim();
     const hasCommandVerb = /\b(add|remove|delete|move|create|update|put|take|pin|unpin|set|change|rename|tag|untag|clear|make|mark|assign|merge|split|restore)\b/i.test(trimmed);
     const wordCount = trimmed.split(/\s+/).length;
-    const isConfirmation = priorMessages.length > 0 && /^(yes|yeah|yep|sure|ok(ay)?|the\s+(first|second|third|last|one|other)|that\s+one|those)\b/i.test(trimmed);
+    const isConfirmation = priorMessages.length > 0
+      && !hasCommandVerb
+      && /^(yes|yeah|yep|sure|ok(ay)?|the\s+(first|second|third|last|one|other)|that\s+one|those)\b/i.test(trimmed);
     const isShortNoun = wordCount <= 4 && !hasCommandVerb;
     if (isConfirmation || isShortNoun) {
       intent = 'query';


### PR DESCRIPTION
## Summary

Addresses all 9 findings from the ultrareview pass on PR #118 (deterministic AI matching, already merged). Changes are gated behind `AI_DETERMINISTIC_MATCH=true` (default off in production), so all of these are dormant until that flag is flipped — but should land before any rollout.

## Findings fixed

### Privacy + sanitization (commit `673b8df1`)
- **bug_002 (normal)** — Cross-user metadata leak: `buildPlannerSchemaContext` was missing the `userId` parameter and visibility predicate that every sibling query in `aiContext.ts` enforces. Peers in a shared location could see tag names from each other's `visibility='private'` bins (e.g. `medical-records`, `tax-2025`) embedded in the planner's `<inventory_schema>` — and shipped to the third-party LLM provider. Threaded `userId` through and added `AND (b.visibility = 'location' OR b.created_by = $2)`.
- **bug_008 (nit)** — Planner user message was JSON-stringifying tags/areas without `sanitizeForPrompt`, while every other AI context flow runs user-controlled strings through it. Added `.map(sanitizeForPrompt)` on both arrays.

### Routing + prompt safety (commit `d80ad0c9`)
- **bug_001 (normal)** — A user with a saved `query_prompt` (legacy `{answer,matches}` schema customization) silently disabled the planner: `resolvePrompt` returns `customPrompt || defaultPrompt` (replacement, not prefix). Refactored `buildPlannerSystemPrompt` to append the custom prompt as `ADDITIONAL USER GUIDANCE` rather than replacing `PLANNER_PROMPT`, mirroring the legacy `buildSystemPrompt` pattern in `inventoryQuery.ts`.
- **bug_010 (normal)** — `"yes please add tools"` and similar conversational replies were getting routed to the planner because the `isConfirmation` regex didn't check for command verbs. The asymmetric `!hasCommandVerb` guard (present on `isShortNoun`, missing on `isConfirmation`) was the smoking gun. Added `&& !hasCommandVerb` to `isConfirmation`.
- **bug_011 (nit)** — `validateQueryPlan` throws when terms are all whitespace, escaping `enrichResult` and leaking raw plan JSON to the client (the `done` payload becomes `{kind,terms,answer}` instead of `{answer,matches}`). Wrapped `validateQueryPlan` + `executeQueryPlan` in try/catch returning the same fallback as the `safeParse` failure right above.

### Matcher correctness + schema (commit `4f942b2f`)
- **bug_017 (normal)** — `simplePluralStem` produced 2-char stems for short `-ies` words (`ties→ty`, `lies→ly`, `pies→py`), which became `LIKE '%ty%'` SQL probes matching every bin/item/tag containing the bigram (Battery, Pretty, Empty, etc.). Tightened from `w.length >= 4` to `w.length >= 5` so 4-letter `-ies` words fall through to the plain-`s` strip rule and produce correct 3-char stems.
- **bug_014 (normal)** — Probe-vs-haystack punctuation asymmetry: `normalizeForMatch` replaced punctuation with spaces but the SQL haystack only `LOWER()`'d. Multi-word queries crossing apostrophes/hyphens/`#`/`&`/`/` failed silently — `Tom's Tools` invisible to query `Tom's tools`, `kid-friendly` invisible to `kid friendly`, etc. Added `sqlNormalizeName()` helper using cross-dialect chained REPLACE (8 punctuation chars) applied to `b.name`, `te.value`, and `bi.name` in `findLiteralMatches`.
- **merged_bug_004 (normal)** — `LIMIT 30` was applied before the JS-side `applyFieldFilter` and `filterByScope`, so when more than 30 bins satisfied the WHERE clause, both filters could drop every legitimately-matching bin and return empty. Threaded `scopedBinIds?` and `fields?` into all five matcher signatures (`findLiteralMatches`, `findPinnedMatches`, `findPrivateMatches`, `findCheckedOutMatches`, `findTrashedMatches`) and pushed the predicates into SQL before LIMIT. Removed the now-redundant JS post-filters.
- **bug_003 (nit)** — `HydratedMatch` was missing `total_item_count`, but the client `QueryMatch` type declares it required and `BinItemGroup.tsx` reads it for the "+N more items" indicator. Added the field; populated with `c.items.length` since the planner path doesn't truncate items.

## Test plan

- [x] `cd server && npx vitest run` — 1614 pass / 1 skip (was 1545 baseline, +69 from new regression tests)
- [x] `npx vitest run` (client) — 1660 pass (no client-side changes; baseline preserved)
- [x] `cd server && npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check .` — no new errors (71 pre-existing warnings)
- [x] New regression tests: privacy isolation in `plannerSchemaContext.test.ts`, planner-prompt-prefix in `queryPlan.test.ts`, punctuation/scope/field-restriction in `inventoryMatcher.test.ts`, ies-stem fix in `inventoryMatch.test.ts`

## Notes

- All changes are server-side, behind `AI_DETERMINISTIC_MATCH=true`. No client changes required (`HydratedMatch` schema fix preserves the existing `QueryMatch` shape the client already expects).
- Three commits, one per logical cluster — easy to bisect or revert individually if needed.