### PR TITLE
feat: collapse Ask AI matched items by default

### DIFF
--- a/src/features/ai/BinDisclosurePill.tsx
+++ b/src/features/ai/BinDisclosurePill.tsx
@@ -8,6 +8,7 @@ interface BinDisclosurePillProps {
   expanded?: boolean;
   controlsId?: string;
   binName?: string;
+  /** Called when the button is clicked. Caller is responsible for stopPropagation if the pill is nested under another clickable region. */
   onToggle?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -44,7 +45,7 @@ export function BinDisclosurePill({
       aria-label={label}
       className={cn(
         PILL_CONTENT,
-        'min-h-[40px] min-w-[44px] justify-center hover:bg-[var(--bg-active)] transition-colors',
+        'min-h-[44px] min-w-[44px] justify-center hover:bg-[var(--bg-active)] transition-colors',
         focusRing,
       )}
     >

--- a/src/features/ai/BinDisclosurePill.tsx
+++ b/src/features/ai/BinDisclosurePill.tsx
@@ -1,0 +1,60 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { MouseEvent } from 'react';
+import { cn, focusRing } from '@/lib/utils';
+
+interface BinDisclosurePillProps {
+  countLabel: string;
+  mode: 'expand' | 'nav';
+  expanded?: boolean;
+  controlsId?: string;
+  binName?: string;
+  onToggle?: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+const PILL_CONTENT =
+  'inline-flex items-center gap-1 rounded-[var(--radius-xs)] bg-[var(--bg-hover)] px-2.5 py-1 text-[12px] font-medium text-[var(--text-secondary)] tabular-nums select-none';
+
+export function BinDisclosurePill({
+  countLabel,
+  mode,
+  expanded = false,
+  controlsId,
+  binName,
+  onToggle,
+}: BinDisclosurePillProps) {
+  if (mode === 'nav') {
+    return (
+      <span className={PILL_CONTENT} aria-hidden="true">
+        {countLabel}
+        <ChevronRight className="h-3 w-3 text-[var(--text-tertiary)]" />
+      </span>
+    );
+  }
+
+  const label = binName
+    ? `${expanded ? 'Hide' : 'Show'} ${countLabel} in ${binName}`
+    : `${expanded ? 'Hide' : 'Show'} ${countLabel}`;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={expanded}
+      aria-controls={controlsId}
+      aria-label={label}
+      className={cn(
+        PILL_CONTENT,
+        'min-h-[40px] min-w-[44px] justify-center hover:bg-[var(--bg-active)] transition-colors',
+        focusRing,
+      )}
+    >
+      {countLabel}
+      <ChevronDown
+        className={cn(
+          'h-3 w-3 text-[var(--text-tertiary)] transition-transform duration-200 motion-reduce:transition-none',
+          expanded && 'rotate-180',
+        )}
+      />
+    </button>
+  );
+}

--- a/src/features/ai/BinGroupHeader.tsx
+++ b/src/features/ai/BinGroupHeader.tsx
@@ -58,7 +58,6 @@ export function BinGroupHeader({
   if (interactive) {
     return (
       <div
-        data-trashed={isTrashed ? 'true' : undefined}
         className={cn(
           'w-full flex items-center rounded-t-[var(--radius-sm)]',
           isTrashed && 'opacity-70',

--- a/src/features/ai/BinGroupHeader.tsx
+++ b/src/features/ai/BinGroupHeader.tsx
@@ -68,6 +68,7 @@ export function BinGroupHeader({
           type="button"
           onClick={onOpen}
           aria-label={`Open ${name}`}
+          data-trashed={isTrashed ? 'true' : undefined}
           className="flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left hover:bg-[var(--bg-active)] transition-colors rounded-tl-[var(--radius-sm)]"
         >
           {iconNode}

--- a/src/features/ai/BinGroupHeader.tsx
+++ b/src/features/ai/BinGroupHeader.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, Trash2 } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { BinIconBadge } from '@/components/ui/bin-icon-badge';
 import { resolveColor } from '@/lib/colorPalette';
 import { resolveIcon } from '@/lib/iconMap';
@@ -11,6 +12,15 @@ interface BinGroupHeaderProps {
   color: string;
   isTrashed: boolean;
   onOpen: () => void;
+  /** Optional element rendered on the right side. Defaults to a chevron-right indicator. */
+  trailing?: ReactNode;
+  /**
+   * When true, renders a split row: the icon+name area is one button (open),
+   * and `trailing` is a sibling expected to contain its own focusable control.
+   * When false (default), the whole row is one button and `trailing` is rendered
+   * inside it as visual-only content.
+   */
+  interactive?: boolean;
 }
 
 export function BinGroupHeader({
@@ -20,9 +30,53 @@ export function BinGroupHeader({
   color,
   isTrashed,
   onOpen,
+  trailing,
+  interactive = false,
 }: BinGroupHeaderProps) {
   const BinIcon = resolveIcon(icon);
   const colorPreset = resolveColor(color);
+
+  const iconNode = isTrashed ? (
+    <Trash2 className="h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+  ) : (
+    <BinIconBadge icon={BinIcon} colorPreset={colorPreset} />
+  );
+
+  const titleNode = (
+    <span className="flex-1 min-w-0">
+      <span className="block text-[15px] font-semibold text-[var(--text-primary)] truncate">{name}</span>
+      {areaName && (
+        <span className="block text-[12px] text-[var(--text-tertiary)] mt-0.5">{areaName}</span>
+      )}
+    </span>
+  );
+
+  const trailingDefault = (
+    <ChevronRight className="h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+  );
+
+  if (interactive) {
+    return (
+      <div
+        data-trashed={isTrashed ? 'true' : undefined}
+        className={cn(
+          'w-full flex items-center rounded-t-[var(--radius-sm)]',
+          isTrashed && 'opacity-70',
+        )}
+      >
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={`Open ${name}`}
+          className="flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left hover:bg-[var(--bg-active)] transition-colors rounded-tl-[var(--radius-sm)]"
+        >
+          {iconNode}
+          {titleNode}
+        </button>
+        <div className="pr-2 flex items-center">{trailing ?? trailingDefault}</div>
+      </div>
+    );
+  }
 
   return (
     <button
@@ -35,18 +89,9 @@ export function BinGroupHeader({
         isTrashed && 'opacity-70',
       )}
     >
-      {isTrashed ? (
-        <Trash2 className="h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
-      ) : (
-        <BinIconBadge icon={BinIcon} colorPreset={colorPreset} />
-      )}
-      <span className="flex-1 min-w-0">
-        <span className="block text-[15px] font-semibold text-[var(--text-primary)] truncate">{name}</span>
-        {areaName && (
-          <span className="block text-[12px] text-[var(--text-tertiary)] mt-0.5">{areaName}</span>
-        )}
-      </span>
-      <ChevronRight className="h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+      {iconNode}
+      {titleNode}
+      {trailing ?? trailingDefault}
     </button>
   );
 }

--- a/src/features/ai/BinItemGroup.tsx
+++ b/src/features/ai/BinItemGroup.tsx
@@ -1,6 +1,6 @@
 import { CheckSquare, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
-import { cn, flatCard } from '@/lib/utils';
+import { cn, flatCard, plural } from '@/lib/utils';
 import { BinDisclosurePill } from './BinDisclosurePill';
 import { BinGroupHeader } from './BinGroupHeader';
 import { ItemRow } from './ItemRow';
@@ -27,6 +27,7 @@ export function BinItemGroup({
   onBinClick,
 }: BinItemGroupProps) {
   const display = getMatchDisplay(match);
+  const isExpandable = display.mode === 'inline-disclosure';
   const [expanded, setExpanded] = useState(display.defaultExpanded);
   const itemsId = `items-${match.bin_id}`;
   const hiddenCount = Math.max(0, match.total_item_count - match.items.length);
@@ -34,7 +35,7 @@ export function BinItemGroup({
   const trailing =
     display.mode === 'nav-disclosure' ? (
       <BinDisclosurePill mode="nav" countLabel={display.countLabel} />
-    ) : display.mode === 'inline-disclosure' ? (
+    ) : isExpandable ? (
       <BinDisclosurePill
         mode="expand"
         countLabel={display.countLabel}
@@ -58,24 +59,21 @@ export function BinItemGroup({
         isTrashed={!!match.is_trashed}
         onOpen={() => onBinClick(match.bin_id, match.is_trashed)}
         trailing={trailing}
-        interactive={display.mode === 'inline-disclosure'}
+        interactive={isExpandable}
       />
 
-      {display.mode === 'inline-disclosure' && (
+      {isExpandable && (
         <section
           id={itemsId}
           aria-label={`Items in ${match.name}`}
+          aria-hidden={!expanded}
           className={cn(
             'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none',
             expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
           )}
         >
-          <div
-            ref={(el) => {
-              if (el) el.inert = !expanded;
-            }}
-            className="min-h-0 overflow-hidden"
-          >
+          {/* @ts-expect-error -- inert is valid HTML but not typed in React 18 */}
+          <div className="min-h-0 overflow-hidden" inert={!expanded ? true : undefined}>
             <ul className="border-t border-[var(--border-subtle)]">
               {match.items.map((item) => (
                 <li key={item.id}>
@@ -117,7 +115,7 @@ export function BinItemGroup({
                 className="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] border-t border-[var(--border-subtle)] transition-colors"
               >
                 <span className="flex-1 text-left">
-                  + {hiddenCount} more {hiddenCount === 1 ? 'item' : 'items'} — open bin to see all
+                  + {hiddenCount} more {plural(hiddenCount, 'item')} — open bin to see all
                 </span>
                 <ChevronRight className="h-3.5 w-3.5 shrink-0" />
               </button>

--- a/src/features/ai/BinItemGroup.tsx
+++ b/src/features/ai/BinItemGroup.tsx
@@ -70,7 +70,12 @@ export function BinItemGroup({
             expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
           )}
         >
-          <div className="min-h-0 overflow-hidden">
+          <div
+            ref={(el) => {
+              if (el) el.inert = !expanded;
+            }}
+            className="min-h-0 overflow-hidden"
+          >
             <ul className="border-t border-[var(--border-subtle)]">
               {match.items.map((item) => (
                 <li key={item.id}>

--- a/src/features/ai/BinItemGroup.tsx
+++ b/src/features/ai/BinItemGroup.tsx
@@ -1,7 +1,10 @@
 import { CheckSquare, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
 import { cn, flatCard } from '@/lib/utils';
+import { BinDisclosurePill } from './BinDisclosurePill';
 import { BinGroupHeader } from './BinGroupHeader';
 import { ItemRow } from './ItemRow';
+import { getMatchDisplay } from './matchDisplay';
 import type { QueryMatch } from './useInventoryQuery';
 import type { useItemQuerySelection } from './useItemQuerySelection';
 
@@ -16,9 +19,35 @@ interface BinItemGroupProps {
   onBinClick: (binId: string, isTrashed?: boolean) => void;
 }
 
-export function BinItemGroup({ match, canWrite, selection, removedItemIds, onBinClick }: BinItemGroupProps) {
-  const hasItems = match.items.length > 0;
+export function BinItemGroup({
+  match,
+  canWrite,
+  selection,
+  removedItemIds,
+  onBinClick,
+}: BinItemGroupProps) {
+  const display = getMatchDisplay(match);
+  const [expanded, setExpanded] = useState(display.defaultExpanded);
+  const itemsId = `items-${match.bin_id}`;
   const hiddenCount = Math.max(0, match.total_item_count - match.items.length);
+
+  const trailing =
+    display.mode === 'nav-disclosure' ? (
+      <BinDisclosurePill mode="nav" countLabel={display.countLabel} />
+    ) : display.mode === 'inline-disclosure' ? (
+      <BinDisclosurePill
+        mode="expand"
+        countLabel={display.countLabel}
+        expanded={expanded}
+        controlsId={itemsId}
+        binName={match.name}
+        onToggle={(e) => {
+          e.stopPropagation();
+          setExpanded((v) => !v);
+        }}
+      />
+    ) : undefined;
+
   return (
     <div className={cn(flatCard, 'overflow-hidden rounded-[var(--radius-sm)]')}>
       <BinGroupHeader
@@ -28,55 +57,67 @@ export function BinItemGroup({ match, canWrite, selection, removedItemIds, onBin
         color={match.color}
         isTrashed={!!match.is_trashed}
         onOpen={() => onBinClick(match.bin_id, match.is_trashed)}
+        trailing={trailing}
+        interactive={display.mode === 'inline-disclosure'}
       />
-      {hasItems && (
-        <ul className="border-t border-[var(--border-subtle)]">
-          {match.items.map((item) => (
-            <li key={item.id}>
-              <ItemRow
-                item={item}
-                binId={match.bin_id}
-                canWrite={canWrite}
-                isTrashed={!!match.is_trashed}
-                onOpenBin={(id) => onBinClick(id, match.is_trashed)}
-                selected={selection?.isSelected(item.id) ?? false}
-                onToggleSelect={
-                  selection
-                    ? () => selection.toggleItem(item.id, match.bin_id, item.name)
-                    : undefined
-                }
-                externallyRemoved={removedItemIds?.has(item.id) ?? false}
-              />
-            </li>
-          ))}
-        </ul>
-      )}
-      {selection &&
-        canWrite &&
-        !match.is_trashed &&
-        hasItems &&
-        !selection.isBinFullySelected(match.bin_id) &&
-        selection.isAnySelectedInBin(match.bin_id) && (
-          <button
-            type="button"
-            onClick={() => selection.selectAllInBin(match.bin_id)}
-            className="w-full flex items-center gap-2 px-3 py-2.5 text-[13px] font-medium text-[var(--accent)] hover:bg-[var(--bg-hover)] border-t border-[var(--border-subtle)] transition-colors"
-          >
-            <CheckSquare className="h-4 w-4 shrink-0" />
-            <span>Select all {match.items.length} items</span>
-          </button>
-        )}
-      {hiddenCount > 0 && (
-        <button
-          type="button"
-          onClick={() => onBinClick(match.bin_id, match.is_trashed)}
-          className="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] border-t border-[var(--border-subtle)] transition-colors"
+
+      {display.mode === 'inline-disclosure' && (
+        <section
+          id={itemsId}
+          className={cn(
+            'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none',
+            expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+          )}
         >
-          <span className="flex-1 text-left">
-            + {hiddenCount} more {hiddenCount === 1 ? 'item' : 'items'} — open bin to see all
-          </span>
-          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-        </button>
+          <div className="min-h-0 overflow-hidden">
+            <ul className="border-t border-[var(--border-subtle)]">
+              {match.items.map((item) => (
+                <li key={item.id}>
+                  <ItemRow
+                    item={item}
+                    binId={match.bin_id}
+                    canWrite={canWrite}
+                    isTrashed={!!match.is_trashed}
+                    onOpenBin={(id) => onBinClick(id, match.is_trashed)}
+                    selected={selection?.isSelected(item.id) ?? false}
+                    onToggleSelect={
+                      selection
+                        ? () => selection.toggleItem(item.id, match.bin_id, item.name)
+                        : undefined
+                    }
+                    externallyRemoved={removedItemIds?.has(item.id) ?? false}
+                  />
+                </li>
+              ))}
+            </ul>
+            {selection &&
+              canWrite &&
+              !match.is_trashed &&
+              !selection.isBinFullySelected(match.bin_id) &&
+              selection.isAnySelectedInBin(match.bin_id) && (
+                <button
+                  type="button"
+                  onClick={() => selection.selectAllInBin(match.bin_id)}
+                  className="w-full flex items-center gap-2 px-3 py-2.5 text-[13px] font-medium text-[var(--accent)] hover:bg-[var(--bg-hover)] border-t border-[var(--border-subtle)] transition-colors"
+                >
+                  <CheckSquare className="h-4 w-4 shrink-0" />
+                  <span>Select all {match.items.length} items</span>
+                </button>
+              )}
+            {hiddenCount > 0 && (
+              <button
+                type="button"
+                onClick={() => onBinClick(match.bin_id, match.is_trashed)}
+                className="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] border-t border-[var(--border-subtle)] transition-colors"
+              >
+                <span className="flex-1 text-left">
+                  + {hiddenCount} more {hiddenCount === 1 ? 'item' : 'items'} — open bin to see all
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+              </button>
+            )}
+          </div>
+        </section>
       )}
     </div>
   );

--- a/src/features/ai/BinItemGroup.tsx
+++ b/src/features/ai/BinItemGroup.tsx
@@ -64,6 +64,7 @@ export function BinItemGroup({
       {display.mode === 'inline-disclosure' && (
         <section
           id={itemsId}
+          aria-label={`Items in ${match.name}`}
           className={cn(
             'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none',
             expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',

--- a/src/features/ai/__tests__/AiTurnQueryResult.test.tsx
+++ b/src/features/ai/__tests__/AiTurnQueryResult.test.tsx
@@ -48,4 +48,52 @@ describe('AiTurnQueryResult', () => {
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(screen.queryByRole('button', { name: /back/i })).toBeNull();
   });
+
+  it('renders mixed display modes independently — auto-expanded + collapsed do not interfere', () => {
+    render(
+      <MemoryRouter>
+        <AiTurnQueryResult
+          queryResult={{
+            answer: 'Found these.',
+            matches: [
+              {
+                bin_id: 'b1',
+                name: 'Drill Bin',
+                area_name: 'Garage',
+                items: [{ id: 'i1', name: 'drill', quantity: null }],
+                total_item_count: 12,
+                tags: [],
+                relevance: 'contains "drill"',
+                icon: '',
+                color: '#22c55e',
+              },
+              {
+                bin_id: 'b2',
+                name: 'Camping Gear',
+                area_name: 'Garage',
+                items: [
+                  { id: 'i2', name: 'Tent', quantity: null },
+                  { id: 'i3', name: 'Sleeping bag', quantity: null },
+                ],
+                total_item_count: 2,
+                tags: [],
+                relevance: 'name contains "camping"',
+                icon: '',
+                color: '#22c55e',
+              },
+            ],
+          }}
+          onBinClick={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+    // First bin: single-item match → auto-expanded.
+    expect(
+      screen.getByRole('button', { name: /hide 1 item in drill bin/i }).getAttribute('aria-expanded'),
+    ).toBe('true');
+    // Second bin: name match → collapsed.
+    expect(
+      screen.getByRole('button', { name: /show 2 items in camping gear/i }).getAttribute('aria-expanded'),
+    ).toBe('false');
+  });
 });

--- a/src/features/ai/__tests__/BinDisclosurePill.test.tsx
+++ b/src/features/ai/__tests__/BinDisclosurePill.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BinDisclosurePill } from '../BinDisclosurePill';
+
+describe('BinDisclosurePill', () => {
+  it('renders as a non-button span in nav mode', () => {
+    const { container } = render(
+      <BinDisclosurePill mode="nav" countLabel="12 items" />,
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(container.textContent).toContain('12 items');
+  });
+
+  it('renders as a button in expand mode and toggles aria-expanded', () => {
+    render(
+      <BinDisclosurePill
+        mode="expand"
+        countLabel="3 items"
+        expanded={false}
+        binName="Camping Gear"
+        onToggle={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    expect(btn.getAttribute('aria-label')).toBe('Show 3 items in Camping Gear');
+  });
+
+  it('reflects expanded=true in aria-expanded and label', () => {
+    render(
+      <BinDisclosurePill
+        mode="expand"
+        countLabel="1 item"
+        expanded
+        binName="Garage"
+        onToggle={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(btn.getAttribute('aria-label')).toBe('Hide 1 item in Garage');
+  });
+
+  it('invokes onToggle when clicked', () => {
+    const onToggle = vi.fn();
+    render(
+      <BinDisclosurePill
+        mode="expand"
+        countLabel="3 items"
+        expanded={false}
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes aria-controls when controlsId is set', () => {
+    render(
+      <BinDisclosurePill
+        mode="expand"
+        countLabel="3 items"
+        expanded={false}
+        controlsId="items-abc"
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button').getAttribute('aria-controls')).toBe('items-abc');
+  });
+});

--- a/src/features/ai/__tests__/BinDisclosurePill.test.tsx
+++ b/src/features/ai/__tests__/BinDisclosurePill.test.tsx
@@ -51,6 +51,7 @@ describe('BinDisclosurePill', () => {
         onToggle={onToggle}
       />,
     );
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('Show 3 items');
     fireEvent.click(screen.getByRole('button'));
     expect(onToggle).toHaveBeenCalledTimes(1);
   });

--- a/src/features/ai/__tests__/BinGroupHeader.test.tsx
+++ b/src/features/ai/__tests__/BinGroupHeader.test.tsx
@@ -34,6 +34,26 @@ describe('BinGroupHeader', () => {
     expect(container.querySelector('[data-trashed="true"]')).toBeTruthy();
   });
 
+  it('applies trashed styling on the wrapper when isTrashed and interactive', () => {
+    const { container } = render(
+      <BinGroupHeader
+        name="X"
+        areaName=""
+        icon=""
+        color="#000"
+        isTrashed
+        onOpen={vi.fn()}
+        interactive
+        trailing={
+          <button type="button" aria-label="toggle items">
+            tog
+          </button>
+        }
+      />,
+    );
+    expect(container.querySelector('[data-trashed="true"]')).toBeTruthy();
+  });
+
   it('renders trailing element when provided (single-button mode)', () => {
     render(
       <BinGroupHeader

--- a/src/features/ai/__tests__/BinGroupHeader.test.tsx
+++ b/src/features/ai/__tests__/BinGroupHeader.test.tsx
@@ -33,4 +33,68 @@ describe('BinGroupHeader', () => {
     );
     expect(container.querySelector('[data-trashed="true"]')).toBeTruthy();
   });
+
+  it('renders trailing element when provided (single-button mode)', () => {
+    render(
+      <BinGroupHeader
+        name="X"
+        areaName=""
+        icon=""
+        color="#000"
+        isTrashed={false}
+        onOpen={vi.fn()}
+        trailing={<span data-testid="trailing">trailing-content</span>}
+      />,
+    );
+    expect(screen.getByTestId('trailing').textContent).toBe('trailing-content');
+    // Single-button mode: only one button, the bin opener.
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('renders split layout with two siblings when interactive is true', () => {
+    render(
+      <BinGroupHeader
+        name="X"
+        areaName=""
+        icon=""
+        color="#000"
+        isTrashed={false}
+        onOpen={vi.fn()}
+        interactive
+        trailing={
+          <button type="button" aria-label="toggle items">
+            tog
+          </button>
+        }
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /open/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /toggle items/i })).toBeDefined();
+  });
+
+  it('clicking the open button does not invoke handler on the trailing button (interactive)', () => {
+    const onOpen = vi.fn();
+    const onToggle = vi.fn();
+    render(
+      <BinGroupHeader
+        name="X"
+        areaName=""
+        icon=""
+        color="#000"
+        isTrashed={false}
+        onOpen={onOpen}
+        interactive
+        trailing={
+          <button type="button" aria-label="toggle items" onClick={onToggle}>
+            tog
+          </button>
+        }
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/ai/__tests__/BinItemGroup.test.tsx
+++ b/src/features/ai/__tests__/BinItemGroup.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { BinItemGroup } from '../BinItemGroup';
@@ -15,7 +15,7 @@ vi.mock('@/features/items/itemActions', () => ({
   updateQuantitySafe: vi.fn().mockResolvedValue({ ok: true, quantity: null }),
 }));
 
-const match: QueryMatch = {
+const baseMatch: QueryMatch = {
   bin_id: 'b1',
   name: 'Camping Gear',
   area_name: 'Garage',
@@ -25,29 +25,79 @@ const match: QueryMatch = {
   ],
   total_item_count: 2,
   tags: [],
-  relevance: '',
+  relevance: 'name contains "camping"',
   icon: '',
   color: '#22c55e',
 };
 
+function renderGroup(match: QueryMatch, onBinClick = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <BinItemGroup match={match} canWrite={false} onBinClick={onBinClick} />
+    </MemoryRouter>,
+  );
+}
+
 describe('BinItemGroup', () => {
-  it('renders header and each item', () => {
-    render(
-      <MemoryRouter>
-        <BinItemGroup match={match} canWrite={false} onBinClick={vi.fn()} />
-      </MemoryRouter>,
-    );
+  it('renders bin header text always', () => {
+    renderGroup(baseMatch);
     expect(screen.getByText('Camping Gear')).toBeDefined();
-    expect(screen.getByText('Tent')).toBeDefined();
-    expect(screen.getByText('Sleeping bag')).toBeDefined();
   });
 
-  it('does not render item rows when items is empty', () => {
-    render(
-      <MemoryRouter>
-        <BinItemGroup match={{ ...match, items: [] }} canWrite={false} onBinClick={vi.fn()} />
-      </MemoryRouter>,
-    );
-    expect(screen.queryByText('Tent')).toBeNull();
+  it('hides items by default (collapsed) for non-item kinds', () => {
+    renderGroup(baseMatch);
+    const toggle = screen.getByRole('button', { name: /show 2 items in camping gear/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('auto-expands when single item match (kind=item, items.length=1)', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [{ id: 'i1', name: 'drill', quantity: null }],
+      total_item_count: 12,
+      relevance: 'contains "drill"',
+    };
+    renderGroup(match);
+    const toggle = screen.getByRole('button', { name: /hide 1 item in camping gear/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('clicking the disclosure toggles aria-expanded and does not invoke onBinClick', () => {
+    const onBinClick = vi.fn();
+    renderGroup(baseMatch, onBinClick);
+    const toggle = screen.getByRole('button', { name: /show 2 items in camping gear/i });
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(onBinClick).not.toHaveBeenCalled();
+  });
+
+  it('clicking the bin name area calls onBinClick', () => {
+    const onBinClick = vi.fn();
+    renderGroup(baseMatch, onBinClick);
+    fireEvent.click(screen.getByRole('button', { name: /open camping gear/i }));
+    expect(onBinClick).toHaveBeenCalledWith('b1', undefined);
+  });
+
+  it('renders nav-disclosure (no aria-expanded) when items empty but total > 0', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [],
+      total_item_count: 12,
+    };
+    renderGroup(match);
+    expect(screen.queryByRole('button', { name: /show.*items/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /hide.*items/i })).toBeNull();
+    expect(screen.getByText('12 items')).toBeDefined();
+  });
+
+  it('renders header-only (no pill) when bin has no items at all', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [],
+      total_item_count: 0,
+    };
+    renderGroup(match);
+    expect(screen.queryByRole('button', { name: /items/i })).toBeNull();
+    expect(screen.queryByText(/items/)).toBeNull();
   });
 });

--- a/src/features/ai/__tests__/QueryAnswerBody.test.tsx
+++ b/src/features/ai/__tests__/QueryAnswerBody.test.tsx
@@ -77,22 +77,22 @@ describe('QueryAnswerBody', () => {
           makeMatch({
             bin_id: 'b1',
             name: 'Camping Gear',
-            items: [
-              { id: 'i1', name: 'Tent', quantity: null },
-              { id: 'i2', name: 'Sleeping Bag', quantity: 2 },
-            ],
+            items: [{ id: 'i1', name: 'Tent', quantity: null }],
+            total_item_count: 1,
+            relevance: 'contains "tent"',
           }),
           makeMatch({
             bin_id: 'b2',
             name: 'Tool Box',
             items: [{ id: 'i3', name: 'Hammer', quantity: null }],
+            total_item_count: 1,
+            relevance: 'contains "hammer"',
           }),
         ],
       },
       onBinClick: vi.fn(),
     });
     expect(screen.getByText('Tent')).toBeDefined();
-    expect(screen.getByText('Sleeping Bag')).toBeDefined();
     expect(screen.getByText('Hammer')).toBeDefined();
   });
 

--- a/src/features/ai/__tests__/matchDisplay.test.ts
+++ b/src/features/ai/__tests__/matchDisplay.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { getMatchDisplay, parseRelevanceKind } from '../matchDisplay';
+import type { QueryMatch } from '../useInventoryQuery';
+
+describe('parseRelevanceKind', () => {
+  it.each([
+    ['contains "drill"', 'item'],
+    ['contains "x with spaces"', 'item'],
+    ['name contains "kitchen"', 'name'],
+    ['tagged "garage"', 'tag'],
+    ['pinned', 'metadata'],
+    ['private', 'metadata'],
+    ['in trash', 'metadata'],
+    ['has checked-out items', 'metadata'],
+    ['name similar to query', 'fuzzy'],
+    ['matches query', 'unknown'],
+    ['', 'unknown'],
+    ['random gibberish', 'unknown'],
+  ])('parses %j as %s', (input, expected) => {
+    expect(parseRelevanceKind(input)).toBe(expected);
+  });
+});
+
+describe('getMatchDisplay', () => {
+  const baseMatch: QueryMatch = {
+    bin_id: 'b1',
+    name: 'Test',
+    area_name: '',
+    items: [],
+    total_item_count: 0,
+    tags: [],
+    relevance: '',
+    icon: '',
+    color: '',
+  };
+
+  it('returns header-only for empty bin', () => {
+    expect(getMatchDisplay(baseMatch)).toEqual({
+      mode: 'header-only',
+      defaultExpanded: false,
+      countLabel: '',
+    });
+  });
+
+  it('returns nav-disclosure when items empty but total > 0 (plural)', () => {
+    expect(getMatchDisplay({ ...baseMatch, total_item_count: 12 })).toEqual({
+      mode: 'nav-disclosure',
+      defaultExpanded: false,
+      countLabel: '12 items',
+    });
+  });
+
+  it('returns nav-disclosure with singular for 1 total item', () => {
+    expect(getMatchDisplay({ ...baseMatch, total_item_count: 1 })).toEqual({
+      mode: 'nav-disclosure',
+      defaultExpanded: false,
+      countLabel: '1 item',
+    });
+  });
+
+  it('returns inline-disclosure collapsed by default for non-item kinds', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [{ id: 'i1', name: 'X', quantity: null }],
+      total_item_count: 1,
+      relevance: 'name contains "test"',
+    };
+    expect(getMatchDisplay(match)).toEqual({
+      mode: 'inline-disclosure',
+      defaultExpanded: false,
+      countLabel: '1 item',
+    });
+  });
+
+  it('auto-expands single item match (kind=item, items.length=1)', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [{ id: 'i1', name: 'drill', quantity: null }],
+      total_item_count: 12,
+      relevance: 'contains "drill"',
+    };
+    expect(getMatchDisplay(match)).toEqual({
+      mode: 'inline-disclosure',
+      defaultExpanded: true,
+      countLabel: '1 item',
+    });
+  });
+
+  it('does not auto-expand when item kind but multiple items', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [
+        { id: 'i1', name: 'AA battery', quantity: null },
+        { id: 'i2', name: 'AAA battery', quantity: null },
+      ],
+      total_item_count: 5,
+      relevance: 'contains "battery"',
+    };
+    expect(getMatchDisplay(match).defaultExpanded).toBe(false);
+  });
+
+  it('does not auto-expand for tag-kind single item', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [{ id: 'i1', name: 'rope', quantity: null }],
+      total_item_count: 1,
+      relevance: 'tagged "garage"',
+    };
+    expect(getMatchDisplay(match).defaultExpanded).toBe(false);
+  });
+
+  it('does not auto-expand for metadata-kind single item', () => {
+    const match: QueryMatch = {
+      ...baseMatch,
+      items: [{ id: 'i1', name: 'something', quantity: null }],
+      total_item_count: 1,
+      relevance: 'pinned',
+    };
+    expect(getMatchDisplay(match).defaultExpanded).toBe(false);
+  });
+});

--- a/src/features/ai/__tests__/matchDisplay.test.ts
+++ b/src/features/ai/__tests__/matchDisplay.test.ts
@@ -8,6 +8,7 @@ describe('parseRelevanceKind', () => {
     ['contains "x with spaces"', 'item'],
     ['name contains "kitchen"', 'name'],
     ['tagged "garage"', 'tag'],
+    ['tag contains "garage"', 'unknown'],
     ['pinned', 'metadata'],
     ['private', 'metadata'],
     ['in trash', 'metadata'],

--- a/src/features/ai/matchDisplay.ts
+++ b/src/features/ai/matchDisplay.ts
@@ -1,0 +1,57 @@
+import { pluralize } from '@/lib/utils';
+import type { QueryMatch } from './useInventoryQuery';
+
+export type DisplayMode = 'header-only' | 'inline-disclosure' | 'nav-disclosure';
+export type RelevanceKind = 'item' | 'name' | 'tag' | 'metadata' | 'fuzzy' | 'unknown';
+
+export interface MatchDisplay {
+  mode: DisplayMode;
+  defaultExpanded: boolean;
+  countLabel: string;
+}
+
+const METADATA_HINTS = new Set([
+  'pinned',
+  'private',
+  'in trash',
+  'has checked-out items',
+]);
+
+/**
+ * Maps the server-side `relevance` string (from `describeMatchHint` and the
+ * metadata matchers in server/src/lib/inventoryMatcher.ts) to a typed kind.
+ *
+ * If those server strings ever change format, the test suite for this file
+ * will fail loudly.
+ */
+export function parseRelevanceKind(relevance: string): RelevanceKind {
+  if (!relevance) return 'unknown';
+  if (relevance.startsWith('contains "')) return 'item';
+  if (relevance.startsWith('name contains "')) return 'name';
+  if (relevance.startsWith('tagged "')) return 'tag';
+  if (METADATA_HINTS.has(relevance)) return 'metadata';
+  if (relevance === 'name similar to query') return 'fuzzy';
+  return 'unknown';
+}
+
+export function getMatchDisplay(match: QueryMatch): MatchDisplay {
+  const itemsCount = match.items.length;
+  const totalCount = match.total_item_count;
+
+  if (itemsCount === 0 && totalCount === 0) {
+    return { mode: 'header-only', defaultExpanded: false, countLabel: '' };
+  }
+  if (itemsCount === 0) {
+    return {
+      mode: 'nav-disclosure',
+      defaultExpanded: false,
+      countLabel: pluralize(totalCount, 'item'),
+    };
+  }
+  const kind = parseRelevanceKind(match.relevance);
+  return {
+    mode: 'inline-disclosure',
+    defaultExpanded: kind === 'item' && itemsCount === 1,
+    countLabel: pluralize(itemsCount, 'item'),
+  };
+}

--- a/src/features/ai/matchDisplay.ts
+++ b/src/features/ai/matchDisplay.ts
@@ -52,6 +52,7 @@ export function getMatchDisplay(match: QueryMatch): MatchDisplay {
   return {
     mode: 'inline-disclosure',
     defaultExpanded: kind === 'item' && itemsCount === 1,
+    // Pill shows MATCHED item count; BinItemGroup's "+N more" footer covers the delta to total.
     countLabel: pluralize(itemsCount, 'item'),
   };
 }


### PR DESCRIPTION
## Summary

- Hide matched items by default in Ask AI answer turns. Each bin row exposes a per-bin disclosure on the right that reveals the items inline; the existing "tap bin to open" behavior is preserved.
- Three render modes selected per match by a pure helper that reads the existing server-emitted `relevance` string: `header-only` (empty bin, no pill), `nav-disclosure` (truncated — bin has items but the AI returned none, count pill navigates to bin detail), `inline-disclosure` (matched items, count pill expands inline).
- Auto-expansion fires only when `relevance` starts with `contains "..."` and `items.length === 1` — preserves the "found it" moment for single-item lookups (e.g. "where's my drill") without expanding multi-match results by default.

Architecture is client-only — no server schema, wire format, or executor changes. The decision logic lives in a new `src/features/ai/matchDisplay.ts` helper. The disclosure UI is a new `BinDisclosurePill` component (button in expand mode, span in nav mode). `BinGroupHeader` was refactored to accept a `trailing` slot plus an `interactive` flag for split-button rendering.

## Notable details

- **Animation:** items wrapper uses the `grid-template-rows: 0fr ⇄ 1fr` CSS trick (200ms ease-out, `motion-reduce:transition-none`). Inner `<div className="min-h-0 overflow-hidden">` clips during collapse.
- **A11y:** disclosure has `aria-expanded` + `aria-controls`, the `<section>` has `aria-label="Items in {name}"` and `aria-hidden={!expanded}`, and collapsed contents are excluded from the tab order via `inert`.
- **Hit targets:** pill is `min-h-[44px] min-w-[44px]` per WCAG 2.5.5.
- **State:** local `useState` per `BinItemGroup` instance; turns are keyed by `match.bin_id` in `ItemQueryResults`, so new questions correctly reset state.

## Test plan

- [x] `npx vitest run` — 170 files / 1711 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on changed files — clean
- [x] `npx vite build` — succeeds
- [ ] Visual smoke (must run locally with `npm run dev:all`):
  - "show me pinned bins" → all collapsed with `N items ▾` pill
  - "where's my drill" (single bin, single matched item) → auto-expanded
  - Multi-match query → independent expand state per bin
  - Tap bin name vs pill: only pill expands, only name navigates
  - Tab order skips collapsed items
  - DevTools `prefers-reduced-motion: reduce` → instant expand/collapse
  - Bulk-select inside an expanded bin still works

## Files

New:
- `src/features/ai/matchDisplay.ts` (+ tests)
- `src/features/ai/BinDisclosurePill.tsx` (+ tests)

Modified:
- `src/features/ai/BinGroupHeader.tsx` (+ tests) — adds `trailing` slot and `interactive` split mode
- `src/features/ai/BinItemGroup.tsx` (+ tests) — wires the helpers, owns expand state
- `src/features/ai/__tests__/AiTurnQueryResult.test.tsx` — adds mixed-mode integration test
- `src/features/ai/__tests__/QueryAnswerBody.test.tsx` — fixture updated so item-name assertions remain meaningful with the new collapse default