### PR TITLE
fix: replace broken README hero image with absolute CDN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <p>Inventory with intelligence. Organize physical storage bins with QR codes, photo recognition, and multi-user collaboration.</p>
 
 
-  <img src="docs/assets/bins.png" alt="OpenBin dashboard showing bins organized by area" width="700" />
+  <img src="https://openbin.app/screenshots/bins-grid.webp" alt="OpenBin dashboard showing bins organized by area" width="700" />
 
 </div>
 


### PR DESCRIPTION
## Summary

- The `docs/assets/bins.png` image was deleted when screenshots moved to the `openbin-website` repo, leaving the README hero image broken
- Points to the hosted WebP at `https://openbin.app/screenshots/bins-grid.webp` instead

## Test plan

- [ ] View README on GitHub and confirm the hero image renders correctly