### PR TITLE
feat: mobile create FAB with speed-dial menu

### DIFF
--- a/src/components/ui/animations.css
+++ b/src/components/ui/animations.css
@@ -109,6 +109,26 @@
 .fade-in-fast { animation: fadeInFast 0.15s ease-out; }
 @keyframes fadeInFast { from { opacity: 0; } to { opacity: 1; } }
 
+/* ─── Speed-dial pill animations ─── */
+@keyframes pillRiseFast {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.pill-rise-fast {
+  animation: pillRiseFast 0.18s ease-out;
+}
+
+.pill-rise-fast-delayed {
+  animation: pillRiseFast 0.18s ease-out 50ms backwards;
+}
+
 /* ─── Onboarding Feature Cards ─── */
 .onboarding-feature-card { opacity: 0; animation: onboardFadeInUp 0.35s ease-out forwards; }
 .onboarding-feature-card:nth-child(1) { animation-delay: 0s; }
@@ -143,7 +163,8 @@
   .onboarding-completion-icon, .onboarding-action-card,
   .scan-success-enter, .scan-check-scale,
   .scan-check-draw, .scan-ring-1, .scan-ring-2, .scan-ring-3,
-  .scan-text-fade, .scan-text-fade-delay, .fade-in-fast {
+  .scan-text-fade, .scan-text-fade-delay, .fade-in-fast,
+  .pill-rise-fast, .pill-rise-fast-delayed {
     animation: none !important;
   }
   .onboarding-feature-card, .onboarding-action-card { opacity: 1 !important; }

--- a/src/components/ui/animations.css
+++ b/src/components/ui/animations.css
@@ -110,24 +110,8 @@
 @keyframes fadeInFast { from { opacity: 0; } to { opacity: 1; } }
 
 /* ─── Speed-dial pill animations ─── */
-@keyframes pillRiseFast {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.pill-rise-fast {
-  animation: pillRiseFast 0.18s ease-out;
-}
-
-.pill-rise-fast-delayed {
-  animation: pillRiseFast 0.18s ease-out 50ms backwards;
-}
+.pill-rise-fast { animation: onboardFadeInUp 0.18s ease-out; }
+.pill-rise-fast-delayed { animation: onboardFadeInUp 0.18s ease-out 50ms backwards; }
 
 /* ─── Onboarding Feature Cards ─── */
 .onboarding-feature-card { opacity: 0; animation: onboardFadeInUp 0.35s ease-out forwards; }

--- a/src/features/layout/AppLayout.tsx
+++ b/src/features/layout/AppLayout.tsx
@@ -35,6 +35,8 @@ import { useUserPreferences } from '@/lib/userPreferences';
 import { toggleSidebarCollapsed, useSidebarCollapsed } from '@/lib/useSidebarCollapsed';
 import { cn } from '@/lib/utils';
 import { BottomNav } from './BottomNav';
+import { CreateFab } from './CreateFab';
+import { CreateFabProvider } from './CreateFabContext';
 import { DrawerProvider } from './DrawerContext';
 import { MobileDrawer } from './MobileDrawer';
 import { Sidebar, SidebarContent } from './Sidebar';
@@ -207,6 +209,12 @@ export function AppLayout() {
   return (
     <TagColorsProvider>
     <TourProvider tour={tour}>
+    <CreateFabProvider
+      scanDialogOpen={scanDialogOpen}
+      onboardingActive={onboarding.isOnboarding}
+      thinGateActive={!demoMode && thinGate.needsLocation}
+      tourActive={tour.isActive}
+    >
     <div className="min-h-dvh bg-[var(--bg-base)] text-[var(--text-primary)] transition-colors duration-300">
       {/* Global SVG gradient for AI icon */}
       <svg width="0" height="0" className="absolute" aria-hidden="true">
@@ -243,6 +251,7 @@ export function AppLayout() {
           onAskAi={aiEnabled ? openAskAi : undefined}
         />
       )}
+      <CreateFab />
 
       <ScanDialogContext.Provider value={{ openScanDialog }}>
       <DrawerProvider isOnboarding={onboarding.isOnboarding} onOpen={() => setDrawerOpen(true)}>
@@ -352,6 +361,7 @@ export function AppLayout() {
         <TourBanner appName={settings.appName} onStart={() => tour.start(HIGHLIGHTS_TOUR)} onDismiss={dismissTour} />
       )}
     </div>
+    </CreateFabProvider>
     </TourProvider>
     </TagColorsProvider>
   );

--- a/src/features/layout/CreateFab.tsx
+++ b/src/features/layout/CreateFab.tsx
@@ -1,0 +1,38 @@
+import { Plus } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
+import { useTerminology } from '@/lib/terminology';
+import { usePermissions } from '@/lib/usePermissions';
+import { usePlan } from '@/lib/usePlan';
+import { useCreateFabSuppression } from './CreateFabContext';
+
+const HIDDEN_PATHS = new Set(['/capture', '/new-bin', '/scan']);
+
+export function CreateFab() {
+  const { pathname } = useLocation();
+  const { canCreateBin } = usePermissions();
+  const { isLocked, isSelfHosted } = usePlan();
+  const suppression = useCreateFabSuppression();
+  const terminology = useTerminology();
+
+  if (HIDDEN_PATHS.has(pathname)) return null;
+  if (pathname.startsWith('/admin/')) return null;
+  if (suppression.scanDialogOpen) return null;
+  if (suppression.onboardingActive) return null;
+  if (suppression.thinGateActive) return null;
+  if (suppression.tourActive) return null;
+  if (!canCreateBin) return null;
+  if (isLocked && !isSelfHosted) return null;
+
+  return (
+    <button
+      type="button"
+      aria-label={`Create ${terminology.bin}`}
+      aria-haspopup="menu"
+      aria-expanded={false}
+      className="print-hide fixed right-4 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--text-on-accent)] shadow-lg lg:hidden"
+      style={{ bottom: 'calc(16px + var(--bottom-bar-height) + var(--safe-bottom))' }}
+    >
+      <Plus className="h-6 w-6" strokeWidth={2.2} />
+    </button>
+  );
+}

--- a/src/features/layout/CreateFab.tsx
+++ b/src/features/layout/CreateFab.tsx
@@ -17,6 +17,14 @@ export function CreateFab() {
   const terminology = useTerminology();
   const [open, setOpen] = useState(false);
   const fabRef = useRef<HTMLButtonElement>(null);
+  const newBinPillRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the lower pill (New bin) when the speed dial opens
+  useEffect(() => {
+    if (open) {
+      queueMicrotask(() => newBinPillRef.current?.focus());
+    }
+  }, [open]);
 
   // Close on Escape
   useEffect(() => {
@@ -63,7 +71,7 @@ export function CreateFab() {
               type="button"
               role="menuitem"
               aria-label="Add from photos"
-              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md fade-in-fast motion-reduce:animate-none"
+              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast-delayed motion-reduce:animate-none"
               onClick={() => {
                 setOpen(false);
                 // navigation wired in Task 5
@@ -73,10 +81,11 @@ export function CreateFab() {
               <span className="text-[14px] font-medium">Add from photos</span>
             </button>
             <button
+              ref={newBinPillRef}
               type="button"
               role="menuitem"
               aria-label={newBinLabel}
-              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md fade-in-fast motion-reduce:animate-none"
+              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast motion-reduce:animate-none"
               onClick={() => {
                 setOpen(false);
                 // navigation wired in Task 5

--- a/src/features/layout/CreateFab.tsx
+++ b/src/features/layout/CreateFab.tsx
@@ -1,6 +1,6 @@
 import { Camera, Plus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTerminology } from '@/lib/terminology';
 import { usePermissions } from '@/lib/usePermissions';
 import { usePlan } from '@/lib/usePlan';
@@ -18,6 +18,7 @@ export function CreateFab() {
   const [open, setOpen] = useState(false);
   const fabRef = useRef<HTMLButtonElement>(null);
   const newBinPillRef = useRef<HTMLButtonElement>(null);
+  const navigate = useNavigate();
 
   // Focus the lower pill (New bin) when the speed dial opens
   useEffect(() => {
@@ -25,6 +26,12 @@ export function CreateFab() {
       queueMicrotask(() => newBinPillRef.current?.focus());
     }
   }, [open]);
+
+  // Close defensively when the route changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the intentional trigger
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
 
   // Close on Escape
   useEffect(() => {
@@ -74,7 +81,7 @@ export function CreateFab() {
               className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast-delayed motion-reduce:animate-none"
               onClick={() => {
                 setOpen(false);
-                // navigation wired in Task 5
+                navigate('/capture');
               }}
             >
               <Camera className="h-5 w-5" />
@@ -88,7 +95,7 @@ export function CreateFab() {
               className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast motion-reduce:animate-none"
               onClick={() => {
                 setOpen(false);
-                // navigation wired in Task 5
+                navigate('/bins', { state: { create: true } });
               }}
             >
               <Plus className="h-5 w-5" />

--- a/src/features/layout/CreateFab.tsx
+++ b/src/features/layout/CreateFab.tsx
@@ -1,15 +1,27 @@
 import '@/components/ui/animations.css';
-import { Camera, Plus } from 'lucide-react';
+import { Camera, type LucideIcon, Plus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useNavigationGuard } from '@/lib/navigationGuard';
 import { useTerminology } from '@/lib/terminology';
 import { usePermissions } from '@/lib/usePermissions';
 import { usePlan } from '@/lib/usePlan';
-import { cn } from '@/lib/utils';
+import { cn, focusRing } from '@/lib/utils';
 import { useCreateFabSuppression } from './CreateFabContext';
 
 const HIDDEN_PATHS = new Set(['/capture', '/new-bin', '/scan']);
+
+const PILL_CLASS =
+  'flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md';
+
+interface Pill {
+  key: string;
+  icon: LucideIcon;
+  label: string;
+  animClass: string;
+  ref?: React.RefObject<HTMLButtonElement>;
+  onSelect: () => void;
+}
 
 export function CreateFab() {
   const { pathname } = useLocation();
@@ -23,20 +35,17 @@ export function CreateFab() {
   const navigate = useNavigate();
   const { guardedNavigate } = useNavigationGuard();
 
-  // Focus the lower pill (New bin) when the speed dial opens
   useEffect(() => {
     if (open) {
       queueMicrotask(() => newBinPillRef.current?.focus());
     }
   }, [open]);
 
-  // Close defensively when the route changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the intentional trigger
   useEffect(() => {
     setOpen(false);
   }, [pathname]);
 
-  // Close on Escape
   useEffect(() => {
     if (!open) return;
     function handleKey(e: KeyboardEvent) {
@@ -46,8 +55,8 @@ export function CreateFab() {
         fabRef.current?.focus();
       }
     }
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
   }, [open]);
 
   if (HIDDEN_PATHS.has(pathname)) return null;
@@ -60,6 +69,24 @@ export function CreateFab() {
   if (isLocked && !isSelfHosted) return null;
 
   const newBinLabel = `New ${terminology.bin}`;
+
+  const pills: Pill[] = [
+    {
+      key: 'photos',
+      icon: Camera,
+      label: 'Add from photos',
+      animClass: 'pill-rise-fast-delayed',
+      onSelect: () => guardedNavigate(() => navigate('/capture')),
+    },
+    {
+      key: 'new-bin',
+      icon: Plus,
+      label: newBinLabel,
+      animClass: 'pill-rise-fast',
+      ref: newBinPillRef,
+      onSelect: () => guardedNavigate(() => navigate('/bins', { state: { create: true } })),
+    },
+  ];
 
   return (
     <>
@@ -77,33 +104,23 @@ export function CreateFab() {
       >
         {open && (
           <div role="menu" aria-label="Create options" className="flex flex-col items-end gap-2">
-            <button
-              type="button"
-              role="menuitem"
-              aria-label="Add from photos"
-              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast-delayed motion-reduce:animate-none"
-              onClick={() => {
-                setOpen(false);
-                guardedNavigate(() => navigate('/capture'));
-              }}
-            >
-              <Camera className="h-5 w-5" />
-              <span className="text-[14px] font-medium">Add from photos</span>
-            </button>
-            <button
-              ref={newBinPillRef}
-              type="button"
-              role="menuitem"
-              aria-label={newBinLabel}
-              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast motion-reduce:animate-none"
-              onClick={() => {
-                setOpen(false);
-                guardedNavigate(() => navigate('/bins', { state: { create: true } }));
-              }}
-            >
-              <Plus className="h-5 w-5" />
-              <span className="text-[14px] font-medium">{newBinLabel}</span>
-            </button>
+            {pills.map(({ key, icon: Icon, label, animClass, ref: pillRef, onSelect }) => (
+              <button
+                key={key}
+                ref={pillRef}
+                type="button"
+                role="menuitem"
+                aria-label={label}
+                className={cn(PILL_CLASS, animClass, focusRing)}
+                onClick={() => {
+                  setOpen(false);
+                  onSelect();
+                }}
+              >
+                <Icon className="h-5 w-5" />
+                <span className="text-[14px] font-medium">{label}</span>
+              </button>
+            ))}
           </div>
         )}
         <button
@@ -113,7 +130,10 @@ export function CreateFab() {
           aria-haspopup="menu"
           aria-expanded={open}
           onClick={() => setOpen((v) => !v)}
-          className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--text-on-accent)] shadow-lg"
+          className={cn(
+            'flex h-14 w-14 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--text-on-accent)] shadow-lg',
+            focusRing,
+          )}
         >
           <Plus
             className={cn('h-6 w-6 transition-transform duration-150 motion-reduce:transition-none', open && 'rotate-45')}

--- a/src/features/layout/CreateFab.tsx
+++ b/src/features/layout/CreateFab.tsx
@@ -1,6 +1,8 @@
+import '@/components/ui/animations.css';
 import { Camera, Plus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigationGuard } from '@/lib/navigationGuard';
 import { useTerminology } from '@/lib/terminology';
 import { usePermissions } from '@/lib/usePermissions';
 import { usePlan } from '@/lib/usePlan';
@@ -19,6 +21,7 @@ export function CreateFab() {
   const fabRef = useRef<HTMLButtonElement>(null);
   const newBinPillRef = useRef<HTMLButtonElement>(null);
   const navigate = useNavigate();
+  const { guardedNavigate } = useNavigationGuard();
 
   // Focus the lower pill (New bin) when the speed dial opens
   useEffect(() => {
@@ -81,7 +84,7 @@ export function CreateFab() {
               className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast-delayed motion-reduce:animate-none"
               onClick={() => {
                 setOpen(false);
-                navigate('/capture');
+                guardedNavigate(() => navigate('/capture'));
               }}
             >
               <Camera className="h-5 w-5" />
@@ -95,7 +98,7 @@ export function CreateFab() {
               className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md pill-rise-fast motion-reduce:animate-none"
               onClick={() => {
                 setOpen(false);
-                navigate('/bins', { state: { create: true } });
+                guardedNavigate(() => navigate('/bins', { state: { create: true } }));
               }}
             >
               <Plus className="h-5 w-5" />

--- a/src/features/layout/CreateFab.tsx
+++ b/src/features/layout/CreateFab.tsx
@@ -1,8 +1,10 @@
-import { Plus } from 'lucide-react';
+import { Camera, Plus } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTerminology } from '@/lib/terminology';
 import { usePermissions } from '@/lib/usePermissions';
 import { usePlan } from '@/lib/usePlan';
+import { cn } from '@/lib/utils';
 import { useCreateFabSuppression } from './CreateFabContext';
 
 const HIDDEN_PATHS = new Set(['/capture', '/new-bin', '/scan']);
@@ -13,6 +15,22 @@ export function CreateFab() {
   const { isLocked, isSelfHosted } = usePlan();
   const suppression = useCreateFabSuppression();
   const terminology = useTerminology();
+  const [open, setOpen] = useState(false);
+  const fabRef = useRef<HTMLButtonElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+        fabRef.current?.focus();
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open]);
 
   if (HIDDEN_PATHS.has(pathname)) return null;
   if (pathname.startsWith('/admin/')) return null;
@@ -23,16 +41,67 @@ export function CreateFab() {
   if (!canCreateBin) return null;
   if (isLocked && !isSelfHosted) return null;
 
+  const newBinLabel = `New ${terminology.bin}`;
+
   return (
-    <button
-      type="button"
-      aria-label={`Create ${terminology.bin}`}
-      aria-haspopup="menu"
-      aria-expanded={false}
-      className="print-hide fixed right-4 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--text-on-accent)] shadow-lg lg:hidden"
-      style={{ bottom: 'calc(16px + var(--bottom-bar-height) + var(--safe-bottom))' }}
-    >
-      <Plus className="h-6 w-6" strokeWidth={2.2} />
-    </button>
+    <>
+      {open && (
+        <div
+          data-testid="create-fab-backdrop"
+          aria-hidden="true"
+          className="print-hide fixed inset-0 z-40 lg:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+      <div
+        className="print-hide fixed right-4 z-50 flex flex-col items-end gap-2 lg:hidden"
+        style={{ bottom: 'calc(16px + var(--bottom-bar-height) + var(--safe-bottom))' }}
+      >
+        {open && (
+          <div role="menu" aria-label="Create options" className="flex flex-col items-end gap-2">
+            <button
+              type="button"
+              role="menuitem"
+              aria-label="Add from photos"
+              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md fade-in-fast motion-reduce:animate-none"
+              onClick={() => {
+                setOpen(false);
+                // navigation wired in Task 5
+              }}
+            >
+              <Camera className="h-5 w-5" />
+              <span className="text-[14px] font-medium">Add from photos</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              aria-label={newBinLabel}
+              className="flat-heavy flex items-center gap-2 rounded-[var(--radius-lg)] px-4 py-2.5 text-[var(--text-primary)] shadow-md fade-in-fast motion-reduce:animate-none"
+              onClick={() => {
+                setOpen(false);
+                // navigation wired in Task 5
+              }}
+            >
+              <Plus className="h-5 w-5" />
+              <span className="text-[14px] font-medium">{newBinLabel}</span>
+            </button>
+          </div>
+        )}
+        <button
+          ref={fabRef}
+          type="button"
+          aria-label={`Create ${terminology.bin}`}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--text-on-accent)] shadow-lg"
+        >
+          <Plus
+            className={cn('h-6 w-6 transition-transform duration-150 motion-reduce:transition-none', open && 'rotate-45')}
+            strokeWidth={2.2}
+          />
+        </button>
+      </div>
+    </>
   );
 }

--- a/src/features/layout/CreateFabContext.tsx
+++ b/src/features/layout/CreateFabContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useMemo } from 'react';
+
+export interface CreateFabSuppression {
+  scanDialogOpen: boolean;
+  onboardingActive: boolean;
+  thinGateActive: boolean;
+  tourActive: boolean;
+}
+
+const CreateFabContext = createContext<CreateFabSuppression | null>(null);
+
+export function useCreateFabSuppression(): CreateFabSuppression {
+  const ctx = useContext(CreateFabContext);
+  if (!ctx) throw new Error('useCreateFabSuppression must be used within CreateFabProvider');
+  return ctx;
+}
+
+interface CreateFabProviderProps extends CreateFabSuppression {
+  children: React.ReactNode;
+}
+
+export function CreateFabProvider({
+  scanDialogOpen,
+  onboardingActive,
+  thinGateActive,
+  tourActive,
+  children,
+}: CreateFabProviderProps) {
+  const value = useMemo(
+    () => ({ scanDialogOpen, onboardingActive, thinGateActive, tourActive }),
+    [scanDialogOpen, onboardingActive, thinGateActive, tourActive],
+  );
+  return <CreateFabContext.Provider value={value}>{children}</CreateFabContext.Provider>;
+}

--- a/src/features/layout/__tests__/CreateFab.test.tsx
+++ b/src/features/layout/__tests__/CreateFab.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateFab } from '../CreateFab';
@@ -100,5 +100,64 @@ describe('CreateFab visibility (hidden cases)', () => {
     vi.mocked(usePlan).mockReturnValue({ isLocked: true, isSelfHosted: true } as ReturnType<typeof usePlan>);
     const { container } = render(<Harness pathname="/bins" />);
     expect(container.firstChild).not.toBeNull();
+  });
+});
+
+describe('CreateFab closed state', () => {
+  beforeEach(async () => {
+    const { usePermissions } = await import('@/lib/usePermissions');
+    const { usePlan } = await import('@/lib/usePlan');
+    const { useTerminology } = await import('@/lib/terminology');
+    vi.mocked(usePermissions).mockReturnValue({ canCreateBin: true } as ReturnType<typeof usePermissions>);
+    vi.mocked(usePlan).mockReturnValue({ isLocked: false, isSelfHosted: false } as ReturnType<typeof usePlan>);
+    vi.mocked(useTerminology).mockReturnValue({
+      bin: 'bin',
+      bins: 'bins',
+      Bin: 'Bin',
+      Bins: 'Bins',
+      location: 'location',
+      locations: 'locations',
+      Location: 'Location',
+      Locations: 'Locations',
+      area: 'area',
+      areas: 'areas',
+      Area: 'Area',
+      Areas: 'Areas',
+    });
+  });
+
+  it('renders a button on /bins', () => {
+    render(<Harness pathname="/bins" />);
+    expect(screen.getByRole('button', { name: /create bin/i })).toBeInTheDocument();
+  });
+
+  it('renders on /settings/preferences (settings show the FAB)', () => {
+    render(<Harness pathname="/settings/preferences" />);
+    expect(screen.getByRole('button', { name: /create bin/i })).toBeInTheDocument();
+  });
+
+  it('uses the active location terminology in the aria-label', async () => {
+    const { useTerminology } = await import('@/lib/terminology');
+    vi.mocked(useTerminology).mockReturnValue({
+      bin: 'box',
+      bins: 'boxes',
+      Bin: 'Box',
+      Bins: 'Boxes',
+      location: 'location',
+      locations: 'locations',
+      Location: 'Location',
+      Locations: 'Locations',
+      area: 'area',
+      areas: 'areas',
+      Area: 'Area',
+      Areas: 'Areas',
+    });
+    render(<Harness pathname="/bins" />);
+    expect(screen.getByRole('button', { name: /create box/i })).toBeInTheDocument();
+  });
+
+  it('starts with aria-expanded="false"', () => {
+    render(<Harness pathname="/bins" />);
+    expect(screen.getByRole('button', { name: /create/i })).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/src/features/layout/__tests__/CreateFab.test.tsx
+++ b/src/features/layout/__tests__/CreateFab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateFab } from '../CreateFab';
@@ -159,5 +159,66 @@ describe('CreateFab closed state', () => {
   it('starts with aria-expanded="false"', () => {
     render(<Harness pathname="/bins" />);
     expect(screen.getByRole('button', { name: /create/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('CreateFab speed dial', () => {
+  beforeEach(async () => {
+    const { usePermissions } = await import('@/lib/usePermissions');
+    const { usePlan } = await import('@/lib/usePlan');
+    const { useTerminology } = await import('@/lib/terminology');
+    vi.mocked(usePermissions).mockReturnValue({ canCreateBin: true } as ReturnType<typeof usePermissions>);
+    vi.mocked(usePlan).mockReturnValue({ isLocked: false, isSelfHosted: false } as ReturnType<typeof usePlan>);
+    vi.mocked(useTerminology).mockReturnValue({
+      bin: 'bin',
+      bins: 'bins',
+      Bin: 'Bin',
+      Bins: 'Bins',
+      location: 'location',
+      locations: 'locations',
+      Location: 'Location',
+      Locations: 'Locations',
+      area: 'area',
+      areas: 'areas',
+      Area: 'Area',
+      Areas: 'Areas',
+    });
+  });
+
+  it('does not show pill menu items by default', () => {
+    render(<Harness pathname="/bins" />);
+    expect(screen.queryByRole('menuitem', { name: /new bin/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /add from photos/i })).not.toBeInTheDocument();
+  });
+
+  it('opens the speed dial when the FAB is tapped', () => {
+    render(<Harness pathname="/bins" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    expect(screen.getByRole('button', { name: /create bin/i })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menuitem', { name: /new bin/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /add from photos/i })).toBeInTheDocument();
+  });
+
+  it('closes the speed dial when the FAB is tapped again', () => {
+    render(<Harness pathname="/bins" />);
+    const fab = screen.getByRole('button', { name: /create bin/i });
+    fireEvent.click(fab);
+    fireEvent.click(fab);
+    expect(fab).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('menuitem', { name: /new bin/i })).not.toBeInTheDocument();
+  });
+
+  it('closes when Escape is pressed', () => {
+    render(<Harness pathname="/bins" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.getByRole('button', { name: /create bin/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    render(<Harness pathname="/bins" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    fireEvent.click(screen.getByTestId('create-fab-backdrop'));
+    expect(screen.getByRole('button', { name: /create bin/i })).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/src/features/layout/__tests__/CreateFab.test.tsx
+++ b/src/features/layout/__tests__/CreateFab.test.tsx
@@ -1,0 +1,104 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreateFab } from '../CreateFab';
+import { CreateFabProvider, type CreateFabSuppression } from '../CreateFabContext';
+
+vi.mock('@/lib/usePermissions', () => ({
+  usePermissions: vi.fn(() => ({ canCreateBin: true })),
+}));
+
+vi.mock('@/lib/usePlan', () => ({
+  usePlan: vi.fn(() => ({ isLocked: false, isSelfHosted: false })),
+}));
+
+vi.mock('@/lib/terminology', () => ({
+  useTerminology: vi.fn(() => ({ Bin: 'Bin', bin: 'bin' })),
+}));
+
+interface HarnessProps {
+  pathname: string;
+  suppression?: Partial<CreateFabSuppression>;
+}
+
+function Harness({ pathname, suppression }: HarnessProps) {
+  const merged: CreateFabSuppression = {
+    scanDialogOpen: false,
+    onboardingActive: false,
+    thinGateActive: false,
+    tourActive: false,
+    ...suppression,
+  };
+  return (
+    <MemoryRouter initialEntries={[pathname]}>
+      <CreateFabProvider {...merged}>
+        <CreateFab />
+      </CreateFabProvider>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CreateFab visibility (hidden cases)', () => {
+  beforeEach(async () => {
+    const { usePermissions } = await import('@/lib/usePermissions');
+    const { usePlan } = await import('@/lib/usePlan');
+    vi.mocked(usePermissions).mockReturnValue({ canCreateBin: true } as ReturnType<typeof usePermissions>);
+    vi.mocked(usePlan).mockReturnValue({ isLocked: false, isSelfHosted: false } as ReturnType<typeof usePlan>);
+  });
+
+  it.each([
+    ['/capture'],
+    ['/new-bin'],
+    ['/scan'],
+    ['/admin/users'],
+    ['/admin/system'],
+  ])('renders nothing on %s', (pathname) => {
+    const { container } = render(<Harness pathname={pathname} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when scan dialog is open', () => {
+    const { container } = render(<Harness pathname="/bins" suppression={{ scanDialogOpen: true }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing during onboarding', () => {
+    const { container } = render(<Harness pathname="/bins" suppression={{ onboardingActive: true }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when thin-gate is active', () => {
+    const { container } = render(<Harness pathname="/bins" suppression={{ thinGateActive: true }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when a tour is active', () => {
+    const { container } = render(<Harness pathname="/bins" suppression={{ tourActive: true }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for viewers (canCreateBin=false)', async () => {
+    const { usePermissions } = await import('@/lib/usePermissions');
+    vi.mocked(usePermissions).mockReturnValue({ canCreateBin: false } as ReturnType<typeof usePermissions>);
+    const { container } = render(<Harness pathname="/bins" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the cloud plan is locked', async () => {
+    const { usePlan } = await import('@/lib/usePlan');
+    vi.mocked(usePlan).mockReturnValue({ isLocked: true, isSelfHosted: false } as ReturnType<typeof usePlan>);
+    const { container } = render(<Harness pathname="/bins" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders when locked but self-hosted (no lock on self-host)', async () => {
+    const { usePlan } = await import('@/lib/usePlan');
+    vi.mocked(usePlan).mockReturnValue({ isLocked: true, isSelfHosted: true } as ReturnType<typeof usePlan>);
+    const { container } = render(<Harness pathname="/bins" />);
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/src/features/layout/__tests__/CreateFab.test.tsx
+++ b/src/features/layout/__tests__/CreateFab.test.tsx
@@ -219,7 +219,7 @@ describe('CreateFab speed dial', () => {
   it('closes when Escape is pressed', () => {
     render(<Harness pathname="/bins" />);
     fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
-    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.getByRole('button', { name: /create bin/i })).toHaveAttribute('aria-expanded', 'false');
   });
 

--- a/src/features/layout/__tests__/CreateFab.test.tsx
+++ b/src/features/layout/__tests__/CreateFab.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation as useRouterLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateFab } from '../CreateFab';
 import { CreateFabProvider, type CreateFabSuppression } from '../CreateFabContext';
@@ -228,5 +228,82 @@ describe('CreateFab speed dial', () => {
     fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
     fireEvent.click(screen.getByTestId('create-fab-backdrop'));
     expect(screen.getByRole('button', { name: /create bin/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+function LocationProbe() {
+  const loc = useRouterLocation();
+  return (
+    <div data-testid="probe">
+      <span data-testid="pathname">{loc.pathname}</span>
+      <span data-testid="state">{JSON.stringify(loc.state ?? null)}</span>
+    </div>
+  );
+}
+
+function NavHarness({ start = '/bins' }: { start?: string }) {
+  const merged: CreateFabSuppression = {
+    scanDialogOpen: false,
+    onboardingActive: false,
+    thinGateActive: false,
+    tourActive: false,
+  };
+  return (
+    <MemoryRouter initialEntries={[start]}>
+      <CreateFabProvider {...merged}>
+        <CreateFab />
+        <Routes>
+          <Route path="/bins" element={<LocationProbe />} />
+          <Route path="/capture" element={<LocationProbe />} />
+          <Route path="/items" element={<LocationProbe />} />
+        </Routes>
+      </CreateFabProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('CreateFab navigation', () => {
+  beforeEach(async () => {
+    const { usePermissions } = await import('@/lib/usePermissions');
+    const { usePlan } = await import('@/lib/usePlan');
+    const { useTerminology } = await import('@/lib/terminology');
+    vi.mocked(usePermissions).mockReturnValue({ canCreateBin: true } as ReturnType<typeof usePermissions>);
+    vi.mocked(usePlan).mockReturnValue({ isLocked: false, isSelfHosted: false } as ReturnType<typeof usePlan>);
+    vi.mocked(useTerminology).mockReturnValue({
+      bin: 'bin',
+      bins: 'bins',
+      Bin: 'Bin',
+      Bins: 'Bins',
+      location: 'location',
+      locations: 'locations',
+      Location: 'Location',
+      Locations: 'Locations',
+      area: 'area',
+      areas: 'areas',
+      Area: 'Area',
+      Areas: 'Areas',
+    });
+  });
+
+  it('"New bin" navigates to /bins with { create: true } state', () => {
+    render(<NavHarness start="/items" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /new bin/i }));
+    expect(screen.getByTestId('pathname').textContent).toBe('/bins');
+    expect(screen.getByTestId('state').textContent).toBe('{"create":true}');
+  });
+
+  it('"Add from photos" navigates to /capture', () => {
+    render(<NavHarness start="/items" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /add from photos/i }));
+    expect(screen.getByTestId('pathname').textContent).toBe('/capture');
+  });
+
+  it('closes the speed dial when route changes (no longer renders pills)', () => {
+    render(<NavHarness start="/items" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /new bin/i }));
+    expect(screen.queryByRole('menuitem', { name: /new bin/i })).not.toBeInTheDocument();
   });
 });

--- a/src/features/layout/__tests__/CreateFab.test.tsx
+++ b/src/features/layout/__tests__/CreateFab.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateFab } from '../CreateFab';
@@ -197,6 +197,14 @@ describe('CreateFab speed dial', () => {
     expect(screen.getByRole('button', { name: /create bin/i })).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByRole('menuitem', { name: /new bin/i })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /add from photos/i })).toBeInTheDocument();
+  });
+
+  it('moves focus to the New bin pill when opened', async () => {
+    render(<Harness pathname="/bins" />);
+    fireEvent.click(screen.getByRole('button', { name: /create bin/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: /new bin/i })).toHaveFocus();
+    });
   });
 
   it('closes the speed dial when the FAB is tapped again', () => {

--- a/src/features/layout/__tests__/CreateFabContext.test.tsx
+++ b/src/features/layout/__tests__/CreateFabContext.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { CreateFabProvider, useCreateFabSuppression } from '../CreateFabContext';
+
+describe('useCreateFabSuppression', () => {
+  it('throws when used outside provider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useCreateFabSuppression())).toThrow(
+      'useCreateFabSuppression must be used within CreateFabProvider',
+    );
+    spy.mockRestore();
+  });
+
+  it('returns the suppression flags passed to the provider', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CreateFabProvider
+        scanDialogOpen={true}
+        onboardingActive={false}
+        thinGateActive={true}
+        tourActive={false}
+      >
+        {children}
+      </CreateFabProvider>
+    );
+
+    const { result } = renderHook(() => useCreateFabSuppression(), { wrapper });
+
+    expect(result.current).toEqual({
+      scanDialogOpen: true,
+      onboardingActive: false,
+      thinGateActive: true,
+      tourActive: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a mobile-only floating action button (`+`) that opens a 2-item speed-dial menu — **New {bin}** and **Add from photos** — reachable from every authenticated screen where creating a bin makes sense. Closes the long-standing gap where users on `/items`, `/tags`, `/print`, or `/settings/*` had to navigate back to `/bins` just to add a bin.

- New component `CreateFab` self-suppresses on `/capture`, `/new-bin`, `/scan`, `/admin/*`, when scan dialog/onboarding/thin-gate/tour are active, for viewers, and when the cloud plan is locked.
- Tapping the FAB fans up two pills with staggered entry animation; tap, Escape, backdrop, or route change all close the menu.
- "New {bin}" routes to `/bins` with the existing create-modal state. "Add from photos" routes to `/capture` (bulk-group flow).
- Uses `useTerminology()` so the label respects the location's custom term (e.g. "New box").
- Uses `guardedNavigate` for consistency with other layout-layer navigation.
- 36 layout tests, 25 specifically for the FAB (visibility matrix, closed-state, open/close, focus, navigation).

## Test plan

- [ ] On a narrow viewport, confirm the FAB appears bottom-right on `/`, `/bins`, `/items`, `/tags`, `/locations`, `/checkouts`, `/shopping-list`, `/settings/preferences`, `/print`, `/reorganize`, and `/bin/:id`.
- [ ] Confirm it is hidden on `/capture`, `/new-bin`, and `/admin/users`.
- [ ] Tap the FAB → pills appear with the lower (New bin) pill animating first, upper (Add from photos) 50ms later. FAB icon rotates 45° to an X.
- [ ] Tap outside / press Escape → menu closes, FAB icon rotates back.
- [ ] Tap "New {bin}" → navigates to `/bins`, bin-create modal opens.
- [ ] Tap "Add from photos" → navigates to `/capture` (and the FAB disappears since /capture is hidden).
- [ ] Open the scan dialog from the bottom nav → FAB hides while the scanner is active.
- [ ] As a viewer, confirm the FAB never appears.
- [ ] Start a tour from settings → FAB hides for the duration of the tour.
- [ ] `Ctrl+P` print preview → FAB does not appear.